### PR TITLE
Fix stale collection schema cache after alias mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## milvus-sdk-cpp 2.6.5 (2026-07-24)
+## milvus-sdk-cpp 2.6.5 (2026-07-27)
 ### Feature
 - Support highlighting for search results
 - Support DumpMessages(), AlterRole(), and UpdateUser() interfaces
@@ -11,6 +11,9 @@
 ### Improvement
 - Align CreateRoleRequest/CreateUserRequest/SearchResponse/QueryResponse with other SDKs
 - Avoid conflicts with a system-installed nlohmann/json library
+
+### Bug
+- Invalidate cached collection schemas after successful or transport-ambiguous alias and collection identity mutations
 
 
 ## milvus-sdk-cpp 2.6.4 (2026-06-17)

--- a/src/impl/MilvusClientImpl.cpp
+++ b/src/impl/MilvusClientImpl.cpp
@@ -35,6 +35,31 @@
 #include "utils/TypeUtils.h"
 
 namespace milvus {
+namespace {
+
+// A gRPC deadline or ambiguous transport failure can be reported after Milvus has committed a metadata mutation.
+// Invalidate cached collection descriptions in that case, but retain them for definitive local or server rejections,
+// including retry exhaustion caused by server-side rate limiting.
+bool
+isAmbiguousMutationFailure(const Status& status) {
+    switch (status.RpcErrCode()) {
+        case ::grpc::StatusCode::OK:
+        case ::grpc::StatusCode::INVALID_ARGUMENT:
+        case ::grpc::StatusCode::NOT_FOUND:
+        case ::grpc::StatusCode::ALREADY_EXISTS:
+        case ::grpc::StatusCode::PERMISSION_DENIED:
+        case ::grpc::StatusCode::UNAUTHENTICATED:
+        case ::grpc::StatusCode::RESOURCE_EXHAUSTED:
+        case ::grpc::StatusCode::FAILED_PRECONDITION:
+        case ::grpc::StatusCode::OUT_OF_RANGE:
+        case ::grpc::StatusCode::UNIMPLEMENTED:
+            return false;
+        default:
+            return true;
+    }
+}
+
+}  // namespace
 
 std::shared_ptr<MilvusClient>
 MilvusClient::Create() {
@@ -116,8 +141,17 @@ MilvusClientImpl::CreateCollection(const CollectionSchema& schema, int64_t num_p
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::CreateCollectionRequest, proto::common::Status>(
-        validate, pre, &MilvusConnection::CreateCollection, nullptr);
+    auto post = [this, &schema](const proto::common::Status&) {
+        removeCollectionDesc(schema.Name());
+        return Status::OK();
+    };
+
+    auto status = connection_.Invoke<proto::milvus::CreateCollectionRequest, proto::common::Status>(
+        validate, pre, &MilvusConnection::CreateCollection, post);
+    if (isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(schema.Name());
+    }
+    return status;
 }
 
 Status
@@ -155,8 +189,12 @@ MilvusClientImpl::DropCollection(const std::string& collection_name) {
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::DropCollectionRequest, proto::common::Status>(
+    auto status = connection_.Invoke<proto::milvus::DropCollectionRequest, proto::common::Status>(
         pre, &MilvusConnection::DropCollection, post);
+    if (isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(collection_name);
+    }
+    return status;
 }
 
 Status
@@ -231,8 +269,13 @@ MilvusClientImpl::RenameCollection(const std::string& collection_name, const std
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::RenameCollectionRequest, proto::common::Status>(
+    auto status = connection_.Invoke<proto::milvus::RenameCollectionRequest, proto::common::Status>(
         pre, &MilvusConnection::RenameCollection);
+    if (status.IsOk() || isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(collection_name);
+        removeCollectionDesc(new_collection_name);
+    }
+    return status;
 }
 
 Status
@@ -499,8 +542,12 @@ MilvusClientImpl::CreateAlias(const std::string& collection_name, const std::str
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::CreateAliasRequest, proto::common::Status>(pre,
-                                                                                        &MilvusConnection::CreateAlias);
+    auto status = connection_.Invoke<proto::milvus::CreateAliasRequest, proto::common::Status>(
+        pre, &MilvusConnection::CreateAlias);
+    if (status.IsOk() || isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(alias);
+    }
+    return status;
 }
 
 Status
@@ -510,8 +557,12 @@ MilvusClientImpl::DropAlias(const std::string& alias) {
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::DropAliasRequest, proto::common::Status>(pre,
-                                                                                      &MilvusConnection::DropAlias);
+    auto status =
+        connection_.Invoke<proto::milvus::DropAliasRequest, proto::common::Status>(pre, &MilvusConnection::DropAlias);
+    if (status.IsOk() || isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(alias);
+    }
+    return status;
 }
 
 Status
@@ -522,8 +573,12 @@ MilvusClientImpl::AlterAlias(const std::string& collection_name, const std::stri
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::AlterAliasRequest, proto::common::Status>(pre,
-                                                                                       &MilvusConnection::AlterAlias);
+    auto status =
+        connection_.Invoke<proto::milvus::AlterAliasRequest, proto::common::Status>(pre, &MilvusConnection::AlterAlias);
+    if (status.IsOk() || isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(alias);
+    }
+    return status;
 }
 
 Status

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -37,6 +37,31 @@
 #include "utils/TypeUtils.h"
 
 namespace milvus {
+namespace {
+
+// A gRPC deadline or ambiguous transport failure can be reported after Milvus has committed a metadata mutation.
+// Invalidate cached collection descriptions in that case, but retain them for definitive local or server rejections,
+// including retry exhaustion caused by server-side rate limiting.
+bool
+isAmbiguousMutationFailure(const Status& status) {
+    switch (status.RpcErrCode()) {
+        case ::grpc::StatusCode::OK:
+        case ::grpc::StatusCode::INVALID_ARGUMENT:
+        case ::grpc::StatusCode::NOT_FOUND:
+        case ::grpc::StatusCode::ALREADY_EXISTS:
+        case ::grpc::StatusCode::PERMISSION_DENIED:
+        case ::grpc::StatusCode::UNAUTHENTICATED:
+        case ::grpc::StatusCode::RESOURCE_EXHAUSTED:
+        case ::grpc::StatusCode::FAILED_PRECONDITION:
+        case ::grpc::StatusCode::OUT_OF_RANGE:
+        case ::grpc::StatusCode::UNIMPLEMENTED:
+            return false;
+        default:
+            return true;
+    }
+}
+
+}  // namespace
 
 std::shared_ptr<MilvusClientV2>
 MilvusClientV2::Create() {
@@ -156,6 +181,8 @@ MilvusClientV2Impl::CreateCollection(const CreateCollectionRequest& request) {
     };
 
     auto post = [this, &request, &schema](const proto::common::Status& rpc_response) {
+        removeCollectionDesc(request.DatabaseName(), request.CollectionName());
+
         if (request.Indexes().empty()) {
             return Status::OK();
         }
@@ -180,8 +207,12 @@ MilvusClientV2Impl::CreateCollection(const CreateCollectionRequest& request) {
         return LoadCollection(load_req);
     };
 
-    return connection_.Invoke<proto::milvus::CreateCollectionRequest, proto::common::Status>(
+    auto status = connection_.Invoke<proto::milvus::CreateCollectionRequest, proto::common::Status>(
         validate, pre, &MilvusConnection::CreateCollection, post);
+    if (isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(request.DatabaseName(), request.CollectionName());
+    }
+    return status;
 }
 
 Status
@@ -251,8 +282,12 @@ MilvusClientV2Impl::DropCollection(const DropCollectionRequest& request) {
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::DropCollectionRequest, proto::common::Status>(
+    auto status = connection_.Invoke<proto::milvus::DropCollectionRequest, proto::common::Status>(
         pre, &MilvusConnection::DropCollection, post);
+    if (isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(request.DatabaseName(), request.CollectionName());
+    }
+    return status;
 }
 
 Status
@@ -526,8 +561,13 @@ MilvusClientV2Impl::RenameCollection(const RenameCollectionRequest& request) {
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::RenameCollectionRequest, proto::common::Status>(
+    auto status = connection_.Invoke<proto::milvus::RenameCollectionRequest, proto::common::Status>(
         pre, &MilvusConnection::RenameCollection);
+    if (status.IsOk() || isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(request.DatabaseName(), request.CollectionName());
+        removeCollectionDesc(request.DatabaseName(), request.NewCollectionName());
+    }
+    return status;
 }
 
 Status
@@ -942,8 +982,12 @@ MilvusClientV2Impl::CreateAlias(const CreateAliasRequest& request) {
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::CreateAliasRequest, proto::common::Status>(pre,
-                                                                                        &MilvusConnection::CreateAlias);
+    auto status = connection_.Invoke<proto::milvus::CreateAliasRequest, proto::common::Status>(
+        pre, &MilvusConnection::CreateAlias);
+    if (status.IsOk() || isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(request.DatabaseName(), request.Alias());
+    }
+    return status;
 }
 
 Status
@@ -954,8 +998,12 @@ MilvusClientV2Impl::DropAlias(const DropAliasRequest& request) {
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::DropAliasRequest, proto::common::Status>(pre,
-                                                                                      &MilvusConnection::DropAlias);
+    auto status =
+        connection_.Invoke<proto::milvus::DropAliasRequest, proto::common::Status>(pre, &MilvusConnection::DropAlias);
+    if (status.IsOk() || isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(request.DatabaseName(), request.Alias());
+    }
+    return status;
 }
 
 Status
@@ -967,8 +1015,12 @@ MilvusClientV2Impl::AlterAlias(const AlterAliasRequest& request) {
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::AlterAliasRequest, proto::common::Status>(pre,
-                                                                                       &MilvusConnection::AlterAlias);
+    auto status =
+        connection_.Invoke<proto::milvus::AlterAliasRequest, proto::common::Status>(pre, &MilvusConnection::AlterAlias);
+    if (status.IsOk() || isAmbiguousMutationFailure(status)) {
+        removeCollectionDesc(request.DatabaseName(), request.Alias());
+    }
+    return status;
 }
 
 Status
@@ -3167,7 +3219,8 @@ MilvusClientV2Impl::getCollectionDesc(const std::string& db_name, const std::str
     // the reason is: describeCollection() could be limited by server-side(DDL request throttling is enabled)
     // we don't intend to allow too many threads run into describeCollection() in this method
     std::lock_guard<std::mutex> lock(collection_desc_cache_mtx_);
-    auto it = collection_desc_cache_.find(collection_name);
+    auto name = combineDbCollectionName(actual_db, collection_name);
+    auto it = collection_desc_cache_.find(name);
     if (it != collection_desc_cache_.end()) {
         if (it->second != nullptr && !force_update) {
             desc_ptr = it->second;
@@ -3181,7 +3234,6 @@ MilvusClientV2Impl::getCollectionDesc(const std::string& db_name, const std::str
     auto status = describeCollection(rquest, response, rpc_timeout_ms);
     if (status.IsOk()) {
         desc_ptr = std::make_shared<CollectionDesc>(response.Desc());
-        auto name = combineDbCollectionName(actual_db, collection_name);
         collection_desc_cache_[name] = desc_ptr;
         return status;
     }

--- a/src/impl/MilvusClientV2Impl.h
+++ b/src/impl/MilvusClientV2Impl.h
@@ -415,9 +415,7 @@ class MilvusClientV2Impl : public MilvusClientV2, public std::enable_shared_from
  private:
     ConnectionHandler connection_;
 
-    // cache of collection schemas
-    // this cache is db level, once useDatabase() is called, this cache will be cleaned
-    // so, it is fine to use collection name as key, no need to involve db name
+    // Cache of collection schemas, keyed by database name and collection name.
     std::map<std::string, CollectionDescPtr> collection_desc_cache_;
     std::mutex collection_desc_cache_mtx_;
 };

--- a/test/it/v1/TestAliasCache.cpp
+++ b/test/it/v1/TestAliasCache.cpp
@@ -1,0 +1,324 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <tuple>
+
+#include "../mocks/MilvusMockedTest.h"
+
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::Combine;
+using ::testing::InSequence;
+using ::testing::Property;
+using ::testing::Values;
+
+namespace {
+
+enum class AliasMutation { CREATE, ALTER, DROP };
+
+void
+SetInsertSchema(milvus::proto::milvus::DescribeCollectionResponse* response) {
+    auto* field = response->mutable_schema()->add_fields();
+    field->set_name("id");
+    field->set_data_type(milvus::proto::schema::DataType::Int64);
+    field->set_is_primary_key(true);
+}
+
+void
+ExpectInsert(testing::StrictMock<::milvus::MilvusMockedService>& service, const std::string& collection_name) {
+    EXPECT_CALL(service,
+                Insert(_, Property(&milvus::proto::milvus::InsertRequest::collection_name, collection_name), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::InsertRequest*,
+                     milvus::proto::milvus::MutationResult* response) {
+            response->mutable_ids()->mutable_int_id()->add_data(1);
+            response->set_insert_cnt(1);
+            return ::grpc::Status{};
+        });
+}
+
+milvus::Status
+RunInsert(const milvus::MilvusClientPtr& client, const std::string& collection_name) {
+    std::vector<milvus::FieldDataPtr> fields{std::make_shared<milvus::Int64FieldData>("id", std::vector<int64_t>{1})};
+    milvus::DmlResults results;
+    return client->Insert(collection_name, "", fields, results);
+}
+
+void
+ExpectAliasMutation(testing::StrictMock<::milvus::MilvusMockedService>& service, AliasMutation mutation,
+                    const std::string& collection_name, const std::string& alias,
+                    ::grpc::Status rpc_status = ::grpc::Status{}) {
+    switch (mutation) {
+        case AliasMutation::CREATE:
+            EXPECT_CALL(service, CreateAlias(_,
+                                             AllOf(Property(&milvus::proto::milvus::CreateAliasRequest::collection_name,
+                                                            collection_name),
+                                                   Property(&milvus::proto::milvus::CreateAliasRequest::alias, alias)),
+                                             _))
+                .WillOnce([rpc_status](::grpc::ServerContext*, const milvus::proto::milvus::CreateAliasRequest*,
+                                       milvus::proto::common::Status*) { return rpc_status; });
+            break;
+        case AliasMutation::ALTER:
+            EXPECT_CALL(
+                service,
+                AlterAlias(_,
+                           AllOf(Property(&milvus::proto::milvus::AlterAliasRequest::collection_name, collection_name),
+                                 Property(&milvus::proto::milvus::AlterAliasRequest::alias, alias)),
+                           _))
+                .WillOnce([rpc_status](::grpc::ServerContext*, const milvus::proto::milvus::AlterAliasRequest*,
+                                       milvus::proto::common::Status*) { return rpc_status; });
+            break;
+        case AliasMutation::DROP:
+            EXPECT_CALL(service, DropAlias(_, Property(&milvus::proto::milvus::DropAliasRequest::alias, alias), _))
+                .WillOnce([rpc_status](::grpc::ServerContext*, const milvus::proto::milvus::DropAliasRequest*,
+                                       milvus::proto::common::Status*) { return rpc_status; });
+            break;
+    }
+}
+
+milvus::Status
+RunAliasMutation(const milvus::MilvusClientPtr& client, AliasMutation mutation, const std::string& collection_name,
+                 const std::string& alias) {
+    switch (mutation) {
+        case AliasMutation::CREATE:
+            return client->CreateAlias(collection_name, alias);
+        case AliasMutation::ALTER:
+            return client->AlterAlias(collection_name, alias);
+        case AliasMutation::DROP:
+            return client->DropAlias(alias);
+    }
+    return {milvus::StatusCode::UNKNOWN_ERROR, "Unknown alias mutation"};
+}
+
+class V1AliasCacheTest : public MilvusMockedTest, public testing::WithParamInterface<AliasMutation> {};
+
+TEST_P(V1AliasCacheTest, SuccessfulMutationInvalidatesCollectionDescCache) {
+    auto status = client_->Connect(milvus::ConnectParam{"127.0.0.1", server_.ListenPort()});
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    const std::string alias = "active_collection";
+    const std::string target = "new_collection";
+
+    InSequence sequence;
+    EXPECT_CALL(
+        service_,
+        DescribeCollection(_, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, alias), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetInsertSchema(response);
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, alias);
+    ExpectAliasMutation(service_, GetParam(), target, alias);
+    EXPECT_CALL(
+        service_,
+        DescribeCollection(_, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, alias), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetInsertSchema(response);
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, alias);
+
+    status = RunInsert(client_, alias);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = RunAliasMutation(client_, GetParam(), target, alias);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = RunInsert(client_, alias);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+INSTANTIATE_TEST_SUITE_P(AllAliasMutations, V1AliasCacheTest,
+                         testing::Values(AliasMutation::CREATE, AliasMutation::ALTER, AliasMutation::DROP));
+
+class V1AmbiguousAliasCacheTest : public MilvusMockedTest,
+                                  public testing::WithParamInterface<std::tuple<AliasMutation, ::grpc::StatusCode>> {};
+
+TEST_P(V1AmbiguousAliasCacheTest, MutationInvalidatesCollectionDescCache) {
+    auto status = client_->Connect(milvus::ConnectParam{"127.0.0.1", server_.ListenPort()});
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    const std::string alias = "active_collection";
+    const auto mutation = std::get<0>(GetParam());
+    const auto rpc_code = std::get<1>(GetParam());
+
+    InSequence sequence;
+    EXPECT_CALL(service_, DescribeCollection(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetInsertSchema(response);
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, alias);
+    ExpectAliasMutation(service_, mutation, "new_collection", alias,
+                        ::grpc::Status{rpc_code, "ambiguous transport failure"});
+    EXPECT_CALL(service_, DescribeCollection(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetInsertSchema(response);
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, alias);
+
+    status = RunInsert(client_, alias);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = RunAliasMutation(client_, mutation, "new_collection", alias);
+    ASSERT_FALSE(status.IsOk());
+    EXPECT_EQ(rpc_code == ::grpc::StatusCode::DEADLINE_EXCEEDED ? milvus::StatusCode::TIMEOUT
+                                                                : milvus::StatusCode::RPC_FAILED,
+              status.Code());
+    status = RunInsert(client_, alias);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+INSTANTIATE_TEST_SUITE_P(AllAliasMutationsAndTransportFailures, V1AmbiguousAliasCacheTest,
+                         Combine(Values(AliasMutation::CREATE, AliasMutation::ALTER, AliasMutation::DROP),
+                                 Values(::grpc::StatusCode::UNKNOWN, ::grpc::StatusCode::DEADLINE_EXCEEDED)));
+
+TEST_F(MilvusMockedTest, RejectedV1AliasMutationKeepsCollectionDescCache) {
+    auto status = client_->Connect(milvus::ConnectParam{"127.0.0.1", server_.ListenPort()});
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    const std::string alias = "active_collection";
+
+    InSequence sequence;
+    EXPECT_CALL(
+        service_,
+        DescribeCollection(_, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, alias), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetInsertSchema(response);
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, alias);
+    EXPECT_CALL(service_, AlterAlias(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::AlterAliasRequest*,
+                     milvus::proto::common::Status* response) {
+            response->set_code(1);
+            response->set_reason("alter rejected");
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, alias);
+
+    status = RunInsert(client_, alias);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = client_->AlterAlias("new_collection", alias);
+    ASSERT_FALSE(status.IsOk());
+    EXPECT_EQ(milvus::StatusCode::SERVER_FAILED, status.Code());
+    status = RunInsert(client_, alias);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+TEST_F(MilvusMockedTest, RateLimitRetryTimeoutKeepsCollectionDescCache) {
+    auto status = client_->Connect(milvus::ConnectParam{"127.0.0.1", server_.ListenPort()});
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    milvus::RetryParam retry_param;
+    status = client_->SetRetryParam(retry_param.WithMaxRetryTimes(2).WithInitialBackOffMs(1).WithMaxBackOffMs(1));
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    const std::string alias = "active_collection";
+
+    InSequence sequence;
+    EXPECT_CALL(service_, DescribeCollection(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetInsertSchema(response);
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, alias);
+    EXPECT_CALL(service_, AlterAlias(_, _, _))
+        .Times(2)
+        .WillRepeatedly([](::grpc::ServerContext*, const milvus::proto::milvus::AlterAliasRequest*,
+                           milvus::proto::common::Status* response) {
+            response->set_code(8);
+            response->set_reason("rate limited");
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, alias);
+
+    status = RunInsert(client_, alias);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = client_->AlterAlias("new_collection", alias);
+    ASSERT_FALSE(status.IsOk());
+    EXPECT_EQ(milvus::StatusCode::TIMEOUT, status.Code());
+    EXPECT_EQ(0, status.RpcErrCode());
+    EXPECT_EQ(8, status.ServerCode());
+    status = RunInsert(client_, alias);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+TEST_F(MilvusMockedTest, RenameAndRecreateInvalidatesCollectionDescCache) {
+    auto status = client_->Connect(milvus::ConnectParam{"127.0.0.1", server_.ListenPort()});
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    const std::string old_name = "old_collection";
+    const std::string new_name = "new_collection";
+
+    InSequence sequence;
+    EXPECT_CALL(service_,
+                DescribeCollection(
+                    _, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, old_name), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetInsertSchema(response);
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, old_name);
+    EXPECT_CALL(service_,
+                RenameCollection(_,
+                                 AllOf(Property(&milvus::proto::milvus::RenameCollectionRequest::oldname, old_name),
+                                       Property(&milvus::proto::milvus::RenameCollectionRequest::newname, new_name)),
+                                 _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::RenameCollectionRequest*,
+                     milvus::proto::common::Status*) { return ::grpc::Status{}; });
+    EXPECT_CALL(service_,
+                DescribeCollection(
+                    _, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, old_name), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse*) {
+            return ::grpc::Status{::grpc::StatusCode::NOT_FOUND, "collection not found"};
+        });
+    EXPECT_CALL(
+        service_,
+        CreateCollection(_, Property(&milvus::proto::milvus::CreateCollectionRequest::collection_name, old_name), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::CreateCollectionRequest*,
+                     milvus::proto::common::Status*) { return ::grpc::Status{}; });
+    EXPECT_CALL(service_,
+                DescribeCollection(
+                    _, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, old_name), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetInsertSchema(response);
+            return ::grpc::Status{};
+        });
+    ExpectInsert(service_, old_name);
+
+    status = RunInsert(client_, old_name);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+
+    status = client_->RenameCollection(old_name, new_name);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+
+    status = RunInsert(client_, old_name);
+    ASSERT_FALSE(status.IsOk());
+
+    milvus::CollectionSchema schema(old_name);
+    schema.AddField(milvus::FieldSchema("id", milvus::DataType::INT64, "", true));
+    status = client_->CreateCollection(schema);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+
+    status = RunInsert(client_, old_name);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+}  // namespace

--- a/test/it/v2/TestAliasCache.cpp
+++ b/test/it/v2/TestAliasCache.cpp
@@ -1,0 +1,340 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <tuple>
+
+#include "../mocks/MilvusMockedTest.h"
+#include "milvus/MilvusClientV2.h"
+
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::Combine;
+using ::testing::InSequence;
+using ::testing::Property;
+using ::testing::Values;
+
+namespace {
+
+enum class AliasMutation { CREATE, ALTER, DROP };
+
+std::shared_ptr<milvus::MilvusClientV2>
+CreateConnectedV2Client(testing::StrictMock<::milvus::MilvusMockedService>& service, uint16_t port) {
+    EXPECT_CALL(service, Connect(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const ::milvus::proto::milvus::ConnectRequest*,
+                     ::milvus::proto::milvus::ConnectResponse*) { return ::grpc::Status{}; });
+
+    auto client = milvus::MilvusClientV2::Create();
+    auto status = client->Connect(milvus::ConnectParam{"127.0.0.1", port});
+    EXPECT_TRUE(status.IsOk());
+    return client;
+}
+
+void
+SetCollectionID(milvus::proto::milvus::DescribeCollectionResponse* response, int64_t collection_id) {
+    response->set_collectionid(collection_id);
+}
+
+void
+ExpectV2AliasMutation(testing::StrictMock<::milvus::MilvusMockedService>& service, AliasMutation mutation,
+                      const std::string& collection_name, const std::string& alias,
+                      ::grpc::Status rpc_status = ::grpc::Status{}) {
+    switch (mutation) {
+        case AliasMutation::CREATE:
+            EXPECT_CALL(service, CreateAlias(_,
+                                             AllOf(Property(&milvus::proto::milvus::CreateAliasRequest::collection_name,
+                                                            collection_name),
+                                                   Property(&milvus::proto::milvus::CreateAliasRequest::alias, alias)),
+                                             _))
+                .WillOnce([rpc_status](::grpc::ServerContext*, const milvus::proto::milvus::CreateAliasRequest*,
+                                       milvus::proto::common::Status*) { return rpc_status; });
+            break;
+        case AliasMutation::ALTER:
+            EXPECT_CALL(
+                service,
+                AlterAlias(_,
+                           AllOf(Property(&milvus::proto::milvus::AlterAliasRequest::collection_name, collection_name),
+                                 Property(&milvus::proto::milvus::AlterAliasRequest::alias, alias)),
+                           _))
+                .WillOnce([rpc_status](::grpc::ServerContext*, const milvus::proto::milvus::AlterAliasRequest*,
+                                       milvus::proto::common::Status*) { return rpc_status; });
+            break;
+        case AliasMutation::DROP:
+            EXPECT_CALL(service, DropAlias(_, Property(&milvus::proto::milvus::DropAliasRequest::alias, alias), _))
+                .WillOnce([rpc_status](::grpc::ServerContext*, const milvus::proto::milvus::DropAliasRequest*,
+                                       milvus::proto::common::Status*) { return rpc_status; });
+            break;
+    }
+}
+
+milvus::Status
+RunV2AliasMutation(const std::shared_ptr<milvus::MilvusClientV2>& client, AliasMutation mutation,
+                   const std::string& collection_name, const std::string& alias) {
+    switch (mutation) {
+        case AliasMutation::CREATE:
+            return client->CreateAlias(
+                milvus::CreateAliasRequest().WithCollectionName(collection_name).WithAlias(alias));
+        case AliasMutation::ALTER:
+            return client->AlterAlias(milvus::AlterAliasRequest().WithCollectionName(collection_name).WithAlias(alias));
+        case AliasMutation::DROP:
+            return client->DropAlias(milvus::DropAliasRequest().WithAlias(alias));
+    }
+    return {milvus::StatusCode::UNKNOWN_ERROR, "Unknown alias mutation"};
+}
+
+class V2AliasCacheTest : public UnconnectMilvusMockedTest, public testing::WithParamInterface<AliasMutation> {};
+
+TEST_P(V2AliasCacheTest, SuccessfulMutationInvalidatesCollectionDescCache) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    const std::string alias = "active_collection";
+    const std::string target = "new_collection";
+
+    InSequence sequence;
+    EXPECT_CALL(
+        service_,
+        DescribeCollection(_, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, alias), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetCollectionID(response, 100);
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_,
+                ManualCompaction(_, Property(&milvus::proto::milvus::ManualCompactionRequest::collectionid, 100), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+    ExpectV2AliasMutation(service_, GetParam(), target, alias);
+    EXPECT_CALL(
+        service_,
+        DescribeCollection(_, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, alias), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetCollectionID(response, 200);
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_,
+                ManualCompaction(_, Property(&milvus::proto::milvus::ManualCompactionRequest::collectionid, 200), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+
+    milvus::CompactResponse response;
+    auto status = client->Compact(milvus::CompactRequest().WithCollectionName(alias), response);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = RunV2AliasMutation(client, GetParam(), target, alias);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = client->Compact(milvus::CompactRequest().WithCollectionName(alias), response);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+INSTANTIATE_TEST_SUITE_P(AllAliasMutations, V2AliasCacheTest,
+                         testing::Values(AliasMutation::CREATE, AliasMutation::ALTER, AliasMutation::DROP));
+
+class V2AmbiguousAliasCacheTest : public UnconnectMilvusMockedTest,
+                                  public testing::WithParamInterface<std::tuple<AliasMutation, ::grpc::StatusCode>> {};
+
+TEST_P(V2AmbiguousAliasCacheTest, MutationInvalidatesCollectionDescCache) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    const std::string alias = "active_collection";
+    const auto mutation = std::get<0>(GetParam());
+    const auto rpc_code = std::get<1>(GetParam());
+
+    InSequence sequence;
+    EXPECT_CALL(service_, DescribeCollection(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetCollectionID(response, 100);
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_, ManualCompaction(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+    ExpectV2AliasMutation(service_, mutation, "new_collection", alias,
+                          ::grpc::Status{rpc_code, "ambiguous transport failure"});
+    EXPECT_CALL(service_, DescribeCollection(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetCollectionID(response, 200);
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_, ManualCompaction(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+
+    milvus::CompactResponse response;
+    auto status = client->Compact(milvus::CompactRequest().WithCollectionName(alias), response);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = RunV2AliasMutation(client, mutation, "new_collection", alias);
+    ASSERT_FALSE(status.IsOk());
+    EXPECT_EQ(rpc_code == ::grpc::StatusCode::DEADLINE_EXCEEDED ? milvus::StatusCode::TIMEOUT
+                                                                : milvus::StatusCode::RPC_FAILED,
+              status.Code());
+    status = client->Compact(milvus::CompactRequest().WithCollectionName(alias), response);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+INSTANTIATE_TEST_SUITE_P(AllAliasMutationsAndTransportFailures, V2AmbiguousAliasCacheTest,
+                         Combine(Values(AliasMutation::CREATE, AliasMutation::ALTER, AliasMutation::DROP),
+                                 Values(::grpc::StatusCode::UNKNOWN, ::grpc::StatusCode::DEADLINE_EXCEEDED)));
+
+TEST_F(UnconnectMilvusMockedTest, RejectedV2AliasMutationKeepsCollectionDescCache) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    const std::string alias = "active_collection";
+
+    InSequence sequence;
+    EXPECT_CALL(service_, DescribeCollection(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetCollectionID(response, 100);
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_, ManualCompaction(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+    EXPECT_CALL(service_, AlterAlias(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::AlterAliasRequest*,
+                     milvus::proto::common::Status* response) {
+            response->set_code(1);
+            response->set_reason("alter rejected");
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_, ManualCompaction(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+
+    milvus::CompactResponse response;
+    auto status = client->Compact(milvus::CompactRequest().WithCollectionName(alias), response);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = client->AlterAlias(milvus::AlterAliasRequest().WithCollectionName("new_collection").WithAlias(alias));
+    ASSERT_FALSE(status.IsOk());
+    EXPECT_EQ(milvus::StatusCode::SERVER_FAILED, status.Code());
+    status = client->Compact(milvus::CompactRequest().WithCollectionName(alias), response);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+TEST_F(UnconnectMilvusMockedTest, RateLimitRetryTimeoutKeepsCollectionDescCache) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    milvus::RetryParam retry_param;
+    auto status = client->SetRetryParam(retry_param.WithMaxRetryTimes(2).WithInitialBackOffMs(1).WithMaxBackOffMs(1));
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    const std::string alias = "active_collection";
+
+    InSequence sequence;
+    EXPECT_CALL(service_, DescribeCollection(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetCollectionID(response, 100);
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_, ManualCompaction(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+    EXPECT_CALL(service_, AlterAlias(_, _, _))
+        .Times(2)
+        .WillRepeatedly([](::grpc::ServerContext*, const milvus::proto::milvus::AlterAliasRequest*,
+                           milvus::proto::common::Status* response) {
+            response->set_code(8);
+            response->set_reason("rate limited");
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_, ManualCompaction(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+
+    milvus::CompactResponse response;
+    status = client->Compact(milvus::CompactRequest().WithCollectionName(alias), response);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+    status = client->AlterAlias(milvus::AlterAliasRequest().WithCollectionName("new_collection").WithAlias(alias));
+    ASSERT_FALSE(status.IsOk());
+    EXPECT_EQ(milvus::StatusCode::TIMEOUT, status.Code());
+    EXPECT_EQ(0, status.RpcErrCode());
+    EXPECT_EQ(8, status.ServerCode());
+    status = client->Compact(milvus::CompactRequest().WithCollectionName(alias), response);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+TEST_F(UnconnectMilvusMockedTest, RenameAndRecreateInvalidatesCollectionDescCache) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+    const std::string old_name = "old_collection";
+    const std::string new_name = "new_collection";
+
+    InSequence sequence;
+    EXPECT_CALL(service_,
+                DescribeCollection(
+                    _, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, old_name), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetCollectionID(response, 100);
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_,
+                ManualCompaction(_, Property(&milvus::proto::milvus::ManualCompactionRequest::collectionid, 100), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+    EXPECT_CALL(service_,
+                RenameCollection(_,
+                                 AllOf(Property(&milvus::proto::milvus::RenameCollectionRequest::oldname, old_name),
+                                       Property(&milvus::proto::milvus::RenameCollectionRequest::newname, new_name)),
+                                 _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::RenameCollectionRequest*,
+                     milvus::proto::common::Status*) { return ::grpc::Status{}; });
+    EXPECT_CALL(service_,
+                DescribeCollection(
+                    _, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, old_name), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse*) {
+            return ::grpc::Status{::grpc::StatusCode::NOT_FOUND, "collection not found"};
+        });
+    EXPECT_CALL(
+        service_,
+        CreateCollection(_, Property(&milvus::proto::milvus::CreateCollectionRequest::collection_name, old_name), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::CreateCollectionRequest*,
+                     milvus::proto::common::Status*) { return ::grpc::Status{}; });
+    EXPECT_CALL(service_,
+                DescribeCollection(
+                    _, Property(&milvus::proto::milvus::DescribeCollectionRequest::collection_name, old_name), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::DescribeCollectionRequest*,
+                     milvus::proto::milvus::DescribeCollectionResponse* response) {
+            SetCollectionID(response, 200);
+            return ::grpc::Status{};
+        });
+    EXPECT_CALL(service_,
+                ManualCompaction(_, Property(&milvus::proto::milvus::ManualCompactionRequest::collectionid, 200), _))
+        .WillOnce([](::grpc::ServerContext*, const milvus::proto::milvus::ManualCompactionRequest*,
+                     milvus::proto::milvus::ManualCompactionResponse*) { return ::grpc::Status{}; });
+
+    milvus::CompactResponse compact_response;
+    auto status = client->Compact(milvus::CompactRequest().WithCollectionName(old_name), compact_response);
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+
+    status = client->RenameCollection(
+        milvus::RenameCollectionRequest().WithCollectionName(old_name).WithNewCollectionName(new_name));
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+
+    status = client->Compact(milvus::CompactRequest().WithCollectionName(old_name), compact_response);
+    ASSERT_FALSE(status.IsOk());
+
+    auto schema = std::make_shared<milvus::CollectionSchema>();
+    schema->AddField(milvus::FieldSchema("id", milvus::DataType::INT64, "", true));
+    status = client->CreateCollection(
+        milvus::CreateCollectionRequest().WithCollectionName(old_name).WithCollectionSchema(std::move(schema)));
+    ASSERT_TRUE(status.IsOk()) << status.Message();
+
+    status = client->Compact(milvus::CompactRequest().WithCollectionName(old_name), compact_response);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+}
+
+}  // namespace

--- a/test/st/cases/TestAlias.cpp
+++ b/test/st/cases/TestAlias.cpp
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+
 #include "MilvusServerTest.h"
 
 using milvus::test::MilvusServerTest;
@@ -102,5 +104,65 @@ TEST_F(MilvusServerTestAlias, AlterAlias) {
 
     // cleanup
     client_->DropAlias(milvus::DropAliasRequest().WithAlias(alias_name));
+    client_->DropCollection(milvus::DropCollectionRequest().WithCollectionName(collection_name2));
+}
+
+TEST_F(MilvusServerTestAlias, DescribeCollectionAfterAliasSwitchAndDrop) {
+    const std::string alias_name = milvus::test::RanName("alias_");
+    const std::string collection_name2 = milvus::test::RanName("AliasTest2_");
+
+    auto schema2 = std::make_shared<milvus::CollectionSchema>(collection_name2, "second collection");
+    schema2->AddField(milvus::FieldSchema("key", milvus::DataType::VARCHAR, "key", true).WithMaxLength(64));
+    schema2->AddField(milvus::FieldSchema("embedding", milvus::DataType::FLOAT_VECTOR, "vector").WithDimension(8));
+    auto status = client_->CreateCollection(
+        milvus::CreateCollectionRequest().WithCollectionName(collection_name2).WithCollectionSchema(schema2));
+    milvus::test::ExpectStatusOK(status);
+
+    status =
+        client_->CreateAlias(milvus::CreateAliasRequest().WithCollectionName(collection_name).WithAlias(alias_name));
+    milvus::test::ExpectStatusOK(status);
+
+    milvus::DescribeCollectionResponse first_desc;
+    status =
+        client_->DescribeCollection(milvus::DescribeCollectionRequest().WithCollectionName(alias_name), first_desc);
+    milvus::test::ExpectStatusOK(status);
+    EXPECT_EQ(collection_name, first_desc.Desc().CollectionName());
+    EXPECT_EQ("id", first_desc.Desc().Schema().PrimaryFieldName());
+    const auto& first_schema = first_desc.Desc().Schema();
+    const auto first_pk = std::find_if(first_schema.Fields().begin(), first_schema.Fields().end(),
+                                       [&first_schema](const auto& field) {
+                                           return field.Name() == first_schema.PrimaryFieldName();
+                                       });
+    ASSERT_NE(first_schema.Fields().end(), first_pk);
+    EXPECT_EQ(milvus::DataType::INT64, first_pk->FieldDataType());
+
+    status =
+        client_->AlterAlias(milvus::AlterAliasRequest().WithCollectionName(collection_name2).WithAlias(alias_name));
+    milvus::test::ExpectStatusOK(status);
+
+    milvus::DescribeCollectionResponse second_desc;
+    status =
+        client_->DescribeCollection(milvus::DescribeCollectionRequest().WithCollectionName(alias_name), second_desc);
+    milvus::test::ExpectStatusOK(status);
+    EXPECT_EQ(collection_name2, second_desc.Desc().CollectionName());
+    EXPECT_EQ("second collection", second_desc.Desc().Description());
+    EXPECT_EQ("key", second_desc.Desc().Schema().PrimaryFieldName());
+    const auto& second_schema = second_desc.Desc().Schema();
+    const auto second_pk = std::find_if(second_schema.Fields().begin(), second_schema.Fields().end(),
+                                        [&second_schema](const auto& field) {
+                                            return field.Name() == second_schema.PrimaryFieldName();
+                                        });
+    ASSERT_NE(second_schema.Fields().end(), second_pk);
+    EXPECT_EQ(milvus::DataType::VARCHAR, second_pk->FieldDataType());
+    EXPECT_NE(first_desc.Desc().ID(), second_desc.Desc().ID());
+
+    status = client_->DropAlias(milvus::DropAliasRequest().WithAlias(alias_name));
+    milvus::test::ExpectStatusOK(status);
+
+    milvus::DescribeCollectionResponse dropped_alias_desc;
+    status = client_->DescribeCollection(milvus::DescribeCollectionRequest().WithCollectionName(alias_name),
+                                         dropped_alias_desc);
+    EXPECT_FALSE(status.IsOk());
+
     client_->DropCollection(milvus::DropCollectionRequest().WithCollectionName(collection_name2));
 }


### PR DESCRIPTION
create_alias/alter_alias/drop_alias never touch collection_desc_cache, which getCollectionDesc keys by the caller-supplied name — an alias when the user passes one. After repointing an alias, getCollectionDesc resolve the primary key from the stale cached schema, so if the new target has a different PK/schema they build wrong requests against it; insert/upsert self-heal via the schema-timestamp mismatch retry and query() never consults the cache, the cache also never auto-expires. Evict the (db, alias) cache entry on every alias mutation.