### PR TITLE
Align collection schema evolution APIs with AlterCollectionSchema

### DIFF
--- a/examples/src/v2/add_field.cpp
+++ b/examples/src/v2/add_field.cpp
@@ -166,11 +166,13 @@ main(int argc, char* argv[]) {
         milvus::FunctionPtr function = std::make_shared<milvus::Function>(function_name, milvus::FunctionType::BM25);
         function->AddInputFieldName(field_text);
         function->AddOutputFieldName(field_sparse);
+        milvus::IndexDesc index(field_sparse, "", milvus::IndexType::SPARSE_INVERTED_INDEX, milvus::MetricType::BM25);
 
         status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
                                               .WithCollectionName(collection_name)
                                               .WithField(std::move(sparse_field))
-                                              .WithFunction(function));
+                                              .WithFunction(function)
+                                              .WithIndex(std::move(index)));
         util::CheckStatus("add function-backed field 'sparse'", status);
         std::cout << "Function-backed field 'sparse' added" << std::endl;
         DescribeCollection(client);

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -704,7 +704,24 @@ MilvusClientV2Impl::DropCollectionFieldProperties(const DropCollectionFieldPrope
 
 Status
 MilvusClientV2Impl::AddCollectionField(const AddCollectionFieldRequest& request) {
-    auto pre = [&request](proto::milvus::AddCollectionFieldRequest& rpc_request) {
+    auto alter_pre = [&request](proto::milvus::AlterCollectionSchemaRequest& rpc_request) {
+        rpc_request.set_db_name(request.DatabaseName());
+        rpc_request.set_collection_name(request.CollectionName());
+
+        auto* field_info = rpc_request.mutable_action()->mutable_add_request()->add_field_infos();
+        ConvertFieldSchema(request.Field(), *field_info->mutable_field_schema());
+        return Status::OK();
+    };
+
+    auto status =
+        connection_.Invoke<proto::milvus::AlterCollectionSchemaRequest, proto::milvus::AlterCollectionSchemaResponse>(
+            alter_pre, &MilvusConnection::AlterCollectionSchema);
+    // An older coordinator reports an internal gRPC UNIMPLEMENTED as Milvus ErrServiceUnimplemented (code 10).
+    if (status.RpcErrCode() != static_cast<int32_t>(::grpc::StatusCode::UNIMPLEMENTED) && status.ServerCode() != 10) {
+        return status;
+    }
+
+    auto legacy_pre = [&request](proto::milvus::AddCollectionFieldRequest& rpc_request) {
         rpc_request.set_db_name(request.DatabaseName());
         rpc_request.set_collection_name(request.CollectionName());
 
@@ -718,7 +735,7 @@ MilvusClientV2Impl::AddCollectionField(const AddCollectionFieldRequest& request)
     };
 
     return connection_.Invoke<proto::milvus::AddCollectionFieldRequest, proto::common::Status>(
-        pre, &MilvusConnection::AddCollectionField);
+        legacy_pre, &MilvusConnection::AddCollectionField);
 }
 
 Status
@@ -857,6 +874,27 @@ MilvusClientV2Impl::AddFunctionField(const AddFunctionFieldRequest& request) {
         if (request.Function()->OutputFieldNames()[0] != request.Field().Name()) {
             return Status{StatusCode::INVALID_ARGUMENT, "Function output field name must match the field being added."};
         }
+
+        const auto& index = request.Index();
+        if (index.IndexType() == IndexType::INVALID) {
+            return Status{StatusCode::INVALID_ARGUMENT,
+                          "An explicit index type is required for the function output field."};
+        }
+        if (index.IndexType() == IndexType::AUTOINDEX) {
+            return Status{StatusCode::INVALID_ARGUMENT, "AUTOINDEX is not supported for the function output field."};
+        }
+        if (!index.FieldName().empty() && index.FieldName() != request.Field().Name()) {
+            return Status{StatusCode::INVALID_ARGUMENT, "Index field name must match the function output field name."};
+        }
+        // FieldInfo.extra_params uses the canonical flat representation. Reject the
+        // legacy params envelope because it can overwrite the typed index fields
+        // when the server expands it.
+        for (const auto* reserved_key : {INDEX_TYPE, METRIC_TYPE, PARAMS}) {
+            if (index.ExtraParams().find(reserved_key) != index.ExtraParams().end()) {
+                return Status{StatusCode::INVALID_ARGUMENT,
+                              std::string("Index extra params must not contain reserved key: ") + reserved_key};
+            }
+        }
         return Status::OK();
     };
 
@@ -868,6 +906,23 @@ MilvusClientV2Impl::AddFunctionField(const AddFunctionFieldRequest& request) {
         auto* field_info = add_request->add_field_infos();
         ConvertFieldSchema(request.Field(), *field_info->mutable_field_schema());
         field_info->mutable_field_schema()->set_is_function_output(true);
+        const auto& index = request.Index();
+        field_info->set_index_name(index.IndexName());
+
+        auto* index_type = field_info->add_extra_params();
+        index_type->set_key(INDEX_TYPE);
+        index_type->set_value(std::to_string(index.IndexType()));
+        if (index.MetricType() != MetricType::DEFAULT) {
+            auto* metric_type = field_info->add_extra_params();
+            metric_type->set_key(METRIC_TYPE);
+            metric_type->set_value(std::to_string(index.MetricType()));
+        }
+        for (const auto& pair : index.ExtraParams()) {
+            auto* param = field_info->add_extra_params();
+            param->set_key(pair.first);
+            param->set_value(pair.second);
+        }
+
         ConvertFunctionSchema(request.Function(), *add_request->add_func_schema());
         return Status::OK();
     };

--- a/src/impl/request/collection/AddFunctionFieldRequest.cpp
+++ b/src/impl/request/collection/AddFunctionFieldRequest.cpp
@@ -52,4 +52,20 @@ AddFunctionFieldRequest::WithFunction(const FunctionPtr& function) {
     return *this;
 }
 
+const IndexDesc&
+AddFunctionFieldRequest::Index() const {
+    return index_;
+}
+
+void
+AddFunctionFieldRequest::SetIndex(IndexDesc&& index) {
+    index_ = std::move(index);
+}
+
+AddFunctionFieldRequest&
+AddFunctionFieldRequest::WithIndex(IndexDesc&& index) {
+    SetIndex(std::move(index));
+    return *this;
+}
+
 }  // namespace milvus

