### PR TITLE
Auto publish packages

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,4 +1,4 @@
-name: Create draft release
+name: Create release
 
 on:
   push:
@@ -7,17 +7,18 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
-  # create a draft release for an exact release tag (vX.Y.Z).
+  # Create and publish a release for an exact release tag (vX.Y.Z).
   # Tags that do not match this format are ignored, which allows pushing other tags (e.g. vX.Y)
   # without triggering the release workflow.
-  draft-release:
-    name: Create draft release
+  release:
+    name: Create release
     runs-on: ubuntu-latest
     steps:
       - name: Prepare release metadata
@@ -26,7 +27,7 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           if ! echo "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Tag $RELEASE_TAG is not an exact release tag in vX.Y.Z format. Skipping draft release."
+            echo "Tag $RELEASE_TAG is not an exact release tag in vX.Y.Z format. Skipping release."
             echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -38,7 +39,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "release_date=${release_date}" >> "$GITHUB_OUTPUT"
           echo "milvus_minor=${milvus_minor}" >> "$GITHUB_OUTPUT"
-      - name: Create draft release
+      - name: Create release
         if: steps.release-info.outputs.is_release_tag == 'true'
         uses: ncipollo/release-action@v1
         with:
@@ -47,8 +48,27 @@ jobs:
           body: |
             Release date: ${{ steps.release-info.outputs.release_date }}
             Compatible with Milvus v${{ steps.release-info.outputs.milvus_minor }}.x
-          draft: true
+          draft: false
           allowUpdates: true
           omitNameDuringUpdate: true
           omitBodyDuringUpdate: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger release package builds
