### PR TITLE
Add static library output

### DIFF
--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -20,6 +20,6 @@ add_executable(sdk_simple
         )
 
 target_link_libraries(sdk_simple
-        milvus_sdk
+        milvus_sdk_static
         pthread
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,11 +21,24 @@ include_directories(proto-gen)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/impl impl_files)
 include(proto-gen/proto-gen.cmake) # milvus_sdk_proto_files
 
-add_library(milvus_sdk SHARED
+# static library
+add_library(milvus_sdk_static STATIC
         ${impl_files}
         ${milvus_sdk_proto_files}
         )
+set_target_properties(milvus_sdk_static PROPERTIES OUTPUT_NAME milvus_sdk)
+target_link_libraries(milvus_sdk_static grpc++)
+add_dependencies(milvus_sdk_static protoc grpc_cpp_plugin)
 
-target_link_libraries(milvus_sdk grpc++)
+# shared library
+add_library(milvus_sdk_shared SHARED
+        ${impl_files}
+        ${milvus_sdk_proto_files}
+        )
+set_target_properties(milvus_sdk_shared PROPERTIES OUTPUT_NAME milvus_sdk)
+target_link_libraries(milvus_sdk_shared grpc++)
+add_dependencies(milvus_sdk_shared protoc grpc_cpp_plugin)
 
-install(TARGETS milvus_sdk DESTINATION lib)
+include(GNUInstallDirs)
+install(TARGETS milvus_sdk_static milvus_sdk_shared
+        DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,11 +20,11 @@ endif ()
 
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/ut ut_files)
 add_executable(testing-ut ${ut_files})
-target_link_libraries(testing-ut PRIVATE milvus_sdk ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} pthread)
+target_link_libraries(testing-ut PRIVATE milvus_sdk_static ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} pthread)
 gtest_discover_tests(testing-ut)
 
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/it it_files)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/it/mocks it_mocks_files)
 add_executable(testing-it ${it_files} ${it_mocks_files})
-target_link_libraries(testing-it PRIVATE milvus_sdk ${GTEST_LIBRARIES} ${GMOCK_LIBRARIES} ${GTEST_MAIN_LIBRARIES} pthread)
+target_link_libraries(testing-it PRIVATE milvus_sdk_static ${GTEST_LIBRARIES} ${GMOCK_LIBRARIES} ${GTEST_MAIN_LIBRARIES} pthread)
 gtest_discover_tests(testing-it)


### PR DESCRIPTION
- add build libmilvus.a output
- using static library for example/test linking.

Signed-off-by: Ji Bin <matrixji@live.com>