--- a/src/include/milvus/MilvusClientV2.h
+++ b/src/include/milvus/MilvusClientV2.h
@@ -478,10 +478,12 @@ class MILVUS_SDK_API MilvusClientV2 {
 
     /**
      * @brief Add a function to an existing collection.
+     * @deprecated Use AddFunctionField() to add the function together with a new output field and bound index.
      *
      * @param [in] request input parameters
      * @return Status operation successfully or not
      */
+    [[deprecated("Use AddFunctionField() instead")]]
     virtual Status
     AddCollectionFunction(const AddCollectionFunctionRequest& request) = 0;
 
@@ -506,10 +508,12 @@ class MILVUS_SDK_API MilvusClientV2 {
 
     /**
      * @brief Drop a function of an existing collection.
+     * @deprecated Use DropFunctionField() to drop the function together with its output field and bound index.
      *
      * @param [in] request input parameters
      * @return Status operation successfully or not
      */
+    [[deprecated("Use DropFunctionField() instead; it also drops the output field and bound index")]]
     virtual Status
     DropCollectionFunction(const DropCollectionFunctionRequest& request) = 0;
 

--- a/src/include/milvus/request/collection/AddFunctionFieldRequest.h
+++ b/src/include/milvus/request/collection/AddFunctionFieldRequest.h
@@ -20,6 +20,7 @@
 
 #include "../../types/FieldSchema.h"
 #include "../../types/Function.h"
+#include "../../types/IndexDesc.h"
 #include "./CollectionRequestBase.h"
 #include "milvus/Export.h"
 
@@ -71,9 +72,34 @@ class MILVUS_SDK_API AddFunctionFieldRequest : public CollectionRequestBase<AddF
     AddFunctionFieldRequest&
     WithFunction(const FunctionPtr& function);
 
+    /**
+     * @brief Get the index bound to the function output field.
+     *
+     * The bound index is required and must use an explicit index type. AUTOINDEX is not supported.
+     */
+    const IndexDesc&
+    Index() const;
+
+    /**
+     * @brief Set the index bound to the function output field.
+     *
+     * The bound index is required and must use an explicit index type. AUTOINDEX is not supported.
+     */
+    void
+    SetIndex(IndexDesc&& index);
+
+    /**
+     * @brief Set the index bound to the function output field.
+     *
+     * The bound index is required and must use an explicit index type. AUTOINDEX is not supported.
+     */
+    AddFunctionFieldRequest&
+    WithIndex(IndexDesc&& index);
+
  private:
     FieldSchema field_;
     FunctionPtr function_;
+    IndexDesc index_;
 };
 
 }  // namespace milvus