+        if: steps.release-info.outputs.is_release_tag == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh workflow run release.yaml \
+            --ref "$RELEASE_TAG" \
+            -f tag="$RELEASE_TAG" \
+            -f ubuntu_20_04=true \
+            -f ubuntu_22_04=true \
+            -f ubuntu_24_04=true \
+            -f ubuntu_24_04_arm=true \
+            -f fedora_39=true \
+            -f macos_15=true \
+            -f macos_26=true \
+            -f macos_26_intel=true \
+            -f windows_2022=true

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,13 @@ $ make test
 ```
 ## Try the examples
 Once the `make test` is done, you will see some executable examples under the path `./cmake_build/examples`.
+
+To suppress verbose gRPC internal logs when running the examples, set:
+
+```shell
+export GRPC_VERBOSITY=ERROR
+```
+
 Examples for MilvusClient:
 - `./cmake_build/examples/v1/sdk_array_v1`: example to show the usage of Array field.
 - `./cmake_build/examples/v1/sdk_db_v1`: example to show the usage of databases.

--- a/examples/src/v2/add_field.cpp
+++ b/examples/src/v2/add_field.cpp
@@ -153,6 +153,9 @@ main(int argc, char* argv[]) {
     }
 
     {
+        // This function-backed field demo requires these Milvus server settings:
+        // common.storage.useLoonFFI=true and dataCoord.compaction.bumpSchemaVersion.enabled=true.
+        // dataCoord.compaction.storageVersion.enabled must also remain enabled (the default).
         milvus::FieldSchema text_field = milvus::FieldSchema(field_text, milvus::DataType::VARCHAR)
                                              .WithMaxLength(100)
                                              .EnableAnalyzer(true)

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -36,27 +36,38 @@ if [[ ! -d "${EXAMPLE_DIR}" ]]; then
     exit 1
 fi
 
-readonly CDC_EXAMPLE="${EXAMPLE_DIR}/sdk_cdc_v2"
-if [[ -x "${CDC_EXAMPLE}" ]]; then
-    echo "Skipping sdk_cdc_v2 because it requires two Milvus servers."
-fi
-
-readonly EXTERNAL_TABLE_EXAMPLE="${EXAMPLE_DIR}/sdk_external_table_v2"
-if [[ -x "${EXTERNAL_TABLE_EXAMPLE}" ]]; then
-    echo "Skipping sdk_external_table_v2 because it requires pre-populated external object storage."
-fi
-
-readonly OPTIMIZE_EXAMPLE="${EXAMPLE_DIR}/sdk_optimize_v2"
-if [[ -x "${OPTIMIZE_EXAMPLE}" ]]; then
-    echo "Skipping sdk_optimize_v2."
-fi
-
-mapfile -d '' examples < <(find "${EXAMPLE_DIR}" -maxdepth 1 -type f -name "sdk_*_${version}" \
-    ! -name "sdk_cdc_v2" ! -name "sdk_external_table_v2" ! -name "sdk_optimize_v2" \
+mapfile -d '' all_examples < <(find "${EXAMPLE_DIR}" -maxdepth 1 -type f -name "sdk_*_${version}" \
     -perm -u+x -print0 | sort -z)
-if [[ ${#examples[@]} -eq 0 ]]; then
+if [[ ${#all_examples[@]} -eq 0 ]]; then
     echo "No executable ${version} examples found in: ${EXAMPLE_DIR}" >&2
     echo "Build the examples first, for example with: make test" >&2
+    exit 1
+fi
+
+examples=()
+for example in "${all_examples[@]}"; do
+    example_name="$(basename "${example}")"
+    case "${example_name}" in
+        sdk_cdc_v2)
+            echo "Skipping ${example_name} because it requires two Milvus servers."
+            ;;
+        sdk_external_table_v2)
+            echo "Skipping ${example_name} because it requires pre-populated external object storage."
+            ;;
+        sdk_optimize_v2)
+            echo "Skipping ${example_name} because it is excluded from the batch run."
+            ;;
+        sdk_add_field_v2)
+            echo "Skipping ${example_name} because its function-backed field demo requires additional server settings."
+            ;;
+        *)
+            examples+=("${example}")
+            ;;
+    esac
+done
+
+if [[ ${#examples[@]} -eq 0 ]]; then
+    echo "No runnable ${version} examples remain after applying the skip list." >&2
     exit 1
 fi
 
@@ -76,4 +87,4 @@ for example in "${examples[@]}"; do
 done
 
 echo
-echo "All ${version} examples passed."
+echo "All runnable ${version} examples passed."

--- a/src/include/milvus/MilvusClientV2.h
+++ b/src/include/milvus/MilvusClientV2.h
@@ -483,8 +483,7 @@ class MILVUS_SDK_API MilvusClientV2 {
      * @param [in] request input parameters
      * @return Status operation successfully or not
      */
-    [[deprecated("Use AddFunctionField() instead")]]
-    virtual Status
+    [[deprecated("Use AddFunctionField() instead")]] virtual Status
     AddCollectionFunction(const AddCollectionFunctionRequest& request) = 0;
 
     /**
@@ -513,8 +512,7 @@ class MILVUS_SDK_API MilvusClientV2 {
      * @param [in] request input parameters
      * @return Status operation successfully or not
      */
-    [[deprecated("Use DropFunctionField() instead; it also drops the output field and bound index")]]
-    virtual Status
+    [[deprecated("Use DropFunctionField() instead; it also drops the output field and bound index")]] virtual Status
     DropCollectionFunction(const DropCollectionFunctionRequest& request) = 0;
 
     /**

--- a/test/st/milvus_container.py
+++ b/test/st/milvus_container.py
@@ -15,7 +15,7 @@ import time
 import docker
 import requests
 
-milvus_image = "milvusdb/milvus:master-20260617-7ac57bf2"
+milvus_image = "milvusdb/milvus:master-20260723-32a44262"
 milvus_port = 19510
 
 


### PR DESCRIPTION
Automates the release process when an exact vX.Y.Z tag is pushed.

  - Publishes the GitHub release immediately instead of creating a draft.
  - Triggers package builds for all supported Linux, macOS, and Windows targets.
  - Documents GRPC_VERBOSITY=ERROR for suppressing verbose gRPC example logs.
  - Documents the StorageV3 requirement for the add-field function demo.
  - Skips sdk_add_field_v2 in the batch example runner because it requires special server
    configuration.
  - Updates the Milvus image used by system tests.