### PR TITLE
Remove unsupported OS for github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,17 +38,13 @@ jobs:
       matrix:
         os:
           - distro: Ubuntu
-            version: 18.04
-            image: ubuntu:18.04
-            key: u1804
+            version: 20.04
+            image: ubuntu:20.04
+            key: u2004
           - distro: Ubuntu
             version: 22.04
             image: ubuntu:22.04
             key: u2204
-          - distro: CentOS
-            version: 7
-            image: centos:7
-            key: c7
           - distro: Fedora
             version: 38
             image: fedora:38
@@ -67,9 +63,9 @@ jobs:
       - name: Env
         run: echo "${HOME}/.local/bin" >> $GITHUB_PATH
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/.ccache
@@ -103,9 +99,9 @@ jobs:
       - name: Env
         run: echo "${HOME}/.local/bin" >> $GITHUB_PATH
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/.ccache
@@ -142,9 +138,9 @@ jobs:
       CCACHE_MAXSIZE: 2G
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/.ccache
@@ -167,9 +163,9 @@ jobs:
       CCACHE_COMPRESSLEVEL: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/.ccache


### PR DESCRIPTION
Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). As a result we have started the deprecation process of Node16 for GitHub Actions. All actions have migrated to Node20 by Spring 2024. Some operations systems are no longer supported including Ubuntu 18.04 and CentOS7.

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/