--- a/test/it/mocks/MilvusMockedService.h
+++ b/test/it/mocks/MilvusMockedService.h
@@ -104,6 +104,10 @@ class MilvusMockedService : public ::milvus::proto::milvus::MilvusService::Servi
                  ::grpc::Status(::grpc::ServerContext*, const ::milvus::proto::milvus::AlterCollectionSchemaRequest*,
                                 ::milvus::proto::milvus::AlterCollectionSchemaResponse*));
 
+    MOCK_METHOD3(AddCollectionField,
+                 ::grpc::Status(::grpc::ServerContext*, const ::milvus::proto::milvus::AddCollectionFieldRequest*,
+                                ::milvus::proto::common::Status*));
+
     MOCK_METHOD3(CreatePartition,
                  ::grpc::Status(::grpc::ServerContext*, const ::milvus::proto::milvus::CreatePartitionRequest*,
                                 ::milvus::proto::common::Status*));

--- a/test/it/v2/TestAlterCollectionSchema.cpp
+++ b/test/it/v2/TestAlterCollectionSchema.cpp
@@ -17,11 +17,13 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <unordered_map>
 
 #include "../mocks/MilvusMockedTest.h"
 #include "milvus/MilvusClientV2.h"
 
 using ::milvus::StatusCode;
+using ::milvus::proto::milvus::AddCollectionFieldRequest;
 using ::milvus::proto::milvus::AlterCollectionSchemaRequest;
 using ::milvus::proto::milvus::AlterCollectionSchemaResponse;
 using ::testing::_;
@@ -42,6 +44,184 @@ CreateConnectedV2Client(testing::StrictMock<::milvus::MilvusMockedService>& serv
 }
 
 }  // namespace
