### PR TITLE
feat: set grpc keepalive interval to 10s with 5s timeout

### DIFF
--- a/src/include/milvus/types/ConnectParam.h
+++ b/src/include/milvus/types/ConnectParam.h
@@ -340,9 +340,9 @@ class ConnectParam {
     std::string uri_ = "http://localhost:19530";
 
     uint64_t connect_timeout_ms_ = 10000;    // the same with pymilvus
-    uint64_t keepalive_time_ms_ = 55000;     // the same with pymilvus
-    uint64_t keepalive_timeout_ms_ = 20000;  // the same with java sdk
-    bool keepalive_without_calls_ = false;   // the same with java sdk
+    uint64_t keepalive_time_ms_ = 10000;     // Send keepalive pings every 10 seconds
+    uint64_t keepalive_timeout_ms_ = 5000;   // Keepalive ping timeout after 5 seconds
+    bool keepalive_without_calls_ = true;    // Allow keepalive pings when there are no gRPC calls
     uint64_t rpc_deadline_ms_ = 0;           // the same with java sdk
 
     bool tls_{false};

--- a/test/ut/v1/TestConnectParam.cpp
+++ b/test/ut/v1/TestConnectParam.cpp
@@ -47,3 +47,30 @@ TEST_F(ConnectParamTest, GeneralTesting) {
     param.DisableTls();
     EXPECT_FALSE(param.TlsEnabled());
 }
+
+TEST_F(ConnectParamTest, KeepaliveDefaults) {
+    milvus::ConnectParam param{"localhost", 19530};
+
+    EXPECT_EQ(param.KeepaliveTimeMs(), 10000);
+    EXPECT_EQ(param.KeepaliveTimeoutMs(), 5000);
+    EXPECT_TRUE(param.KeepaliveWithoutCalls());
+}
+
+TEST_F(ConnectParamTest, KeepaliveSettersAndBuilders) {
+    milvus::ConnectParam param{"localhost", 19530};
+
+    param.SetKeepaliveTimeMs(20000);
+    EXPECT_EQ(param.KeepaliveTimeMs(), 20000);
+
+    param.SetKeepaliveTimeoutMs(8000);
+    EXPECT_EQ(param.KeepaliveTimeoutMs(), 8000);
+
+    param.SetKeepaliveWithoutCalls(false);
+    EXPECT_FALSE(param.KeepaliveWithoutCalls());
+
+    // Test builder pattern
+    auto& ref = param.WithKeepaliveTimeMs(30000).WithKeepaliveTimeoutMs(10000).WithKeepaliveWithoutCalls(true);
+    EXPECT_EQ(ref.KeepaliveTimeMs(), 30000);
+    EXPECT_EQ(ref.KeepaliveTimeoutMs(), 10000);
+    EXPECT_TRUE(ref.KeepaliveWithoutCalls());
+}


### PR DESCRIPTION
## Summary
- Reduce `keepalive_time_ms` default from 55s to 10s for faster dead connection detection
- Reduce `keepalive_timeout_ms` default from 20s to 5s
- Enable `keepalive_without_calls` by default (was `false`)
- Add unit tests for keepalive defaults and setter/builder methods

## Test plan
- [ ] Verify `KeepaliveDefaults` test asserts 10s interval, 5s timeout, and permit without calls
- [ ] Verify `KeepaliveSettersAndBuilders` test confirms setters and builder pattern work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)