+
+TEST_F(UnconnectMilvusMockedTest, AddCollectionFieldUsesAlterCollectionSchema) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("new_field", milvus::DataType::INT64);
+    field.SetNullable(true);
+
+    EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const AlterCollectionSchemaRequest* request,
+                     AlterCollectionSchemaResponse* response) {
+            EXPECT_EQ(request->db_name(), "db");
+            EXPECT_EQ(request->collection_name(), "coll");
+            EXPECT_TRUE(request->action().has_add_request());
+            EXPECT_EQ(request->action().add_request().field_infos_size(), 1);
+            EXPECT_EQ(request->action().add_request().func_schema_size(), 0);
+            const auto& field_schema = request->action().add_request().field_infos(0).field_schema();
+            EXPECT_EQ(field_schema.name(), "new_field");
+            EXPECT_EQ(field_schema.data_type(), ::milvus::proto::schema::DataType::Int64);
+            EXPECT_TRUE(field_schema.nullable());
+            response->mutable_alter_status()->set_code(0);
+            return ::grpc::Status{};
+        });
+
+    auto status = client->AddCollectionField(
+        milvus::AddCollectionFieldRequest().WithDatabaseName("db").WithCollectionName("coll").WithField(
+            std::move(field)));
+    EXPECT_TRUE(status.IsOk());
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddCollectionFieldFallsBackOnUnimplemented) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("new_field", milvus::DataType::INT64);
+    field.SetNullable(true);
+    ::testing::InSequence sequence;
+
+    EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const AlterCollectionSchemaRequest*, AlterCollectionSchemaResponse*) {
+            return ::grpc::Status{::grpc::StatusCode::UNIMPLEMENTED, "method not implemented"};
+        });
+    EXPECT_CALL(service_, AddCollectionField(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const AddCollectionFieldRequest* request,
+                     ::milvus::proto::common::Status* response) {
+            EXPECT_EQ(request->db_name(), "db");
+            EXPECT_EQ(request->collection_name(), "coll");
+            ::milvus::proto::schema::FieldSchema field_schema;
+            EXPECT_TRUE(field_schema.ParseFromString(request->schema()));
+            EXPECT_EQ(field_schema.name(), "new_field");
+            EXPECT_EQ(field_schema.data_type(), ::milvus::proto::schema::DataType::Int64);
+            EXPECT_TRUE(field_schema.nullable());
+            response->set_code(0);
+            return ::grpc::Status{};
+        });
+
+    auto status = client->AddCollectionField(
+        milvus::AddCollectionFieldRequest().WithDatabaseName("db").WithCollectionName("coll").WithField(
+            std::move(field)));
+    EXPECT_TRUE(status.IsOk());
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddCollectionFieldFallsBackOnServiceUnimplemented) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("new_field", milvus::DataType::INT64);
+    field.SetNullable(true);
+    ::testing::InSequence sequence;
+
+    EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
+        .WillOnce(
+            [](::grpc::ServerContext*, const AlterCollectionSchemaRequest*, AlterCollectionSchemaResponse* response) {
+                response->mutable_alter_status()->set_code(10);
+                response->mutable_alter_status()->set_reason("service unimplemented");
+                return ::grpc::Status{};
+            });
+    EXPECT_CALL(service_, AddCollectionField(_, _, _))
+        .WillOnce(
+            [](::grpc::ServerContext*, const AddCollectionFieldRequest*, ::milvus::proto::common::Status* response) {
+                response->set_code(0);
+                return ::grpc::Status{};
+            });
+
+    auto status = client->AddCollectionField(
+        milvus::AddCollectionFieldRequest().WithCollectionName("coll").WithField(std::move(field)));
+    EXPECT_TRUE(status.IsOk());
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddCollectionFieldDoesNotFallbackOnServerError) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("new_field", milvus::DataType::INT64);
+    field.SetNullable(true);
+
+    EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
+        .WillOnce(
+            [](::grpc::ServerContext*, const AlterCollectionSchemaRequest*, AlterCollectionSchemaResponse* response) {
+                response->mutable_alter_status()->set_code(::milvus::proto::common::ErrorCode::UnexpectedError);
+                response->mutable_alter_status()->set_reason("alter field failed");
+                return ::grpc::Status{};
+            });
+
+    auto status = client->AddCollectionField(
+        milvus::AddCollectionFieldRequest().WithCollectionName("coll").WithField(std::move(field)));
+    EXPECT_EQ(status.Code(), StatusCode::SERVER_FAILED);
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddCollectionFieldDoesNotFallbackOnServerCodeMatchingGrpcUnimplemented) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("new_field", milvus::DataType::INT64);
+
+    EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
+        .WillOnce(
+            [](::grpc::ServerContext*, const AlterCollectionSchemaRequest*, AlterCollectionSchemaResponse* response) {
+                response->mutable_alter_status()->set_code(static_cast<int32_t>(::grpc::StatusCode::UNIMPLEMENTED));
+                response->mutable_alter_status()->set_reason("server rejected alter field");
+                return ::grpc::Status{};
+            });
+
+    auto status = client->AddCollectionField(
+        milvus::AddCollectionFieldRequest().WithCollectionName("coll").WithField(std::move(field)));
+    EXPECT_EQ(status.Code(), StatusCode::SERVER_FAILED);
+    EXPECT_EQ(status.RpcErrCode(), 0);
+    EXPECT_EQ(status.ServerCode(), static_cast<int32_t>(::grpc::StatusCode::UNIMPLEMENTED));
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddCollectionFieldDoesNotFallbackOnOtherGrpcError) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("new_field", milvus::DataType::INT64);
+    field.SetNullable(true);
+
+    EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const AlterCollectionSchemaRequest*, AlterCollectionSchemaResponse*) {
+            return ::grpc::Status{::grpc::StatusCode::PERMISSION_DENIED, "permission denied"};
+        });
+
+    auto status = client->AddCollectionField(
+        milvus::AddCollectionFieldRequest().WithCollectionName("coll").WithField(std::move(field)));
+    EXPECT_EQ(status.Code(), StatusCode::RPC_FAILED);
+    EXPECT_EQ(status.RpcErrCode(), static_cast<int32_t>(::grpc::StatusCode::PERMISSION_DENIED));
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddCollectionFieldPropagatesLegacyServerError) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("new_field", milvus::DataType::INT64);
+    ::testing::InSequence sequence;
+
+    EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const AlterCollectionSchemaRequest*, AlterCollectionSchemaResponse*) {
+            return ::grpc::Status{::grpc::StatusCode::UNIMPLEMENTED, "method not implemented"};
+        });
+    EXPECT_CALL(service_, AddCollectionField(_, _, _))
+        .WillOnce(
+            [](::grpc::ServerContext*, const AddCollectionFieldRequest*, ::milvus::proto::common::Status* response) {
+                response->set_code(::milvus::proto::common::ErrorCode::UnexpectedError);
+                response->set_reason("legacy add field failed");
+                return ::grpc::Status{};
+            });
+
+    auto status = client->AddCollectionField(
+        milvus::AddCollectionFieldRequest().WithCollectionName("coll").WithField(std::move(field)));
+    EXPECT_EQ(status.Code(), StatusCode::SERVER_FAILED);
+    EXPECT_EQ(status.Message(), "legacy add field failed");
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddCollectionFieldPropagatesLegacyGrpcError) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("new_field", milvus::DataType::INT64);
+    ::testing::InSequence sequence;
+
+    EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const AlterCollectionSchemaRequest*, AlterCollectionSchemaResponse*) {
+            return ::grpc::Status{::grpc::StatusCode::UNIMPLEMENTED, "method not implemented"};
+        });
+    EXPECT_CALL(service_, AddCollectionField(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const AddCollectionFieldRequest*, ::milvus::proto::common::Status*) {
+            return ::grpc::Status{::grpc::StatusCode::PERMISSION_DENIED, "legacy permission denied"};
+        });
+
+    auto status = client->AddCollectionField(
+        milvus::AddCollectionFieldRequest().WithCollectionName("coll").WithField(std::move(field)));
+    EXPECT_EQ(status.Code(), StatusCode::RPC_FAILED);
+    EXPECT_EQ(status.RpcErrCode(), static_cast<int32_t>(::grpc::StatusCode::PERMISSION_DENIED));
+}
 
 TEST_F(UnconnectMilvusMockedTest, DropCollectionFieldNotConnected) {
     auto client = milvus::MilvusClientV2::Create();
@@ -131,11 +311,14 @@ TEST_F(UnconnectMilvusMockedTest, AddFunctionFieldNotConnected) {
     auto function = std::make_shared<milvus::Function>("bm25_fn", milvus::FunctionType::BM25);
     function->AddInputFieldName("text");
     function->AddOutputFieldName("sparse_vec");
+    milvus::IndexDesc index("sparse_vec", "sparse_idx", milvus::IndexType::SPARSE_INVERTED_INDEX,
+                            milvus::MetricType::BM25);
 
     auto status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
                                                .WithCollectionName("coll")
                                                .WithField(std::move(field))
-                                               .WithFunction(function));
+                                               .WithFunction(function)
+                                               .WithIndex(std::move(index)));
     EXPECT_EQ(status.Code(), StatusCode::NOT_CONNECTED);
 }
 
@@ -147,6 +330,8 @@ TEST_F(UnconnectMilvusMockedTest, AddFunctionFieldServerFailed) {
     auto function = std::make_shared<milvus::Function>("bm25_fn", milvus::FunctionType::BM25);
     function->AddInputFieldName("text");
     function->AddOutputFieldName("sparse_vec");
+    milvus::IndexDesc index("sparse_vec", "sparse_idx", milvus::IndexType::SPARSE_INVERTED_INDEX,
+                            milvus::MetricType::BM25);
 
     EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
         .WillOnce(
@@ -159,7 +344,8 @@ TEST_F(UnconnectMilvusMockedTest, AddFunctionFieldServerFailed) {
     auto status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
                                                .WithCollectionName("coll")
                                                .WithField(std::move(field))
-                                               .WithFunction(function));
+                                               .WithFunction(function)
+                                               .WithIndex(std::move(index)));
     EXPECT_EQ(status.Code(), StatusCode::SERVER_FAILED);
 }
 
@@ -171,11 +357,14 @@ TEST_F(UnconnectMilvusMockedTest, AddFunctionFieldRejectsMismatchedOutputName) {
     auto function = std::make_shared<milvus::Function>("bm25_fn", milvus::FunctionType::BM25);
     function->AddInputFieldName("text");
     function->AddOutputFieldName("other_vec");
+    milvus::IndexDesc index("sparse_vec", "sparse_idx", milvus::IndexType::SPARSE_INVERTED_INDEX,
+                            milvus::MetricType::BM25);
 
     auto status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
                                                .WithCollectionName("coll")
                                                .WithField(std::move(field))
-                                               .WithFunction(function));
+                                               .WithFunction(function)
+                                               .WithIndex(std::move(index)));
     EXPECT_EQ(status.Code(), StatusCode::INVALID_ARGUMENT);
 }
 
@@ -187,6 +376,9 @@ TEST_F(UnconnectMilvusMockedTest, AddFunctionField) {
     auto function = std::make_shared<milvus::Function>("bm25_fn", milvus::FunctionType::BM25);
     function->AddInputFieldName("text");
     function->AddOutputFieldName("sparse_vec");
+    milvus::IndexDesc index("sparse_vec", "sparse_idx", milvus::IndexType::SPARSE_INVERTED_INDEX,
+                            milvus::MetricType::BM25);
+    index.AddExtraParam("drop_ratio_build", "0.2");
 
     EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
         .WillOnce([](::grpc::ServerContext*, const AlterCollectionSchemaRequest* request,
@@ -197,8 +389,17 @@ TEST_F(UnconnectMilvusMockedTest, AddFunctionField) {
             if (request->action().add_request().field_infos_size() != 1) {
                 return ::grpc::Status{};
             }
-            EXPECT_EQ(request->action().add_request().field_infos(0).field_schema().name(), "sparse_vec");
-            EXPECT_TRUE(request->action().add_request().field_infos(0).field_schema().is_function_output());
+            const auto& field_info = request->action().add_request().field_infos(0);
+            EXPECT_EQ(field_info.field_schema().name(), "sparse_vec");
+            EXPECT_TRUE(field_info.field_schema().is_function_output());
+            EXPECT_EQ(field_info.index_name(), "sparse_idx");
+            std::unordered_map<std::string, std::string> index_params;
+            for (const auto& param : field_info.extra_params()) {
+                index_params.emplace(param.key(), param.value());
+            }
+            EXPECT_EQ(index_params.at("index_type"), "SPARSE_INVERTED_INDEX");
+            EXPECT_EQ(index_params.at("metric_type"), "BM25");
+            EXPECT_EQ(index_params.at("drop_ratio_build"), "0.2");
             EXPECT_EQ(request->action().add_request().func_schema_size(), 1);
             if (request->action().add_request().func_schema_size() != 1) {
                 return ::grpc::Status{};
@@ -211,8 +412,119 @@ TEST_F(UnconnectMilvusMockedTest, AddFunctionField) {
     auto status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
                                                .WithCollectionName("coll")
                                                .WithField(std::move(field))
-                                               .WithFunction(function));
+                                               .WithFunction(function)
+                                               .WithIndex(std::move(index)));
     EXPECT_TRUE(status.IsOk());
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddFunctionFieldWithMinHash) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("minhash_vec", milvus::DataType::BINARY_VECTOR);
+    field.WithDimension(512);
+    auto function = std::make_shared<milvus::Function>("minhash_fn", milvus::FunctionType::MINHASH);
+    function->AddInputFieldName("text");
+    function->AddOutputFieldName("minhash_vec");
+    milvus::IndexDesc index("", "minhash_idx", milvus::IndexType::MINHASH_LSH, milvus::MetricType::MHJACCARD);
+    index.AddExtraParam("mh_lsh_band", "16");
+
+    EXPECT_CALL(service_, AlterCollectionSchema(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const AlterCollectionSchemaRequest* request,
+                     AlterCollectionSchemaResponse* response) {
+            const auto& add_request = request->action().add_request();
+            EXPECT_EQ(add_request.field_infos_size(), 1);
+            EXPECT_EQ(add_request.func_schema_size(), 1);
+            if (add_request.field_infos_size() != 1 || add_request.func_schema_size() != 1) {
+                return ::grpc::Status{};
+            }
+            const auto& field_info = add_request.field_infos(0);
+            EXPECT_EQ(field_info.field_schema().data_type(), ::milvus::proto::schema::DataType::BinaryVector);
+            EXPECT_EQ(field_info.index_name(), "minhash_idx");
+            std::unordered_map<std::string, std::string> index_params;
+            for (const auto& param : field_info.extra_params()) {
+                index_params.emplace(param.key(), param.value());
+            }
+            EXPECT_EQ(index_params.at("index_type"), "MINHASH_LSH");
+            EXPECT_EQ(index_params.at("metric_type"), "MHJACCARD");
+            EXPECT_EQ(index_params.at("mh_lsh_band"), "16");
+            EXPECT_EQ(add_request.func_schema(0).type(), ::milvus::proto::schema::FunctionType::MinHash);
+            response->mutable_alter_status()->set_code(0);
+            return ::grpc::Status{};
+        });
+
+    auto status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
+                                               .WithCollectionName("coll")
+                                               .WithField(std::move(field))
+                                               .WithFunction(function)
+                                               .WithIndex(std::move(index)));
+    EXPECT_TRUE(status.IsOk());
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddFunctionFieldRejectsMissingBoundIndex) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("sparse_vec", milvus::DataType::SPARSE_FLOAT_VECTOR);
+    auto function = std::make_shared<milvus::Function>("bm25_fn", milvus::FunctionType::BM25);
+    function->AddInputFieldName("text");
+    function->AddOutputFieldName("sparse_vec");
+
+    auto status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
+                                               .WithCollectionName("coll")
+                                               .WithField(std::move(field))
+                                               .WithFunction(function));
+    EXPECT_EQ(status.Code(), StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddFunctionFieldRejectsAutoIndex) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("sparse_vec", milvus::DataType::SPARSE_FLOAT_VECTOR);
+    auto function = std::make_shared<milvus::Function>("bm25_fn", milvus::FunctionType::BM25);
+    function->AddInputFieldName("text");
+    function->AddOutputFieldName("sparse_vec");
+    milvus::IndexDesc index("sparse_vec", "sparse_idx", milvus::IndexType::AUTOINDEX, milvus::MetricType::BM25);
+
+    auto status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
+                                               .WithCollectionName("coll")
+                                               .WithField(std::move(field))
+                                               .WithFunction(function)
+                                               .WithIndex(std::move(index)));
+    EXPECT_EQ(status.Code(), StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddFunctionFieldRejectsMismatchedIndexField) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::FieldSchema field("sparse_vec", milvus::DataType::SPARSE_FLOAT_VECTOR);
+    auto function = std::make_shared<milvus::Function>("bm25_fn", milvus::FunctionType::BM25);
+    function->AddInputFieldName("text");
+    function->AddOutputFieldName("sparse_vec");
+    milvus::IndexDesc index("other_vec", "sparse_idx", milvus::IndexType::SPARSE_INVERTED_INDEX,
+                            milvus::MetricType::BM25);
+
+    auto status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
+                                               .WithCollectionName("coll")
+                                               .WithField(std::move(field))
+                                               .WithFunction(function)
+                                               .WithIndex(std::move(index)));
+    EXPECT_EQ(status.Code(), StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(UnconnectMilvusMockedTest, AddFunctionFieldRejectsReservedIndexParam) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    for (const auto* reserved_key : {"index_type", "metric_type", "params"}) {
+        SCOPED_TRACE(reserved_key);
+        milvus::FieldSchema field("sparse_vec", milvus::DataType::SPARSE_FLOAT_VECTOR);
+        auto function = std::make_shared<milvus::Function>("bm25_fn", milvus::FunctionType::BM25);
+        function->AddInputFieldName("text");
+        function->AddOutputFieldName("sparse_vec");
+        milvus::IndexDesc index("sparse_vec", "sparse_idx", milvus::IndexType::SPARSE_INVERTED_INDEX,
+                                milvus::MetricType::BM25);
+        index.AddExtraParam(reserved_key, "reserved");
+
+        auto status = client->AddFunctionField(milvus::AddFunctionFieldRequest()
+                                                   .WithCollectionName("coll")
+                                                   .WithField(std::move(field))
+                                                   .WithFunction(function)
+                                                   .WithIndex(std::move(index)));
+        EXPECT_EQ(status.Code(), StatusCode::INVALID_ARGUMENT);
+    }
 }
 
 TEST_F(UnconnectMilvusMockedTest, DropFunctionFieldNotConnected) {

--- a/test/st/milvus_container.py
+++ b/test/st/milvus_container.py
@@ -15,7 +15,7 @@ import time
 import docker
 import requests
 
-milvus_image = "milvusdb/milvus:master-20260609-1853a148"
+milvus_image = "milvusdb/milvus:master-20260617-7ac57bf2"
 milvus_port = 19510
 
 

--- a/test/ut/request/TestCollectionRequests.cpp
+++ b/test/ut/request/TestCollectionRequests.cpp
@@ -366,14 +366,22 @@ TEST_F(AddFunctionFieldRequestTest, GettersAndSetters) {
     auto function = std::make_shared<milvus::Function>("bm25_fn", milvus::FunctionType::BM25, "tokenize");
     function->AddInputFieldName("text");
     function->AddOutputFieldName("sparse_vec");
+    milvus::IndexDesc index("sparse_vec", "sparse_idx", milvus::IndexType::SPARSE_INVERTED_INDEX,
+                            milvus::MetricType::BM25);
+    index.AddExtraParam("drop_ratio_build", "0.2");
 
-    auto& ref = req.WithField(std::move(field)).WithFunction(function);
+    auto& ref = req.WithField(std::move(field)).WithFunction(function).WithIndex(std::move(index));
     EXPECT_EQ(&ref, &req);
     EXPECT_EQ(req.Field().Name(), "sparse_vec");
     ASSERT_NE(req.Function(), nullptr);
     EXPECT_EQ(req.Function()->Name(), "bm25_fn");
     EXPECT_EQ(req.Function()->OutputFieldNames().size(), 1);
     EXPECT_EQ(req.Function()->OutputFieldNames()[0], "sparse_vec");
+    EXPECT_EQ(req.Index().FieldName(), "sparse_vec");
+    EXPECT_EQ(req.Index().IndexName(), "sparse_idx");
+    EXPECT_EQ(req.Index().IndexType(), milvus::IndexType::SPARSE_INVERTED_INDEX);
+    EXPECT_EQ(req.Index().MetricType(), milvus::MetricType::BM25);
+    EXPECT_EQ(req.Index().ExtraParams().at("drop_ratio_build"), "0.2");
 }
 
 TEST_F(AddFunctionFieldRequestTest, SetFunction) {
@@ -382,6 +390,15 @@ TEST_F(AddFunctionFieldRequestTest, SetFunction) {
     req.SetFunction(function);
     ASSERT_NE(req.Function(), nullptr);
     EXPECT_EQ(req.Function()->Name(), "bm25_fn");
+}
+
+TEST_F(AddFunctionFieldRequestTest, SetIndex) {
+    milvus::AddFunctionFieldRequest req;
+    milvus::IndexDesc index("sparse_vec", "sparse_idx", milvus::IndexType::SPARSE_WAND, milvus::MetricType::BM25);
+    req.SetIndex(std::move(index));
+    EXPECT_EQ(req.Index().FieldName(), "sparse_vec");
+    EXPECT_EQ(req.Index().IndexName(), "sparse_idx");
+    EXPECT_EQ(req.Index().IndexType(), milvus::IndexType::SPARSE_WAND);
 }
 
 class DropFunctionFieldRequestTest : public ::testing::Test {};


### PR DESCRIPTION
## Summary

- Route `AddCollectionField` through `AlterCollectionSchema`, with a fallback to the legacy RPC only when an older server returns gRPC `Unimplemented`.
- Extend `AddFunctionFieldRequest` with required bound-index metadata and serialize the index name and flat index parameters into `FieldInfo`.
- Validate BM25 and MinHash function output fields and reject missing, automatic, or conflicting bound-index declarations before sending the RPC.
- Mark the legacy add/drop collection-function APIs as deprecated in favor of function-field operations.
- Add request, mock integration, and example coverage for schema routing, fallback behavior, bound-index serialization, and error propagation.

issue: #549

## Compatibility

- New Milvus servers use `AlterCollectionSchema` for `AddCollectionField`.
- Older servers that do not implement `AlterCollectionSchema` continue to work through the legacy `AddCollectionField` RPC.
- Fallback is limited to the transport-level gRPC `Unimplemented` status; application errors and other transport errors are returned unchanged.
- External-collection AddField support relies on the corresponding upstream Milvus server support and is not special-cased in the SDK.

## Related Milvus work

- https://github.com/milvus-io/milvus/pull/51411
- https://github.com/milvus-io/milvus/issues/48983

## Test Plan

- [x] 739 unit tests
- [x] 249 mocked integration tests
- [x] Master E2E for Add/Drop Field, BM25, and MinHash function fields
- [x] Milvus 2.6 compatibility E2E verifying the legacy AddCollectionField fallback
- [x] `git diff --check`
- [x] clang-format check for all changed C++ files