### PR TITLE
feat: add client telemetry support

### DIFF
--- a/src/impl/ClientRequestContext.cpp
+++ b/src/impl/ClientRequestContext.cpp
@@ -1,0 +1,61 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#include "milvus/ClientRequestContext.h"
+
+#include <iomanip>
+#include <random>
+#include <sstream>
+
+namespace milvus {
+namespace {
+thread_local std::string request_id;
+}
+
+void
+ClientRequestContext::Set(const std::string& value) {
+    request_id = value;
+}
+
+const std::string&
+ClientRequestContext::Get() {
+    return request_id;
+}
+
+void
+ClientRequestContext::Clear() {
+    request_id.clear();
+}
+
+std::string
+ClientRequestContext::NewRequestId() {
+    std::random_device device;
+    std::mt19937_64 generator(device());
+    std::uniform_int_distribution<uint64_t> distribution;
+    uint64_t high = 0;
+    uint64_t low = 0;
+    do {
+        high = distribution(generator);
+        low = distribution(generator);
+    } while (high == 0 && low == 0);
+    std::ostringstream stream;
+    stream << std::hex << std::setfill('0') << std::setw(16) << high << std::setw(16) << low;
+    return stream.str();
+}
+
+ScopedClientRequestId::ScopedClientRequestId(const std::string& value) : previous_(ClientRequestContext::Get()) {
+    ClientRequestContext::Set(value);
+}
+
+ScopedClientRequestId::~ScopedClientRequestId() {
+    ClientRequestContext::Set(previous_);
+}
+
+}  // namespace milvus

--- a/src/impl/ClientRequestContext.cpp
+++ b/src/impl/ClientRequestContext.cpp
@@ -10,6 +10,7 @@
 
 #include "milvus/ClientRequestContext.h"
 
+#include <algorithm>
 #include <iomanip>
 #include <random>
 #include <sstream>
@@ -48,6 +49,14 @@ ClientRequestContext::NewRequestId() {
     std::ostringstream stream;
     stream << std::hex << std::setfill('0') << std::setw(16) << high << std::setw(16) << low;
     return stream.str();
+}
+
+bool
+ClientRequestContext::IsValid(const std::string& value) {
+    return value.size() == 32 && value != std::string(32, '0') &&
+           std::all_of(value.begin(), value.end(), [](char character) {
+               return (character >= '0' && character <= '9') || (character >= 'a' && character <= 'f');
+           });
 }
 
 ScopedClientRequestId::ScopedClientRequestId(const std::string& value) : previous_(ClientRequestContext::Get()) {

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -1,0 +1,966 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#include "milvus/ClientTelemetry.h"
+
+#include <grpcpp/client_context.h>
+#include <grpcpp/channel.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cctype>
+#include <cmath>
+#include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <deque>
+#include <iomanip>
+#include <limits>
+#include <map>
+#include <mutex>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <unordered_set>
+#include <utility>
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+#include <milvus/thirdparty/nlohmann/json.hpp>
+
+#include "common.pb.h"
+#include "milvus.grpc.pb.h"
+#include "milvus.pb.h"
+
+namespace milvus {
+namespace {
+
+constexpr size_t kSampleBufferSize = 1000;
+constexpr size_t kSnapshotLimit = 120;
+constexpr uint64_t kSamplingDenominator = 10000;
+constexpr size_t kMaxReplyBytes = 1024 * 1024;
+constexpr uint64_t kMaxUnsupportedBackoffMs = 30 * 60 * 1000;
+
+int64_t
+NowMillis() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+std::string
+RandomUuid() {
+    std::random_device device;
+    std::mt19937_64 generator(device());
+    std::uniform_int_distribution<uint64_t> distribution;
+    auto high = distribution(generator);
+    auto low = distribution(generator);
+    std::ostringstream stream;
+    stream << std::hex << std::setfill('0') << std::setw(8) << static_cast<uint32_t>(high >> 32) << "-"
+           << std::setw(4) << static_cast<uint16_t>(high >> 16) << "-" << std::setw(4)
+           << static_cast<uint16_t>(high) << "-" << std::setw(4) << static_cast<uint16_t>(low >> 48) << "-"
+           << std::setw(12) << (low & 0x0000FFFFFFFFFFFFULL);
+    return stream.str();
+}
+
+std::string
+LocalTimeString() {
+    auto now = std::chrono::system_clock::now();
+    auto value = std::chrono::system_clock::to_time_t(now);
+    std::tm time{};
+#ifdef _WIN32
+    gmtime_s(&time, &value);
+#else
+    gmtime_r(&value, &time);
+#endif
+    std::ostringstream stream;
+    stream << std::put_time(&time, "%Y-%m-%dT%H:%M:%SZ");
+    return stream.str();
+}
+
+std::string
+HostName() {
+    const char* value = std::getenv("HOSTNAME");
+    return value == nullptr ? "Unknown" : value;
+}
+
+std::string
+CollectionName(const google::protobuf::Message& request) {
+    const auto* field = request.GetDescriptor()->FindFieldByName("collection_name");
+    if (field == nullptr || field->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_STRING) {
+        return "";
+    }
+    return request.GetReflection()->GetString(request, field);
+}
+
+uint32_t
+RotateRight(uint32_t value, uint32_t count) {
+    return (value >> count) | (value << (32 - count));
+}
+
+// Small self-contained SHA-256 implementation keeps the SDK independent from a specific TLS provider.
+class Sha256 {
+ public:
+    Sha256()
+        : state_{0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19} {
+    }
+
+    void
+    Update(const std::string& value) {
+        Update(reinterpret_cast<const uint8_t*>(value.data()), value.size());
+    }
+
+    std::string
+    Finish() {
+        uint64_t bit_length = total_size_ * 8;
+        buffer_[buffer_size_++] = 0x80;
+        if (buffer_size_ > 56) {
+            while (buffer_size_ < 64) {
+                buffer_[buffer_size_++] = 0;
+            }
+            Transform(buffer_.data());
+            buffer_size_ = 0;
+        }
+        while (buffer_size_ < 56) {
+            buffer_[buffer_size_++] = 0;
+        }
+        for (int index = 7; index >= 0; --index) {
+            buffer_[buffer_size_++] = static_cast<uint8_t>(bit_length >> (index * 8));
+        }
+        Transform(buffer_.data());
+
+        std::ostringstream stream;
+        stream << std::hex << std::setfill('0');
+        for (auto value : state_) {
+            stream << std::setw(8) << value;
+        }
+        return stream.str();
+    }
+
+ private:
+    void
+    Update(const uint8_t* data, size_t size) {
+        total_size_ += size;
+        for (size_t index = 0; index < size; ++index) {
+            buffer_[buffer_size_++] = data[index];
+            if (buffer_size_ == 64) {
+                Transform(buffer_.data());
+                buffer_size_ = 0;
+            }
+        }
+    }
+
+    void
+    Transform(const uint8_t* block) {
+        static const uint32_t constants[64] = {
+            0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+            0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+            0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+            0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+            0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+            0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+            0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+            0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+            0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+            0xc67178f2};
+        uint32_t schedule[64];
+        for (size_t index = 0; index < 16; ++index) {
+            schedule[index] = (static_cast<uint32_t>(block[index * 4]) << 24) |
+                              (static_cast<uint32_t>(block[index * 4 + 1]) << 16) |
+                              (static_cast<uint32_t>(block[index * 4 + 2]) << 8) |
+                              static_cast<uint32_t>(block[index * 4 + 3]);
+        }
+        for (size_t index = 16; index < 64; ++index) {
+            uint32_t first = RotateRight(schedule[index - 15], 7) ^ RotateRight(schedule[index - 15], 18) ^
+                             (schedule[index - 15] >> 3);
+            uint32_t second = RotateRight(schedule[index - 2], 17) ^ RotateRight(schedule[index - 2], 19) ^
+                              (schedule[index - 2] >> 10);
+            schedule[index] = schedule[index - 16] + first + schedule[index - 7] + second;
+        }
+        uint32_t a = state_[0], b = state_[1], c = state_[2], d = state_[3];
+        uint32_t e = state_[4], f = state_[5], g = state_[6], h = state_[7];
+        for (size_t index = 0; index < 64; ++index) {
+            uint32_t sum1 = RotateRight(e, 6) ^ RotateRight(e, 11) ^ RotateRight(e, 25);
+            uint32_t choice = (e & f) ^ ((~e) & g);
+            uint32_t temp1 = h + sum1 + choice + constants[index] + schedule[index];
+            uint32_t sum0 = RotateRight(a, 2) ^ RotateRight(a, 13) ^ RotateRight(a, 22);
+            uint32_t majority = (a & b) ^ (a & c) ^ (b & c);
+            uint32_t temp2 = sum0 + majority;
+            h = g;
+            g = f;
+            f = e;
+            e = d + temp1;
+            d = c;
+            c = b;
+            b = a;
+            a = temp1 + temp2;
+        }
+        state_[0] += a;
+        state_[1] += b;
+        state_[2] += c;
+        state_[3] += d;
+        state_[4] += e;
+        state_[5] += f;
+        state_[6] += g;
+        state_[7] += h;
+    }
+
+    std::array<uint32_t, 8> state_;
+    std::array<uint8_t, 64> buffer_{};
+    size_t buffer_size_{0};
+    uint64_t total_size_{0};
+};
+
+int64_t
+Timegm(std::tm* value) {
+#ifdef _WIN32
+    return static_cast<int64_t>(_mkgmtime(value));
+#else
+    return static_cast<int64_t>(timegm(value));
+#endif
+}
+
+int64_t
+ParseRfc3339Millis(const std::string& value) {
+    if (value.size() < 19) {
+        throw std::invalid_argument("invalid RFC3339 timestamp");
+    }
+    std::tm time{};
+    std::istringstream stream(value.substr(0, 19));
+    stream >> std::get_time(&time, "%Y-%m-%dT%H:%M:%S");
+    if (stream.fail()) {
+        throw std::invalid_argument("invalid RFC3339 timestamp");
+    }
+    size_t position = 19;
+    int64_t milliseconds = 0;
+    if (position < value.size() && value[position] == '.') {
+        size_t end = position + 1;
+        while (end < value.size() && std::isdigit(static_cast<unsigned char>(value[end]))) {
+            ++end;
+        }
+        auto fraction = value.substr(position + 1, end - position - 1);
+        while (fraction.size() < 3) {
+            fraction.push_back('0');
+        }
+        milliseconds = std::stoll(fraction.substr(0, 3));
+        position = end;
+    }
+    int offset_seconds = 0;
+    if (position < value.size() && value[position] != 'Z') {
+        if (position + 5 >= value.size() || (value[position] != '+' && value[position] != '-')) {
+            throw std::invalid_argument("invalid RFC3339 timezone");
+        }
+        int sign = value[position] == '+' ? 1 : -1;
+        int hours = std::stoi(value.substr(position + 1, 2));
+        int minutes = std::stoi(value.substr(position + 4, 2));
+        offset_seconds = sign * (hours * 3600 + minutes * 60);
+    }
+    return (Timegm(&time) - offset_seconds) * 1000 + milliseconds;
+}
+
+struct MetricBucket {
+    int64_t requests{0};
+    int64_t successes{0};
+    int64_t errors{0};
+    double total_latency_ms{0};
+    double max_latency_ms{0};
+    std::deque<double> samples;
+
+    void
+    Record(double latency_ms, bool success) {
+        ++requests;
+        success ? ++successes : ++errors;
+        total_latency_ms += latency_ms;
+        max_latency_ms = std::max(max_latency_ms, latency_ms);
+        samples.push_back(latency_ms);
+        if (samples.size() > kSampleBufferSize) {
+            samples.pop_front();
+        }
+    }
+
+    TelemetryMetric
+    Snapshot() const {
+        std::vector<double> sorted(samples.begin(), samples.end());
+        std::sort(sorted.begin(), sorted.end());
+        auto index = sorted.empty() ? 0 : std::min(sorted.size() - 1, static_cast<size_t>(sorted.size() * 0.99));
+        return {requests,
+                successes,
+                errors,
+                requests == 0 ? 0 : total_latency_ms / requests,
+                sorted.empty() ? 0 : sorted[index],
+                max_latency_ms};
+    }
+};
+
+struct OperationCollector {
+    MetricBucket global;
+    std::unordered_map<std::string, MetricBucket> collections;
+};
+
+proto::common::Metrics
+ToProtoMetric(const TelemetryMetric& metric) {
+    proto::common::Metrics result;
+    result.set_request_count(metric.request_count);
+    result.set_success_count(metric.success_count);
+    result.set_error_count(metric.error_count);
+    result.set_avg_latency_ms(metric.avg_latency_ms);
+    result.set_p99_latency_ms(metric.p99_latency_ms);
+    result.set_max_latency_ms(metric.max_latency_ms);
+    return result;
+}
+
+nlohmann::json
+MetricJson(const TelemetryMetric& metric) {
+    return {{"request_count", metric.request_count},
+            {"success_count", metric.success_count},
+            {"error_count", metric.error_count},
+            {"avg_latency_ms", metric.avg_latency_ms},
+            {"p99_latency_ms", metric.p99_latency_ms},
+            {"max_latency_ms", metric.max_latency_ms}};
+}
+
+TelemetryCommandReply
+SuccessReply(const std::string& command_id, std::string payload = "") {
+    return {command_id, true, "", std::move(payload)};
+}
+
+TelemetryCommandReply
+FailedReply(const std::string& command_id, const std::string& error) {
+    return {command_id, false, error, ""};
+}
+
+}  // namespace
+
+class ClientTelemetryManager::Impl {
+ public:
+    Impl(const TelemetryConfig& value, const std::string& runtime_client_id)
+        : config(value),
+          stable_client_id(!value.client_id.empty()),
+          client_id(stable_client_id ? value.client_id
+                                     : (runtime_client_id.empty() ? RandomUuid() : runtime_client_id)) {
+        if (config.heartbeat_interval_ms == 0) {
+            config.heartbeat_interval_ms = 30000;
+        }
+        config.sampling_rate = std::max(0.0, std::min(1.0, config.sampling_rate));
+        if (config.error_max_count == 0) {
+            config.error_max_count = 100;
+        }
+        RegisterDefaultHandlers();
+    }
+
+    ~Impl() {
+        Stop();
+    }
+
+    void
+    AttachChannel(const std::shared_ptr<grpc::Channel>& channel, const std::string& user, const std::string& db,
+                  const std::string& endpoint, const std::string& version) {
+        std::lock_guard<std::mutex> lock(mutex);
+        stub = proto::milvus::ClientTelemetryService::NewStub(channel);
+        username = user;
+        database = db;
+        uri = endpoint;
+        sdk_version = version;
+    }
+
+    void
+    Start() {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (ready) {
+            return;
+        }
+        ready = true;
+        if (!config.enabled) {
+            return;
+        }
+        stopped = false;
+        worker = std::thread([this]() { HeartbeatLoop(); });
+    }
+
+    void
+    Stop() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (stopped) {
+                return;
+            }
+            stopped = true;
+            condition.notify_all();
+        }
+        if (worker.joinable() && worker.get_id() != std::this_thread::get_id()) {
+            worker.join();
+        }
+    }
+
+    void
+    HeartbeatLoop() {
+        while (true) {
+            CreateSnapshot();
+            SendHeartbeat();
+            std::unique_lock<std::mutex> lock(mutex);
+            if (stopped) {
+                return;
+            }
+            uint64_t delay = config.heartbeat_interval_ms;
+            if (unsupported_streak > 0) {
+                auto exponent = std::min(unsupported_streak, 20);
+                delay = std::min(kMaxUnsupportedBackoffMs, delay * (uint64_t{1} << exponent));
+            }
+            condition.wait_for(lock, std::chrono::milliseconds(delay), [this]() { return stopped; });
+            if (stopped) {
+                return;
+            }
+        }
+    }
+
+    void
+    CreateSnapshot() {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (!config.enabled) {
+            return;
+        }
+        TelemetrySnapshot snapshot;
+        snapshot.end_time = NowMillis();
+        snapshot.timestamp = last_snapshot_end == 0 ? snapshot.end_time - config.heartbeat_interval_ms : last_snapshot_end;
+        last_snapshot_end = snapshot.end_time;
+        for (auto& entry : collectors) {
+            if (entry.second.global.requests == 0) {
+                continue;
+            }
+            TelemetryOperationMetrics operation;
+            operation.operation = entry.first;
+            operation.global = entry.second.global.Snapshot();
+            for (const auto& collection : entry.second.collections) {
+                operation.collection_metrics.emplace(collection.first, collection.second.Snapshot());
+            }
+            snapshot.metrics.emplace_back(std::move(operation));
+            entry.second = OperationCollector{};
+        }
+        snapshots.push_back(std::move(snapshot));
+        while (snapshots.size() > kSnapshotLimit) {
+            snapshots.pop_front();
+        }
+    }
+
+    void
+    SendHeartbeat() {
+        proto::milvus::ClientHeartbeatRequest request;
+        std::unique_ptr<proto::milvus::ClientTelemetryService::Stub>* stub_pointer = nullptr;
+        size_t reply_count = 0;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (!config.enabled || stub == nullptr) {
+                return;
+            }
+            auto* info = request.mutable_client_info();
+            info->set_sdk_type("CPP");
+            info->set_sdk_version(sdk_version);
+            info->set_local_time(LocalTimeString());
+            info->set_user(username);
+            info->set_host(HostName());
+            (*info->mutable_reserved())["client_id"] = client_id;
+            (*info->mutable_reserved())["client_id_stable"] = stable_client_id ? "true" : "false";
+            if (!database.empty()) {
+                (*info->mutable_reserved())["db_name"] = database;
+            }
+            request.set_report_timestamp(NowMillis());
+            if (!snapshots.empty()) {
+                for (const auto& operation : snapshots.back().metrics) {
+                    auto* output = request.add_metrics();
+                    output->set_operation(operation.operation);
+                    *output->mutable_global() = ToProtoMetric(operation.global);
+                    for (const auto& collection : operation.collection_metrics) {
+                        (*output->mutable_collection_metrics())[collection.first] = ToProtoMetric(collection.second);
+                    }
+                }
+            }
+            for (const auto& reply : pending_replies) {
+                auto* output = request.add_command_replies();
+                output->set_command_id(reply.command_id);
+                output->set_success(reply.success);
+                output->set_error_message(reply.error_message);
+                output->set_payload(reply.payload);
+            }
+            reply_count = pending_replies.size();
+            request.set_config_hash(config_hash);
+            request.set_last_command_timestamp(last_command_timestamp);
+            stub_pointer = &stub;
+        }
+
+        grpc::ClientContext context;
+        context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(10));
+        proto::milvus::ClientHeartbeatResponse response;
+        auto grpc_status = (*stub_pointer)->ClientHeartbeat(&context, request, &response);
+        if (!grpc_status.ok()) {
+            std::lock_guard<std::mutex> lock(mutex);
+            last_heartbeat_error = grpc_status.error_message();
+            if (grpc_status.error_code() == grpc::StatusCode::UNIMPLEMENTED) {
+                ++unsupported_streak;
+            }
+            return;
+        }
+        if (response.status().code() != 0 || response.status().error_code() != proto::common::ErrorCode::Success) {
+            std::lock_guard<std::mutex> lock(mutex);
+            last_heartbeat_error = response.status().reason();
+            return;
+        }
+        std::vector<TelemetryCommand> commands;
+        commands.reserve(response.commands_size());
+        for (const auto& command : response.commands()) {
+            commands.push_back({command.command_id(), command.command_type(), command.payload(), command.create_time(),
+                                command.persistent(), command.target_scope()});
+        }
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            pending_replies.erase(pending_replies.begin(),
+                                  pending_replies.begin() + std::min(reply_count, pending_replies.size()));
+            unsupported_streak = 0;
+            last_heartbeat_error.clear();
+        }
+        ProcessCommands(commands);
+    }
+
+    TelemetryCommandReply
+    HandleCommand(const TelemetryCommand& command) {
+        CommandHandler handler;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            auto iterator = handlers.find(command.command_type);
+            if (iterator == handlers.end()) {
+                return FailedReply(command.command_id, "unknown command type: " + command.command_type);
+            }
+            handler = iterator->second;
+        }
+        try {
+            return handler(command);
+        } catch (const std::exception& exception) {
+            return FailedReply(command.command_id, exception.what());
+        }
+    }
+
+    void
+    ProcessCommands(const std::vector<TelemetryCommand>& commands) {
+        int64_t previous_timestamp;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            previous_timestamp = last_command_timestamp;
+        }
+        int64_t max_timestamp = previous_timestamp;
+        bool has_persistent = false;
+        for (const auto& command : commands) {
+            max_timestamp = std::max(max_timestamp, command.create_time);
+            has_persistent = has_persistent || command.persistent;
+            bool skip = false;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                skip = command.create_time < previous_timestamp || executed_commands.count(command.command_id) > 0;
+                if (skip) {
+                    pending_replies.push_back(SuccessReply(command.command_id));
+                }
+            }
+            if (skip) {
+                continue;
+            }
+            auto reply = HandleCommand(command);
+            std::lock_guard<std::mutex> lock(mutex);
+            executed_commands[command.command_id] = command.create_time;
+            pending_replies.push_back(std::move(reply));
+        }
+        std::lock_guard<std::mutex> lock(mutex);
+        for (auto iterator = executed_commands.begin(); iterator != executed_commands.end();) {
+            if (iterator->second <= previous_timestamp) {
+                iterator = executed_commands.erase(iterator);
+            } else {
+                ++iterator;
+            }
+        }
+        if (has_persistent) {
+            config_hash = ClientTelemetryManager::CalculateConfigHash(commands);
+        }
+        last_command_timestamp = std::max(last_command_timestamp, max_timestamp);
+    }
+
+    void
+    RegisterDefaultHandlers() {
+        handlers["push_config"] = [this](const TelemetryCommand& command) {
+            auto payload = command.payload.empty() ? nlohmann::json::object() : nlohmann::json::parse(command.payload);
+            std::lock_guard<std::mutex> lock(mutex);
+            if (payload.count("enabled")) {
+                config.enabled = payload["enabled"].get<bool>();
+            }
+            if (payload.count("heartbeat_interval_ms")) {
+                auto interval = payload["heartbeat_interval_ms"].get<int64_t>();
+                if (interval <= 0) {
+                    throw std::invalid_argument("heartbeat_interval_ms must be positive");
+                }
+                config.heartbeat_interval_ms = static_cast<uint64_t>(interval);
+            }
+            if (payload.count("sampling_rate")) {
+                config.sampling_rate = std::max(0.0, std::min(1.0, payload["sampling_rate"].get<double>()));
+            }
+            condition.notify_all();
+            return SuccessReply(command.command_id);
+        };
+        handlers["collection_metrics"] = [this](const TelemetryCommand& command) {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (command.payload.empty()) {
+                std::vector<std::string> names(enabled_collections.begin(), enabled_collections.end());
+                std::sort(names.begin(), names.end());
+                nlohmann::json result = {{"enabled_collections", names},
+                                         {"all_collections_enabled", all_collections_enabled}};
+                return SuccessReply(command.command_id, result.dump());
+            }
+            auto payload = nlohmann::json::parse(command.payload);
+            bool enabled = payload.value("enabled", false);
+            auto collections = payload.value("collections", std::vector<std::string>{});
+            bool wildcard = std::find(collections.begin(), collections.end(), "*") != collections.end();
+            if (enabled) {
+                if (collections.empty()) {
+                    throw std::invalid_argument("collections list cannot be empty when enabled=true");
+                }
+                if (wildcard) {
+                    all_collections_enabled = true;
+                } else {
+                    enabled_collections.insert(collections.begin(), collections.end());
+                }
+            } else if (wildcard || collections.empty()) {
+                all_collections_enabled = false;
+                enabled_collections.clear();
+            } else {
+                for (const auto& collection : collections) {
+                    enabled_collections.erase(collection);
+                }
+            }
+            return SuccessReply(command.command_id);
+        };
+        handlers["show_errors"] = [this](const TelemetryCommand& command) {
+            auto payload = command.payload.empty() ? nlohmann::json::object() : nlohmann::json::parse(command.payload);
+            auto max_count = payload.value("max_count", static_cast<size_t>(100));
+            std::vector<TelemetryError> values;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                for (auto iterator = errors.rbegin(); iterator != errors.rend() && values.size() < max_count;
+                     ++iterator) {
+                    values.push_back(*iterator);
+                }
+            }
+            nlohmann::json result = nlohmann::json::array();
+            for (const auto& error : values) {
+                result.push_back({{"timestamp", error.timestamp},
+                                  {"operation", error.operation},
+                                  {"error_msg", error.error_message},
+                                  {"collection", error.collection},
+                                  {"request_id", error.request_id}});
+            }
+            while (result.dump().size() > kMaxReplyBytes && result.size() > 1) {
+                result.erase(result.begin() + result.size() / 2, result.end());
+            }
+            auto encoded = result.dump();
+            while (encoded.size() > kMaxReplyBytes && result.size() == 1 &&
+                   result.at(0).value("error_msg", std::string{}).size() > 1) {
+                auto message = result.at(0).at("error_msg").get<std::string>();
+                result.at(0)["error_msg"] = message.substr(0, std::max<size_t>(1, message.size() / 2)) +
+                                               "...(truncated)";
+                encoded = result.dump();
+            }
+            if (encoded.size() > kMaxReplyBytes) {
+                throw std::invalid_argument("show_errors response exceeds the 1MB payload limit");
+            }
+            return SuccessReply(command.command_id, encoded);
+        };
+        handlers["get_config"] = [this](const TelemetryCommand& command) {
+            std::lock_guard<std::mutex> lock(mutex);
+            std::vector<std::string> collections(enabled_collections.begin(), enabled_collections.end());
+            std::sort(collections.begin(), collections.end());
+            nlohmann::json user_config = {{"address", uri},
+                                          {"username", username},
+                                          {"db_name", database},
+                                          {"telemetry_enabled", config.enabled},
+                                          {"telemetry_heartbeat_interval_ms", config.heartbeat_interval_ms},
+                                          {"telemetry_sampling_rate", config.sampling_rate},
+                                          {"enabled_collections",
+                                           all_collections_enabled ? std::vector<std::string>{"*"} : collections},
+                                          {"all_collections_enabled", all_collections_enabled}};
+            return SuccessReply(command.command_id, nlohmann::json{{"user_config", user_config}}.dump());
+        };
+        handlers["show_latency_history"] = [this](const TelemetryCommand& command) {
+            if (command.payload.empty()) {
+                throw std::invalid_argument("payload is required with start_time and end_time");
+            }
+            auto payload = nlohmann::json::parse(command.payload);
+            int64_t start = ParseRfc3339Millis(payload.at("start_time").get<std::string>());
+            int64_t end = ParseRfc3339Millis(payload.at("end_time").get<std::string>());
+            if (end < start) {
+                throw std::invalid_argument("end_time must be after start_time");
+            }
+            if (end - start > 60 * 60 * 1000) {
+                throw std::invalid_argument("time range cannot exceed 1 hour");
+            }
+            std::vector<TelemetrySnapshot> all;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                all.assign(snapshots.begin(), snapshots.end());
+            }
+            std::vector<TelemetrySnapshot> selected;
+            for (const auto& snapshot : all) {
+                if (snapshot.end_time >= start && snapshot.timestamp <= end) {
+                    selected.push_back(snapshot);
+                }
+            }
+            nlohmann::json response;
+            if (payload.value("detail", false)) {
+                response["snapshots"] = nlohmann::json::array();
+                for (const auto& snapshot : selected) {
+                    nlohmann::json metrics;
+                    for (const auto& operation : snapshot.metrics) {
+                        metrics[operation.operation] = MetricJson(operation.global);
+                    }
+                    response["snapshots"].push_back(
+                        {{"timestamp", snapshot.timestamp}, {"end_time", snapshot.end_time}, {"metrics", metrics}});
+                }
+                response["total_snapshots"] = selected.size();
+            } else {
+                struct Total {
+                    int64_t requests{0};
+                    int64_t successes{0};
+                    int64_t errors{0};
+                    double average{0};
+                    double p99{0};
+                    double maximum{0};
+                };
+                std::map<std::string, Total> totals;
+                for (const auto& snapshot : selected) {
+                    for (const auto& operation : snapshot.metrics) {
+                        auto& total = totals[operation.operation];
+                        total.requests += operation.global.request_count;
+                        total.successes += operation.global.success_count;
+                        total.errors += operation.global.error_count;
+                        total.average += operation.global.avg_latency_ms * operation.global.request_count;
+                        total.p99 += operation.global.p99_latency_ms * operation.global.request_count;
+                        total.maximum = std::max(total.maximum, operation.global.max_latency_ms);
+                    }
+                }
+                nlohmann::json metrics;
+                for (const auto& entry : totals) {
+                    metrics[entry.first] = {{"request_count", entry.second.requests},
+                                            {"success_count", entry.second.successes},
+                                            {"error_count", entry.second.errors},
+                                            {"avg_latency_ms", entry.second.requests == 0
+                                                                   ? 0
+                                                                   : entry.second.average / entry.second.requests},
+                                            {"p99_latency_ms", entry.second.requests == 0
+                                                                   ? 0
+                                                                   : entry.second.p99 / entry.second.requests},
+                                            {"max_latency_ms", entry.second.maximum}};
+                }
+                response = {{"aggregated", {{"start_time", start}, {"end_time", end}, {"metrics", metrics}}},
+                            {"snapshot_count", selected.size()}};
+            }
+            auto encoded = response.dump();
+            if (encoded.size() > kMaxReplyBytes) {
+                throw std::invalid_argument("response too large, try a smaller time range");
+            }
+            return SuccessReply(command.command_id, encoded);
+        };
+    }
+
+    mutable std::mutex mutex;
+    std::condition_variable condition;
+    TelemetryConfig config;
+    const bool stable_client_id;
+    const std::string client_id;
+    std::unique_ptr<proto::milvus::ClientTelemetryService::Stub> stub;
+    std::string username;
+    std::string database;
+    std::string uri;
+    std::string sdk_version;
+    std::unordered_map<std::string, OperationCollector> collectors;
+    std::deque<TelemetryError> errors;
+    std::deque<TelemetrySnapshot> snapshots;
+    std::vector<TelemetryCommandReply> pending_replies;
+    std::unordered_map<std::string, int64_t> executed_commands;
+    std::unordered_map<std::string, CommandHandler> handlers;
+    std::unordered_set<std::string> enabled_collections;
+    bool all_collections_enabled{false};
+    bool ready{false};
+    bool stopped{true};
+    int unsupported_streak{0};
+    uint64_t sampling_counter{0};
+    int64_t last_command_timestamp{0};
+    int64_t last_snapshot_end{0};
+    std::string config_hash;
+    std::string last_heartbeat_error;
+    std::thread worker;
+};
+
+ClientTelemetryManager::ClientTelemetryManager(const TelemetryConfig& config, const std::string& runtime_client_id)
+    : impl_(new Impl(config, runtime_client_id)) {
+}
+
+ClientTelemetryManager::~ClientTelemetryManager() = default;
+
+void
+ClientTelemetryManager::AttachChannel(const std::shared_ptr<grpc::Channel>& channel, const std::string& username,
+                                      const std::string& database, const std::string& uri,
+                                      const std::string& sdk_version) {
+    impl_->AttachChannel(channel, username, database, uri, sdk_version);
+}
+
+void
+ClientTelemetryManager::UpdateDatabase(const std::string& database) {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    impl_->database = database;
+}
+
+void
+ClientTelemetryManager::Start() {
+    impl_->Start();
+}
+
+void
+ClientTelemetryManager::Stop() {
+    impl_->Stop();
+}
+
+bool
+ClientTelemetryManager::IsReady() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->ready;
+}
+
+bool
+ClientTelemetryManager::IsSupported() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->unsupported_streak == 0;
+}
+
+const std::string&
+ClientTelemetryManager::ClientId() const {
+    return impl_->client_id;
+}
+
+std::string
+ClientTelemetryManager::ConfigHash() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->config_hash;
+}
+
+int64_t
+ClientTelemetryManager::LastCommandTimestamp() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->last_command_timestamp;
+}
+
+TelemetryConfig
+ClientTelemetryManager::Config() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->config;
+}
+
+std::string
+ClientTelemetryManager::LastHeartbeatError() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->last_heartbeat_error;
+}
+
+void
+ClientTelemetryManager::RegisterCommandHandler(const std::string& command_type, CommandHandler handler) {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    impl_->handlers[command_type] = std::move(handler);
+}
+
+void
+ClientTelemetryManager::RecordOperation(const std::string& operation, const google::protobuf::Message& request,
+                                        std::chrono::steady_clock::time_point started, bool success,
+                                        const std::string& error_message, const std::string& request_id) {
+    static const std::unordered_set<std::string> operations = {"Insert", "Delete", "Upsert", "Search",
+                                                                "HybridSearch", "Query", "RunAnalyzer"};
+    if (operations.count(operation) == 0) {
+        return;
+    }
+    auto latency = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - started).count();
+    auto collection = CollectionName(request);
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    if (!impl_->config.enabled) {
+        return;
+    }
+    auto rate = impl_->config.sampling_rate;
+    bool sampled = rate >= 1.0;
+    if (rate > 0.0 && rate < 1.0) {
+        auto threshold = static_cast<uint64_t>(rate * kSamplingDenominator);
+        sampled = threshold > 0 && ++impl_->sampling_counter % kSamplingDenominator < threshold;
+    }
+    if (!sampled) {
+        return;
+    }
+    bool collection_enabled = impl_->all_collections_enabled || impl_->enabled_collections.count(collection) > 0;
+    auto& collector = impl_->collectors[operation];
+    collector.global.Record(latency, success);
+    if (!collection.empty() && collection_enabled) {
+        collector.collections[collection].Record(latency, success);
+    }
+    if (!success) {
+        impl_->errors.push_back({NowMillis(), operation, error_message, collection, request_id});
+        while (impl_->errors.size() > impl_->config.error_max_count) {
+            impl_->errors.pop_front();
+        }
+    }
+}
+
+std::vector<TelemetryError>
+ClientTelemetryManager::RecentErrors(size_t max_count) const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    std::vector<TelemetryError> result;
+    for (auto iterator = impl_->errors.rbegin(); iterator != impl_->errors.rend() && result.size() < max_count;
+         ++iterator) {
+        result.push_back(*iterator);
+    }
+    return result;
+}
+
+std::vector<TelemetrySnapshot>
+ClientTelemetryManager::MetricsSnapshots() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return {impl_->snapshots.begin(), impl_->snapshots.end()};
+}
+
+void
+ClientTelemetryManager::ProcessCommands(const std::vector<TelemetryCommand>& commands) {
+    impl_->ProcessCommands(commands);
+}
+
+std::string
+ClientTelemetryManager::CalculateConfigHash(const std::vector<TelemetryCommand>& commands) {
+    std::vector<TelemetryCommand> persistent;
+    for (const auto& command : commands) {
+        if (command.persistent) {
+            persistent.push_back(command);
+        }
+    }
+    if (persistent.empty()) {
+        return "";
+    }
+    std::sort(persistent.begin(), persistent.end(),
+              [](const TelemetryCommand& left, const TelemetryCommand& right) {
+                  return left.command_id < right.command_id;
+              });
+    Sha256 hash;
+    for (const auto& command : persistent) {
+        hash.Update(command.command_id);
+        hash.Update(command.command_type);
+        hash.Update(command.payload);
+    }
+    return hash.Finish().substr(0, 16);
+}
+
+}  // namespace milvus

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -380,10 +380,10 @@ class ClientTelemetryManager::Impl {
             return;
         }
         ready = true;
+        stopped = false;
         if (!config.enabled) {
             return;
         }
-        stopped = false;
         worker = std::thread([this]() { HeartbeatLoop(); });
     }
 
@@ -391,7 +391,7 @@ class ClientTelemetryManager::Impl {
     Stop() {
         {
             std::lock_guard<std::mutex> lock(mutex);
-            if (stopped) {
+            if (!ready && stopped) {
                 return;
             }
             stopped = true;
@@ -400,6 +400,8 @@ class ClientTelemetryManager::Impl {
         if (worker.joinable() && worker.get_id() != std::this_thread::get_id()) {
             worker.join();
         }
+        std::lock_guard<std::mutex> lock(mutex);
+        ready = false;
     }
 
     void

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -21,14 +21,11 @@
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
-#include <ctime>
 #include <deque>
-#include <iomanip>
 #include <limits>
 #include <map>
 #include <mutex>
 #include <random>
-#include <sstream>
 #include <stdexcept>
 #include <thread>
 #include <unordered_set>
@@ -254,23 +251,41 @@ class Sha256 {
 };
 
 int64_t
-Timegm(std::tm* value) {
-#ifdef _WIN32
-    return static_cast<int64_t>(_mkgmtime(value));
-#else
-    return static_cast<int64_t>(timegm(value));
-#endif
+DaysFromCivil(int year, unsigned month, unsigned day) {
+    year -= month <= 2;
+    const int era = (year >= 0 ? year : year - 399) / 400;
+    const unsigned year_of_era = static_cast<unsigned>(year - era * 400);
+    const unsigned adjusted_month = month > 2 ? month - 3 : month + 9;
+    const unsigned day_of_year = (153 * adjusted_month + 2) / 5 + day - 1;
+    const unsigned day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    return static_cast<int64_t>(era) * 146097 + static_cast<int64_t>(day_of_era) - 719468;
 }
 
 int64_t
 ParseRfc3339Millis(const std::string& value) {
-    if (value.size() < 19) {
+    if (value.size() < 20 || value[4] != '-' || value[7] != '-' || value[10] != 'T' || value[13] != ':' ||
+        value[16] != ':') {
         throw std::invalid_argument("invalid RFC3339 timestamp");
     }
-    std::tm time{};
-    std::istringstream stream(value.substr(0, 19));
-    stream >> std::get_time(&time, "%Y-%m-%dT%H:%M:%S");
-    if (stream.fail()) {
+    for (size_t index = 0; index < 19; ++index) {
+        if (index == 4 || index == 7 || index == 10 || index == 13 || index == 16) {
+            continue;
+        }
+        if (!std::isdigit(static_cast<unsigned char>(value[index]))) {
+            throw std::invalid_argument("invalid RFC3339 timestamp");
+        }
+    }
+    const int year = std::stoi(value.substr(0, 4));
+    const int month = std::stoi(value.substr(5, 2));
+    const int day = std::stoi(value.substr(8, 2));
+    const int hour = std::stoi(value.substr(11, 2));
+    const int minute = std::stoi(value.substr(14, 2));
+    const int second = std::stoi(value.substr(17, 2));
+    const bool leap_year = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    constexpr std::array<int, 12> kDaysPerMonth = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (month < 1 || month > 12 || day < 1 ||
+        day > kDaysPerMonth[static_cast<size_t>(month - 1)] + (month == 2 && leap_year ? 1 : 0) || hour > 23 ||
+        minute > 59 || second > 59) {
         throw std::invalid_argument("invalid RFC3339 timestamp");
     }
     size_t position = 19;
@@ -318,7 +333,9 @@ ParseRfc3339Millis(const std::string& value) {
     if (position != value.size()) {
         throw std::invalid_argument("invalid RFC3339 timestamp");
     }
-    return (Timegm(&time) - offset_seconds) * 1000 + milliseconds;
+    const auto seconds = DaysFromCivil(year, static_cast<unsigned>(month), static_cast<unsigned>(day)) * 86400 +
+                         hour * 3600 + minute * 60 + second - offset_seconds;
+    return seconds * 1000 + milliseconds;
 }
 
 struct MetricBucket {

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -467,7 +467,12 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                 return;
             }
             ready = true;
-            stopped = !config.enabled;
+            control_plane_activated = control_plane_activated || config.enabled;
+            if (!control_plane_activated) {
+                stopped = true;
+                return;
+            }
+            stopped = false;
             return;
         }
 
@@ -491,10 +496,15 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
         }
         external_stop_requested = false;
         ready = true;
-        stopped = !config.enabled;
-        if (!config.enabled) {
+        // Initial enabled=false is an explicit opt-out and creates no control-plane traffic.
+        // Once activated, keep the control plane sticky across dynamic disable and
+        // Stop/Start reconnects so the server can later re-enable telemetry.
+        control_plane_activated = control_plane_activated || config.enabled;
+        if (!control_plane_activated) {
+            stopped = true;
             return;
         }
+        stopped = false;
         worker_running = true;
         auto self = shared_from_this();
         worker = std::thread([self = std::move(self)]() { self->HeartbeatLoop(); });
@@ -624,7 +634,7 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
         size_t reply_count = 0;
         {
             std::lock_guard<std::mutex> lock(mutex);
-            if (!config.enabled || stub == nullptr) {
+            if (stub == nullptr) {
                 return;
             }
             auto* info = request.mutable_client_info();
@@ -639,13 +649,18 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                 (*info->mutable_reserved())["db_name"] = database;
             }
             request.set_report_timestamp(NowMillis());
-            for (const auto& operation : latest_snapshot.metrics) {
-                auto* output = request.add_metrics();
-                output->set_operation(operation.operation);
-                *output->mutable_global() = ToProtoMetric(operation.global);
-                for (const auto& collection : operation.collection_metrics) {
-                    if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
-                        (*output->mutable_collection_metrics())[collection.first] = ToProtoMetric(collection.second);
+            // Do not resend the final enabled snapshot after collection is disabled. Replies,
+            // config hash, cursor and incoming commands remain active as the control plane.
+            if (config.enabled) {
+                for (const auto& operation : latest_snapshot.metrics) {
+                    auto* output = request.add_metrics();
+                    output->set_operation(operation.operation);
+                    *output->mutable_global() = ToProtoMetric(operation.global);
+                    for (const auto& collection : operation.collection_metrics) {
+                        if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
+                            (*output->mutable_collection_metrics())[collection.first] =
+                                ToProtoMetric(collection.second);
+                        }
                     }
                 }
             }
@@ -1092,6 +1107,7 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
     bool all_collections_enabled{false};
     bool ready{false};
     bool stopped{true};
+    bool control_plane_activated{false};
     bool worker_running{false};
     bool join_in_progress{false};
     bool external_stop_requested{false};

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -422,7 +422,7 @@ FailedReply(const std::string& command_id, const std::string& error) {
 
 }  // namespace
 
-class ClientTelemetryManager::Impl {
+class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientTelemetryManager::Impl> {
  public:
     Impl(const TelemetryConfig& value, const std::string& runtime_client_id)
         : config(NormalizedTelemetryConfig(value)),
@@ -496,7 +496,8 @@ class ClientTelemetryManager::Impl {
             return;
         }
         worker_running = true;
-        worker = std::thread([this]() { HeartbeatLoop(); });
+        auto self = shared_from_this();
+        worker = std::thread([self = std::move(self)]() { self->HeartbeatLoop(); });
         worker_id = worker.get_id();
     }
 
@@ -558,6 +559,13 @@ class ClientTelemetryManager::Impl {
         }
         std::lock_guard<std::mutex> lock(mutex);
         worker_running = false;
+        // If Stop() was called by a command handler, no external thread owns
+        // join(). Detach only after the loop has finished using this object;
+        // the worker's shared_ptr keeps Impl alive until this function returns.
+        if (worker.joinable() && worker.get_id() == std::this_thread::get_id()) {
+            worker.detach();
+            worker_id = {};
+        }
         condition.notify_all();
     }
 
@@ -1102,10 +1110,15 @@ class ClientTelemetryManager::Impl {
 };
 
 ClientTelemetryManager::ClientTelemetryManager(const TelemetryConfig& config, const std::string& runtime_client_id)
-    : impl_(new Impl(config, runtime_client_id)) {
+    : impl_(std::make_shared<Impl>(config, runtime_client_id)) {
 }
 
-ClientTelemetryManager::~ClientTelemetryManager() = default;
+ClientTelemetryManager::~ClientTelemetryManager() {
+    // The worker also owns Impl while it is running. Always request shutdown
+    // before releasing the manager's reference so destruction from inside a
+    // command handler cannot free state that HeartbeatLoop is still using.
+    impl_->Stop();
+}
 
 void
 ClientTelemetryManager::AttachChannel(const std::shared_ptr<grpc::Channel>& channel, const std::string& username,

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -353,7 +353,7 @@ class ClientTelemetryManager::Impl {
           client_id(stable_client_id ? value.client_id
                                      : (runtime_client_id.empty() ? RandomUuid() : runtime_client_id)) {
         if (config.heartbeat_interval_ms == 0) {
-            config.heartbeat_interval_ms = 30000;
+            config.heartbeat_interval_ms = 10000;
         }
         config.sampling_rate = std::max(0.0, std::min(1.0, config.sampling_rate));
         if (config.error_max_count == 0) {

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -1144,6 +1144,12 @@ ClientTelemetryManager::IsReady() const {
 }
 
 bool
+ClientTelemetryManager::IsWorkerThread() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->worker_running && impl_->worker_id == std::this_thread::get_id();
+}
+
+bool
 ClientTelemetryManager::IsSupported() const {
     std::lock_guard<std::mutex> lock(impl_->mutex);
     return impl_->unsupported_streak == 0;

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -22,10 +22,12 @@
 #include <cstdlib>
 #include <cstring>
 #include <deque>
+#include <iomanip>
 #include <limits>
 #include <map>
 #include <mutex>
 #include <random>
+#include <sstream>
 #include <stdexcept>
 #include <thread>
 #include <unordered_set>
@@ -440,16 +442,26 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
     void
     AttachChannel(const std::shared_ptr<grpc::Channel>& channel, const std::string& user, const std::string& db,
                   const std::string& endpoint, const std::string& version, const std::string& scope) {
+        // Construct every potentially-throwing part before taking either lock. Once locked, only
+        // noexcept shared_ptr/string moves and scalar updates remain, so a failed candidate cannot
+        // partially replace the live telemetry transport or its identity fields.
+        auto stub_holder = proto::milvus::ClientTelemetryService::NewStub(channel);
+        auto new_stub = std::shared_ptr<proto::milvus::ClientTelemetryService::Stub>(std::move(stub_holder));
+        std::string new_username = user;
+        std::string new_database = db;
+        std::string new_uri = endpoint;
+        std::string new_sdk_version = version;
+        std::string new_connection_scope = scope;
+
         std::lock_guard<std::recursive_mutex> command_lock(command_mutex);
         std::lock_guard<std::mutex> lock(mutex);
-        auto new_stub = proto::milvus::ClientTelemetryService::NewStub(channel);
-        stub = std::shared_ptr<proto::milvus::ClientTelemetryService::Stub>(std::move(new_stub));
+        stub = std::move(new_stub);
         ++channel_generation;
-        username = user;
-        database = db;
-        uri = endpoint;
-        sdk_version = version;
-        connection_scope = scope;
+        username = std::move(new_username);
+        database = std::move(new_database);
+        uri = std::move(new_uri);
+        sdk_version = std::move(new_sdk_version);
+        connection_scope = std::move(new_connection_scope);
     }
 
     void
@@ -506,9 +518,19 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
         }
         stopped = false;
         worker_running = true;
-        auto self = shared_from_this();
-        worker = std::thread([self = std::move(self)]() { self->HeartbeatLoop(); });
-        worker_id = worker.get_id();
+        try {
+            auto self = shared_from_this();
+            worker = std::thread([self = std::move(self)]() { self->HeartbeatLoop(); });
+            worker_id = worker.get_id();
+        } catch (...) {
+            // Telemetry startup is best-effort. Restore a clean, retryable stopped state instead
+            // of leaking an exception through Connect() or leaving worker_running without a thread.
+            ready = false;
+            stopped = true;
+            worker_running = false;
+            worker_id = {};
+            condition.notify_all();
+        }
     }
 
     void
@@ -548,8 +570,20 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
     void
     HeartbeatLoop() {
         while (true) {
-            CreateSnapshot();
-            SendHeartbeat();
+            try {
+                CreateSnapshot();
+                SendHeartbeat();
+            } catch (...) {
+                // No telemetry collection, serialization, transport, or extension failure may
+                // escape a std::thread entry and terminate the process. Keep the control plane
+                // alive; the next iteration can retry on the same or a reattached transport.
+                try {
+                    std::lock_guard<std::mutex> lock(mutex);
+                    last_heartbeat_error = "unexpected client telemetry heartbeat failure";
+                } catch (...) {
+                    // Even recording a best-effort diagnostic can fail under memory pressure.
+                }
+            }
             std::unique_lock<std::mutex> lock(mutex);
             if (stopped) {
                 break;
@@ -739,6 +773,10 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             return handler(command);
         } catch (const std::exception& exception) {
             return FailedReply(command.command_id, exception.what());
+        } catch (...) {
+            // Command handlers are extensible application code. Telemetry is best-effort and
+            // must never terminate the process when a handler throws a non-standard exception.
+            return FailedReply(command.command_id, "command handler threw a non-standard exception");
         }
     }
 

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -49,7 +49,16 @@ namespace milvus {
 namespace {
 
 constexpr size_t kSampleBufferSize = 1000;
-constexpr size_t kSnapshotLimit = 120;
+constexpr int64_t kMaxHistoryRangeMs = 60 * 60 * 1000;
+// The default 10-second heartbeat produces 361 boundary-inclusive snapshots in
+// one hour. Keep enough room for that full protocol window while bounding memory
+// when a server pushes a much shorter heartbeat interval. At sub-seven-second
+// intervals the oldest high-frequency detail is intentionally discarded rather
+// than allowing an unbounded number of StoredSnapshot/sample vectors. With the
+// seven supported operations and 1000 retained global samples per operation,
+// this caps raw history latency storage at 3,584,000 doubles (about 27.4 MiB),
+// plus snapshot/explicitly enabled collection metric metadata.
+constexpr size_t kSnapshotLimit = 512;
 // Fixed-point unit for accumulating a fractional sampling rate. A rate becomes an integer
 // step of this many units, so the smallest rate that still samples is 1e-9 -- far below
 // anything an operator would set, which is the point: a configured rate must never round
@@ -123,7 +132,7 @@ HostName() {
         return "Unknown";
     }
     buffer.back() = '\0';
-    return std::string(buffer.data());
+    return {buffer.data()};
 #endif
 }
 
@@ -149,7 +158,7 @@ class Sha256 {
 
     void
     Update(const std::string& value) {
-        Update(reinterpret_cast<const uint8_t*>(value.data()), value.size());
+        update(reinterpret_cast<const uint8_t*>(value.data()), value.size());
     }
 
     std::string
@@ -160,7 +169,7 @@ class Sha256 {
             while (buffer_size_ < 64) {
                 buffer_[buffer_size_++] = 0;
             }
-            Transform(buffer_.data());
+            transform(buffer_.data());
             buffer_size_ = 0;
         }
         while (buffer_size_ < 56) {
@@ -169,7 +178,7 @@ class Sha256 {
         for (int index = 7; index >= 0; --index) {
             buffer_[buffer_size_++] = static_cast<uint8_t>(bit_length >> (index * 8));
         }
-        Transform(buffer_.data());
+        transform(buffer_.data());
 
         std::ostringstream stream;
         stream << std::hex << std::setfill('0');
@@ -181,20 +190,20 @@ class Sha256 {
 
  private:
     void
-    Update(const uint8_t* data, size_t size) {
+    update(const uint8_t* data, size_t size) {
         total_size_ += size;
         for (size_t index = 0; index < size; ++index) {
             buffer_[buffer_size_++] = data[index];
             if (buffer_size_ == 64) {
-                Transform(buffer_.data());
+                transform(buffer_.data());
                 buffer_size_ = 0;
             }
         }
     }
 
     void
-    Transform(const uint8_t* block) {
-        static const uint32_t constants[64] = {
+    transform(const uint8_t* block) {
+        static const std::array<uint32_t, 64> constants = {
             0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
             0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
             0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
@@ -203,7 +212,7 @@ class Sha256 {
             0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
             0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
             0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
-        uint32_t schedule[64];
+        std::array<uint32_t, 64> schedule{};
         for (size_t index = 0; index < 16; ++index) {
             schedule[index] =
                 (static_cast<uint32_t>(block[index * 4]) << 24) | (static_cast<uint32_t>(block[index * 4 + 1]) << 16) |
@@ -254,7 +263,7 @@ int64_t
 DaysFromCivil(int year, unsigned month, unsigned day) {
     year -= month <= 2;
     const int era = (year >= 0 ? year : year - 399) / 400;
-    const unsigned year_of_era = static_cast<unsigned>(year - era * 400);
+    const auto year_of_era = static_cast<unsigned>(year - era * 400);
     const unsigned adjusted_month = month > 2 ? month - 3 : month + 9;
     const unsigned day_of_year = (153 * adjusted_month + 2) / 5 + day - 1;
     const unsigned day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
@@ -377,6 +386,11 @@ struct OperationCollector {
     std::unordered_map<std::string, MetricBucket> collections;
 };
 
+struct StoredSnapshot {
+    TelemetrySnapshot snapshot;
+    std::unordered_map<std::string, std::vector<double>> global_samples;
+};
+
 proto::common::Metrics
 ToProtoMetric(const TelemetryMetric& metric) {
     proto::common::Metrics result;
@@ -440,33 +454,84 @@ class ClientTelemetryManager::Impl {
 
     void
     Start() {
-        std::lock_guard<std::mutex> lock(mutex);
+        std::unique_lock<std::mutex> lock(mutex);
         if (ready) {
             return;
         }
+        const bool called_from_worker = worker_running && worker_id == std::this_thread::get_id();
+        if (called_from_worker) {
+            // Stop()/Start() is used by reconnect handlers. Reuse this worker only
+            // when no external caller has claimed it for joining. An external stop
+            // always wins over a self-restart that races with it.
+            if (join_in_progress || external_stop_requested) {
+                return;
+            }
+            ready = true;
+            stopped = !config.enabled;
+            return;
+        }
+
+        condition.wait(lock, [this]() { return !join_in_progress; });
+        if (ready) {
+            return;
+        }
+        if (worker.joinable()) {
+            join_in_progress = true;
+            auto previous_worker = std::move(worker);
+            lock.unlock();
+            previous_worker.join();
+            lock.lock();
+            worker_id = {};
+            worker_running = false;
+            join_in_progress = false;
+            condition.notify_all();
+            if (ready) {
+                return;
+            }
+        }
+        external_stop_requested = false;
         ready = true;
-        stopped = false;
+        stopped = !config.enabled;
         if (!config.enabled) {
             return;
         }
+        worker_running = true;
         worker = std::thread([this]() { HeartbeatLoop(); });
+        worker_id = worker.get_id();
     }
 
     void
     Stop() {
-        {
-            std::lock_guard<std::mutex> lock(mutex);
-            if (!ready && stopped) {
-                return;
-            }
-            stopped = true;
-            condition.notify_all();
-        }
-        if (worker.joinable() && worker.get_id() != std::this_thread::get_id()) {
-            worker.join();
-        }
-        std::lock_guard<std::mutex> lock(mutex);
+        std::unique_lock<std::mutex> lock(mutex);
+        stopped = true;
         ready = false;
+        condition.notify_all();
+
+        const bool called_from_worker = worker_running && worker_id == std::this_thread::get_id();
+        if (called_from_worker) {
+            return;
+        }
+
+        external_stop_requested = true;
+        condition.wait(lock, [this]() { return !join_in_progress; });
+        if (!worker.joinable()) {
+            worker_id = {};
+            worker_running = false;
+            return;
+        }
+
+        // Move the thread object while holding the state mutex. This gives
+        // exactly one external caller ownership of join(); other Stop()/Start()
+        // calls wait on join_in_progress instead of touching the same std::thread.
+        join_in_progress = true;
+        auto current_worker = std::move(worker);
+        lock.unlock();
+        current_worker.join();
+        lock.lock();
+        worker_id = {};
+        worker_running = false;
+        join_in_progress = false;
+        condition.notify_all();
     }
 
     void
@@ -476,7 +541,7 @@ class ClientTelemetryManager::Impl {
             SendHeartbeat();
             std::unique_lock<std::mutex> lock(mutex);
             if (stopped) {
-                return;
+                break;
             }
             uint64_t delay = config.heartbeat_interval_ms;
             if (unsupported_streak > 0) {
@@ -488,9 +553,12 @@ class ClientTelemetryManager::Impl {
             }
             condition.wait_for(lock, std::chrono::milliseconds(delay), [this]() { return stopped; });
             if (stopped) {
-                return;
+                break;
             }
         }
+        std::lock_guard<std::mutex> lock(mutex);
+        worker_running = false;
+        condition.notify_all();
     }
 
     void
@@ -499,7 +567,8 @@ class ClientTelemetryManager::Impl {
         if (!config.enabled) {
             return;
         }
-        TelemetrySnapshot snapshot;
+        StoredSnapshot stored;
+        auto& snapshot = stored.snapshot;
         snapshot.end_time = NowMillis();
         snapshot.timestamp = last_snapshot_end == 0 || last_snapshot_end > snapshot.end_time
                                  ? snapshot.end_time - config.heartbeat_interval_ms
@@ -512,6 +581,8 @@ class ClientTelemetryManager::Impl {
             TelemetryOperationMetrics operation;
             operation.operation = entry.first;
             operation.global = entry.second.global.Snapshot();
+            stored.global_samples.emplace(entry.first, std::vector<double>(entry.second.global.samples.begin(),
+                                                                           entry.second.global.samples.end()));
             for (const auto& collection : entry.second.collections) {
                 if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
                     operation.collection_metrics.emplace(collection.first, collection.second.Snapshot());
@@ -520,7 +591,18 @@ class ClientTelemetryManager::Impl {
             snapshot.metrics.emplace_back(std::move(operation));
             entry.second = OperationCollector{};
         }
-        snapshots.push_back(std::move(snapshot));
+        // Heartbeats report exactly the collector interval that just ended.
+        // Keep this separate from retained history so skipping an empty history
+        // entry cannot make the next heartbeat resend an older non-empty sample.
+        latest_snapshot = snapshot;
+        const auto history_start = snapshot.end_time - kMaxHistoryRangeMs;
+        while (!snapshots.empty() && snapshots.front().snapshot.end_time < history_start) {
+            snapshots.pop_front();
+        }
+        if (snapshot.metrics.empty()) {
+            return;
+        }
+        snapshots.push_back(std::move(stored));
         while (snapshots.size() > kSnapshotLimit) {
             snapshots.pop_front();
         }
@@ -549,16 +631,13 @@ class ClientTelemetryManager::Impl {
                 (*info->mutable_reserved())["db_name"] = database;
             }
             request.set_report_timestamp(NowMillis());
-            if (!snapshots.empty()) {
-                for (const auto& operation : snapshots.back().metrics) {
-                    auto* output = request.add_metrics();
-                    output->set_operation(operation.operation);
-                    *output->mutable_global() = ToProtoMetric(operation.global);
-                    for (const auto& collection : operation.collection_metrics) {
-                        if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
-                            (*output->mutable_collection_metrics())[collection.first] =
-                                ToProtoMetric(collection.second);
-                        }
+            for (const auto& operation : latest_snapshot.metrics) {
+                auto* output = request.add_metrics();
+                output->set_operation(operation.operation);
+                *output->mutable_global() = ToProtoMetric(operation.global);
+                for (const auto& collection : operation.collection_metrics) {
+                    if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
+                        (*output->mutable_collection_metrics())[collection.first] = ToProtoMetric(collection.second);
                     }
                 }
             }
@@ -674,7 +753,7 @@ class ClientTelemetryManager::Impl {
         }
         std::lock_guard<std::mutex> lock(mutex);
         for (auto iterator = executed_commands.begin(); iterator != executed_commands.end();) {
-            if (iterator->second <= previous_timestamp) {
+            if (iterator->second < max_timestamp) {
                 iterator = executed_commands.erase(iterator);
             } else {
                 ++iterator;
@@ -704,7 +783,7 @@ class ClientTelemetryManager::Impl {
                     throw std::invalid_argument("enabled must be a boolean");
                 }
                 enabled = payload["enabled"].get<bool>();
-                applied.push_back("enabled");
+                applied.emplace_back("enabled");
             }
             if (payload.count("heartbeat_interval_ms")) {
                 if (!payload["heartbeat_interval_ms"].is_number_integer() &&
@@ -715,7 +794,7 @@ class ClientTelemetryManager::Impl {
                 if (interval <= 0) {
                     throw std::invalid_argument("heartbeat_interval_ms must be positive");
                 }
-                applied.push_back("heartbeat_interval_ms");
+                applied.emplace_back("heartbeat_interval_ms");
             }
             if (payload.count("sampling_rate")) {
                 if (!payload["sampling_rate"].is_number()) {
@@ -726,7 +805,7 @@ class ClientTelemetryManager::Impl {
                     throw std::invalid_argument("sampling_rate must be finite");
                 }
                 sampling_rate = std::max(0.0, std::min(1.0, sampling_rate));
-                applied.push_back("sampling_rate");
+                applied.emplace_back("sampling_rate");
             }
             if (payload.count("ttl_seconds")) {
                 if (!payload["ttl_seconds"].is_number_integer() && !payload["ttl_seconds"].is_number_unsigned()) {
@@ -887,21 +966,23 @@ class ClientTelemetryManager::Impl {
             if (end - start > 60 * 60 * 1000) {
                 throw std::invalid_argument("time range cannot exceed 1 hour");
             }
-            std::vector<TelemetrySnapshot> all;
+            std::vector<StoredSnapshot> all;
             {
                 std::lock_guard<std::mutex> lock(mutex);
                 all.assign(snapshots.begin(), snapshots.end());
             }
-            std::vector<TelemetrySnapshot> selected;
-            for (const auto& snapshot : all) {
+            std::vector<StoredSnapshot> selected;
+            for (const auto& stored : all) {
+                const auto& snapshot = stored.snapshot;
                 if (snapshot.end_time >= start && snapshot.timestamp <= end) {
-                    selected.push_back(snapshot);
+                    selected.push_back(stored);
                 }
             }
             nlohmann::json response;
             if (payload.value("detail", false)) {
                 response["snapshots"] = nlohmann::json::array();
-                for (const auto& snapshot : selected) {
+                for (const auto& stored : selected) {
+                    const auto& snapshot = stored.snapshot;
                     nlohmann::json metrics = nlohmann::json::object();
                     for (const auto& operation : snapshot.metrics) {
                         metrics[operation.operation] = MetricJson(operation.global);
@@ -916,30 +997,56 @@ class ClientTelemetryManager::Impl {
                     int64_t successes{0};
                     int64_t errors{0};
                     double average{0};
-                    double p99{0};
                     double maximum{0};
+                    std::vector<std::pair<double, double>> latency_samples;
                 };
                 std::map<std::string, Total> totals;
-                for (const auto& snapshot : selected) {
+                for (const auto& stored : selected) {
+                    const auto& snapshot = stored.snapshot;
                     for (const auto& operation : snapshot.metrics) {
                         auto& total = totals[operation.operation];
                         total.requests += operation.global.request_count;
                         total.successes += operation.global.success_count;
                         total.errors += operation.global.error_count;
                         total.average += operation.global.avg_latency_ms * operation.global.request_count;
-                        total.p99 += operation.global.p99_latency_ms * operation.global.request_count;
                         total.maximum = std::max(total.maximum, operation.global.max_latency_ms);
+                        const auto samples = stored.global_samples.find(operation.operation);
+                        if (samples != stored.global_samples.end() && !samples->second.empty()) {
+                            const auto weight =
+                                static_cast<double>(operation.global.request_count) / samples->second.size();
+                            for (const auto latency : samples->second) {
+                                total.latency_samples.emplace_back(latency, weight);
+                            }
+                        }
                     }
                 }
                 nlohmann::json metrics = nlohmann::json::object();
                 for (const auto& entry : totals) {
+                    auto samples = entry.second.latency_samples;
+                    std::sort(samples.begin(), samples.end(),
+                              [](const std::pair<double, double>& left, const std::pair<double, double>& right) {
+                                  return left.first < right.first;
+                              });
+                    double p99 = 0;
+                    if (!samples.empty()) {
+                        const auto target = static_cast<double>(entry.second.requests) * 0.99;
+                        double cumulative = 0;
+                        p99 = samples.back().first;
+                        for (const auto& sample : samples) {
+                            cumulative += sample.second;
+                            if (cumulative > target) {
+                                p99 = sample.first;
+                                break;
+                            }
+                        }
+                    }
                     metrics[entry.first] = {
                         {"request_count", entry.second.requests},
                         {"success_count", entry.second.successes},
                         {"error_count", entry.second.errors},
                         {"avg_latency_ms",
                          entry.second.requests == 0 ? 0 : entry.second.average / entry.second.requests},
-                        {"p99_latency_ms", entry.second.requests == 0 ? 0 : entry.second.p99 / entry.second.requests},
+                        {"p99_latency_ms", p99},
                         {"max_latency_ms", entry.second.maximum}};
                 }
                 response = {{"aggregated", {{"start_time", start}, {"end_time", end}, {"metrics", metrics}}},
@@ -968,7 +1075,8 @@ class ClientTelemetryManager::Impl {
     std::string connection_scope;
     std::unordered_map<std::string, OperationCollector> collectors;
     std::deque<TelemetryError> errors;
-    std::deque<TelemetrySnapshot> snapshots;
+    TelemetrySnapshot latest_snapshot;
+    std::deque<StoredSnapshot> snapshots;
     std::vector<TelemetryCommandReply> pending_replies;
     std::unordered_map<std::string, int64_t> executed_commands;
     std::unordered_map<std::string, CommandHandler> handlers;
@@ -976,6 +1084,9 @@ class ClientTelemetryManager::Impl {
     bool all_collections_enabled{false};
     bool ready{false};
     bool stopped{true};
+    bool worker_running{false};
+    bool join_in_progress{false};
+    bool external_stop_requested{false};
     int unsupported_streak{0};
     // Carries the fractional sampling rate between operations, in kSamplingScale units:
     // each operation adds the rate and the one that pushes it past a whole unit is the one
@@ -986,6 +1097,7 @@ class ClientTelemetryManager::Impl {
     std::string config_hash;
     std::string last_heartbeat_error;
     std::thread worker;
+    std::thread::id worker_id;
     std::recursive_mutex command_mutex;
 };
 
@@ -1000,12 +1112,6 @@ ClientTelemetryManager::AttachChannel(const std::shared_ptr<grpc::Channel>& chan
                                       const std::string& database, const std::string& uri,
                                       const std::string& sdk_version, const std::string& connection_scope) {
     impl_->AttachChannel(channel, username, database, uri, sdk_version, connection_scope);
-}
-
-void
-ClientTelemetryManager::UpdateDatabase(const std::string& database) {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    impl_->database = database;
 }
 
 void
@@ -1145,7 +1251,12 @@ ClientTelemetryManager::RecentErrors(size_t max_count) const {
 std::vector<TelemetrySnapshot>
 ClientTelemetryManager::MetricsSnapshots() const {
     std::lock_guard<std::mutex> lock(impl_->mutex);
-    return {impl_->snapshots.begin(), impl_->snapshots.end()};
+    std::vector<TelemetrySnapshot> result;
+    result.reserve(impl_->snapshots.size());
+    for (const auto& stored : impl_->snapshots) {
+        result.push_back(stored.snapshot);
+    }
+    return result;
 }
 
 std::vector<TelemetryCommandReply>

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -26,6 +26,7 @@
 #include <limits>
 #include <map>
 #include <mutex>
+#include <queue>
 #include <random>
 #include <sstream>
 #include <stdexcept>
@@ -51,16 +52,15 @@ namespace milvus {
 namespace {
 
 constexpr size_t kSampleBufferSize = 1000;
+constexpr size_t kStoredQuantileSampleCount = 128;
 constexpr int64_t kMaxHistoryRangeMs = 60 * 60 * 1000;
-// The default 10-second heartbeat produces 361 boundary-inclusive snapshots in
-// one hour. Keep enough room for that full protocol window while bounding memory
-// when a server pushes a much shorter heartbeat interval. At sub-seven-second
-// intervals the oldest high-frequency detail is intentionally discarded rather
-// than allowing an unbounded number of StoredSnapshot/sample vectors. With the
-// seven supported operations and 1000 retained global samples per operation,
-// this caps raw history latency storage at 3,584,000 doubles (about 27.4 MiB),
-// plus snapshot/explicitly enabled collection metric metadata.
-constexpr size_t kSnapshotLimit = 512;
+// A one-second heartbeat produces at most 3,601 boundary-inclusive snapshots in
+// one hour. Keep the complete protocol window plus margin while retaining a hard
+// memory bound for shorter server-pushed intervals. Each operation/window stores
+// at most 128 sorted, evenly spaced quantile samples including its minimum and
+// maximum. Across seven supported operations this caps latency history at
+// 3,670,016 doubles (about 28 MiB), plus snapshot/collection metric metadata.
+constexpr size_t kSnapshotLimit = 4096;
 // Fixed-point unit for accumulating a fractional sampling rate. A rate becomes an integer
 // step of this many units, so the smallest rate that still samples is 1e-9 -- far below
 // anything an operator would set, which is the point: a configured rate must never round
@@ -370,9 +370,25 @@ struct MetricBucket {
     }
 
     TelemetryMetric
-    Snapshot() const {
+    Snapshot(std::vector<double>* quantile_samples = nullptr) const {
         std::vector<double> sorted(samples.begin(), samples.end());
         std::sort(sorted.begin(), sorted.end());
+        if (quantile_samples != nullptr) {
+            quantile_samples->clear();
+            const auto count = std::min(sorted.size(), kStoredQuantileSampleCount);
+            quantile_samples->reserve(count);
+            if (count == 1) {
+                quantile_samples->push_back(sorted.front());
+            } else if (count > 1) {
+                // Index 0 and count-1 map exactly to the minimum and maximum. The
+                // intermediate integer indices are evenly spaced over the sorted
+                // reservoir and keep the output compact and already merge-ready.
+                for (size_t index = 0; index < count; ++index) {
+                    const auto source_index = index * (sorted.size() - 1) / (count - 1);
+                    quantile_samples->push_back(sorted[source_index]);
+                }
+            }
+        }
         auto index = sorted.empty() ? 0 : std::min(sorted.size() - 1, static_cast<size_t>(sorted.size() * 0.99));
         return {requests,
                 successes,
@@ -632,9 +648,9 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             }
             TelemetryOperationMetrics operation;
             operation.operation = entry.first;
-            operation.global = entry.second.global.Snapshot();
-            stored.global_samples.emplace(entry.first, std::vector<double>(entry.second.global.samples.begin(),
-                                                                           entry.second.global.samples.end()));
+            std::vector<double> quantile_samples;
+            operation.global = entry.second.global.Snapshot(&quantile_samples);
+            stored.global_samples.emplace(entry.first, std::move(quantile_samples));
             for (const auto& collection : entry.second.collections) {
                 if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
                     operation.collection_metrics.emplace(collection.first, collection.second.Snapshot());
@@ -1027,16 +1043,15 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             if (end - start > 60 * 60 * 1000) {
                 throw std::invalid_argument("time range cannot exceed 1 hour");
             }
-            std::vector<StoredSnapshot> all;
+            std::vector<StoredSnapshot> selected;
             {
                 std::lock_guard<std::mutex> lock(mutex);
-                all.assign(snapshots.begin(), snapshots.end());
-            }
-            std::vector<StoredSnapshot> selected;
-            for (const auto& stored : all) {
-                const auto& snapshot = stored.snapshot;
-                if (snapshot.end_time >= start && snapshot.timestamp <= end) {
-                    selected.push_back(stored);
+                selected.reserve(snapshots.size());
+                for (const auto& stored : snapshots) {
+                    const auto& snapshot = stored.snapshot;
+                    if (snapshot.end_time >= start && snapshot.timestamp <= end) {
+                        selected.push_back(stored);
+                    }
                 }
             }
             nlohmann::json response;
@@ -1059,7 +1074,11 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                     int64_t errors{0};
                     double average{0};
                     double maximum{0};
-                    std::vector<std::pair<double, double>> latency_samples;
+                    struct WeightedSamples {
+                        const std::vector<double>* values;
+                        double weight;
+                    };
+                    std::vector<WeightedSamples> latency_windows;
                 };
                 std::map<std::string, Total> totals;
                 for (const auto& stored : selected) {
@@ -1075,29 +1094,43 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                         if (samples != stored.global_samples.end() && !samples->second.empty()) {
                             const auto weight =
                                 static_cast<double>(operation.global.request_count) / samples->second.size();
-                            for (const auto latency : samples->second) {
-                                total.latency_samples.emplace_back(latency, weight);
-                            }
+                            total.latency_windows.push_back({&samples->second, weight});
                         }
                     }
                 }
                 nlohmann::json metrics = nlohmann::json::object();
                 for (const auto& entry : totals) {
-                    auto samples = entry.second.latency_samples;
-                    std::sort(samples.begin(), samples.end(),
-                              [](const std::pair<double, double>& left, const std::pair<double, double>& right) {
-                                  return left.first < right.first;
-                              });
+                    struct Cursor {
+                        double latency;
+                        size_t window;
+                        size_t sample;
+                    };
+                    const auto later = [](const Cursor& left, const Cursor& right) {
+                        return left.latency > right.latency;
+                    };
+                    std::priority_queue<Cursor, std::vector<Cursor>, decltype(later)> samples(later);
+                    for (size_t window = 0; window < entry.second.latency_windows.size(); ++window) {
+                        const auto* values = entry.second.latency_windows[window].values;
+                        if (values != nullptr && !values->empty()) {
+                            samples.push({values->front(), window, 0});
+                        }
+                    }
                     double p99 = 0;
                     if (!samples.empty()) {
                         const auto target = static_cast<double>(entry.second.requests) * 0.99;
                         double cumulative = 0;
-                        p99 = samples.back().first;
-                        for (const auto& sample : samples) {
-                            cumulative += sample.second;
+                        while (!samples.empty()) {
+                            const auto sample = samples.top();
+                            samples.pop();
+                            const auto& window = entry.second.latency_windows[sample.window];
+                            p99 = sample.latency;
+                            cumulative += window.weight;
                             if (cumulative > target) {
-                                p99 = sample.first;
                                 break;
+                            }
+                            const auto next = sample.sample + 1;
+                            if (next < window.values->size()) {
+                                samples.push({(*window.values)[next], sample.window, next});
                             }
                         }
                     }

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -10,8 +10,8 @@
 
 #include "milvus/ClientTelemetry.h"
 
-#include <grpcpp/client_context.h>
 #include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
 
 #include <algorithm>
 #include <array>
@@ -34,13 +34,19 @@
 #include <unordered_set>
 #include <utility>
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
+
 #include <milvus/thirdparty/nlohmann/json.hpp>
 
 #include "common.pb.h"
 #include "milvus.grpc.pb.h"
 #include "milvus.pb.h"
+#include "milvus/ClientRequestContext.h"
 
 namespace milvus {
 namespace {
@@ -54,6 +60,25 @@ constexpr size_t kSnapshotLimit = 120;
 constexpr uint64_t kSamplingScale = 1000000000ULL;
 constexpr size_t kMaxReplyBytes = 1024 * 1024;
 constexpr uint64_t kMaxUnsupportedBackoffMs = 30 * 60 * 1000;
+
+TelemetryConfig
+NormalizedTelemetryConfig(TelemetryConfig config) {
+    if (config.heartbeat_interval_ms == 0) {
+        config.heartbeat_interval_ms = 10000;
+    }
+    config.sampling_rate = std::max(0.0, std::min(1.0, config.sampling_rate));
+    if (config.error_max_count == 0) {
+        config.error_max_count = 100;
+    }
+    return config;
+}
+
+bool
+SameTelemetryConfig(const TelemetryConfig& left, const TelemetryConfig& right) {
+    return left.enabled == right.enabled && left.heartbeat_interval_ms == right.heartbeat_interval_ms &&
+           left.sampling_rate == right.sampling_rate && left.error_max_count == right.error_max_count &&
+           left.client_id == right.client_id;
+}
 
 int64_t
 NowMillis() {
@@ -69,10 +94,9 @@ RandomUuid() {
     auto high = distribution(generator);
     auto low = distribution(generator);
     std::ostringstream stream;
-    stream << std::hex << std::setfill('0') << std::setw(8) << static_cast<uint32_t>(high >> 32) << "-"
-           << std::setw(4) << static_cast<uint16_t>(high >> 16) << "-" << std::setw(4)
-           << static_cast<uint16_t>(high) << "-" << std::setw(4) << static_cast<uint16_t>(low >> 48) << "-"
-           << std::setw(12) << (low & 0x0000FFFFFFFFFFFFULL);
+    stream << std::hex << std::setfill('0') << std::setw(8) << static_cast<uint32_t>(high >> 32) << "-" << std::setw(4)
+           << static_cast<uint16_t>(high >> 16) << "-" << std::setw(4) << static_cast<uint16_t>(high) << "-"
+           << std::setw(4) << static_cast<uint16_t>(low >> 48) << "-" << std::setw(12) << (low & 0x0000FFFFFFFFFFFFULL);
     return stream.str();
 }
 
@@ -93,8 +117,17 @@ LocalTimeString() {
 
 std::string
 HostName() {
-    const char* value = std::getenv("HOSTNAME");
+#ifdef _WIN32
+    const char* value = std::getenv("COMPUTERNAME");
     return value == nullptr ? "Unknown" : value;
+#else
+    std::array<char, 256> buffer{};
+    if (gethostname(buffer.data(), buffer.size()) != 0) {
+        return "Unknown";
+    }
+    buffer.back() = '\0';
+    return std::string(buffer.data());
+#endif
 }
 
 std::string
@@ -114,9 +147,7 @@ RotateRight(uint32_t value, uint32_t count) {
 // Small self-contained SHA-256 implementation keeps the SDK independent from a specific TLS provider.
 class Sha256 {
  public:
-    Sha256()
-        : state_{0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
-                 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19} {
+    Sha256() : state_{0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19} {
     }
 
     void
@@ -167,22 +198,19 @@ class Sha256 {
     void
     Transform(const uint8_t* block) {
         static const uint32_t constants[64] = {
-            0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
-            0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
-            0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
-            0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
-            0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
-            0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
-            0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
-            0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-            0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
-            0xc67178f2};
+            0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+            0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+            0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+            0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+            0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+            0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+            0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+            0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
         uint32_t schedule[64];
         for (size_t index = 0; index < 16; ++index) {
-            schedule[index] = (static_cast<uint32_t>(block[index * 4]) << 24) |
-                              (static_cast<uint32_t>(block[index * 4 + 1]) << 16) |
-                              (static_cast<uint32_t>(block[index * 4 + 2]) << 8) |
-                              static_cast<uint32_t>(block[index * 4 + 3]);
+            schedule[index] =
+                (static_cast<uint32_t>(block[index * 4]) << 24) | (static_cast<uint32_t>(block[index * 4 + 1]) << 16) |
+                (static_cast<uint32_t>(block[index * 4 + 2]) << 8) | static_cast<uint32_t>(block[index * 4 + 3]);
         }
         for (size_t index = 16; index < 64; ++index) {
             uint32_t first = RotateRight(schedule[index - 15], 7) ^ RotateRight(schedule[index - 15], 18) ^
@@ -252,6 +280,9 @@ ParseRfc3339Millis(const std::string& value) {
         while (end < value.size() && std::isdigit(static_cast<unsigned char>(value[end]))) {
             ++end;
         }
+        if (end == position + 1) {
+            throw std::invalid_argument("invalid RFC3339 timestamp");
+        }
         auto fraction = value.substr(position + 1, end - position - 1);
         while (fraction.size() < 3) {
             fraction.push_back('0');
@@ -260,14 +291,32 @@ ParseRfc3339Millis(const std::string& value) {
         position = end;
     }
     int offset_seconds = 0;
-    if (position < value.size() && value[position] != 'Z') {
-        if (position + 5 >= value.size() || (value[position] != '+' && value[position] != '-')) {
+    if (position >= value.size()) {
+        throw std::invalid_argument("invalid RFC3339 timezone");
+    }
+    if (value[position] == 'Z') {
+        ++position;
+    } else {
+        if (position + 6 != value.size() || (value[position] != '+' && value[position] != '-') ||
+            value[position + 3] != ':') {
             throw std::invalid_argument("invalid RFC3339 timezone");
+        }
+        for (auto index : {position + 1, position + 2, position + 4, position + 5}) {
+            if (!std::isdigit(static_cast<unsigned char>(value[index]))) {
+                throw std::invalid_argument("invalid RFC3339 timezone");
+            }
         }
         int sign = value[position] == '+' ? 1 : -1;
         int hours = std::stoi(value.substr(position + 1, 2));
         int minutes = std::stoi(value.substr(position + 4, 2));
+        if (hours > 23 || minutes > 59) {
+            throw std::invalid_argument("invalid RFC3339 timezone");
+        }
         offset_seconds = sign * (hours * 3600 + minutes * 60);
+        position += 6;
+    }
+    if (position != value.size()) {
+        throw std::invalid_argument("invalid RFC3339 timestamp");
     }
     return (Timegm(&time) - offset_seconds) * 1000 + milliseconds;
 }
@@ -325,12 +374,9 @@ ToProtoMetric(const TelemetryMetric& metric) {
 
 nlohmann::json
 MetricJson(const TelemetryMetric& metric) {
-    return {{"request_count", metric.request_count},
-            {"success_count", metric.success_count},
-            {"error_count", metric.error_count},
-            {"avg_latency_ms", metric.avg_latency_ms},
-            {"p99_latency_ms", metric.p99_latency_ms},
-            {"max_latency_ms", metric.max_latency_ms}};
+    return {{"request_count", metric.request_count},   {"success_count", metric.success_count},
+            {"error_count", metric.error_count},       {"avg_latency_ms", metric.avg_latency_ms},
+            {"p99_latency_ms", metric.p99_latency_ms}, {"max_latency_ms", metric.max_latency_ms}};
 }
 
 TelemetryCommandReply
@@ -348,17 +394,11 @@ FailedReply(const std::string& command_id, const std::string& error) {
 class ClientTelemetryManager::Impl {
  public:
     Impl(const TelemetryConfig& value, const std::string& runtime_client_id)
-        : config(value),
+        : config(NormalizedTelemetryConfig(value)),
+          connection_config(config),
           stable_client_id(!value.client_id.empty()),
           client_id(stable_client_id ? value.client_id
                                      : (runtime_client_id.empty() ? RandomUuid() : runtime_client_id)) {
-        if (config.heartbeat_interval_ms == 0) {
-            config.heartbeat_interval_ms = 10000;
-        }
-        config.sampling_rate = std::max(0.0, std::min(1.0, config.sampling_rate));
-        if (config.error_max_count == 0) {
-            config.error_max_count = 100;
-        }
         RegisterDefaultHandlers();
     }
 
@@ -368,13 +408,17 @@ class ClientTelemetryManager::Impl {
 
     void
     AttachChannel(const std::shared_ptr<grpc::Channel>& channel, const std::string& user, const std::string& db,
-                  const std::string& endpoint, const std::string& version) {
+                  const std::string& endpoint, const std::string& version, const std::string& scope) {
+        std::lock_guard<std::recursive_mutex> command_lock(command_mutex);
         std::lock_guard<std::mutex> lock(mutex);
-        stub = proto::milvus::ClientTelemetryService::NewStub(channel);
+        auto new_stub = proto::milvus::ClientTelemetryService::NewStub(channel);
+        stub = std::shared_ptr<proto::milvus::ClientTelemetryService::Stub>(std::move(new_stub));
+        ++channel_generation;
         username = user;
         database = db;
         uri = endpoint;
         sdk_version = version;
+        connection_scope = scope;
     }
 
     void
@@ -419,8 +463,11 @@ class ClientTelemetryManager::Impl {
             }
             uint64_t delay = config.heartbeat_interval_ms;
             if (unsupported_streak > 0) {
-                auto exponent = std::min(unsupported_streak, 20);
-                delay = std::min(kMaxUnsupportedBackoffMs, delay * (uint64_t{1} << exponent));
+                uint64_t backed_off = std::min(delay, kMaxUnsupportedBackoffMs);
+                for (int index = 0; index < unsupported_streak && backed_off < kMaxUnsupportedBackoffMs; ++index) {
+                    backed_off = backed_off > kMaxUnsupportedBackoffMs / 2 ? kMaxUnsupportedBackoffMs : backed_off * 2;
+                }
+                delay = std::max(delay, backed_off);
             }
             condition.wait_for(lock, std::chrono::milliseconds(delay), [this]() { return stopped; });
             if (stopped) {
@@ -437,7 +484,9 @@ class ClientTelemetryManager::Impl {
         }
         TelemetrySnapshot snapshot;
         snapshot.end_time = NowMillis();
-        snapshot.timestamp = last_snapshot_end == 0 ? snapshot.end_time - config.heartbeat_interval_ms : last_snapshot_end;
+        snapshot.timestamp = last_snapshot_end == 0 || last_snapshot_end > snapshot.end_time
+                                 ? snapshot.end_time - config.heartbeat_interval_ms
+                                 : last_snapshot_end;
         last_snapshot_end = snapshot.end_time;
         for (auto& entry : collectors) {
             if (entry.second.global.requests == 0) {
@@ -447,7 +496,9 @@ class ClientTelemetryManager::Impl {
             operation.operation = entry.first;
             operation.global = entry.second.global.Snapshot();
             for (const auto& collection : entry.second.collections) {
-                operation.collection_metrics.emplace(collection.first, collection.second.Snapshot());
+                if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
+                    operation.collection_metrics.emplace(collection.first, collection.second.Snapshot());
+                }
             }
             snapshot.metrics.emplace_back(std::move(operation));
             entry.second = OperationCollector{};
@@ -461,7 +512,8 @@ class ClientTelemetryManager::Impl {
     void
     SendHeartbeat() {
         proto::milvus::ClientHeartbeatRequest request;
-        std::unique_ptr<proto::milvus::ClientTelemetryService::Stub>* stub_pointer = nullptr;
+        std::shared_ptr<proto::milvus::ClientTelemetryService::Stub> heartbeat_stub;
+        uint64_t heartbeat_generation = 0;
         size_t reply_count = 0;
         {
             std::lock_guard<std::mutex> lock(mutex);
@@ -486,7 +538,10 @@ class ClientTelemetryManager::Impl {
                     output->set_operation(operation.operation);
                     *output->mutable_global() = ToProtoMetric(operation.global);
                     for (const auto& collection : operation.collection_metrics) {
-                        (*output->mutable_collection_metrics())[collection.first] = ToProtoMetric(collection.second);
+                        if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
+                            (*output->mutable_collection_metrics())[collection.first] =
+                                ToProtoMetric(collection.second);
+                        }
                     }
                 }
             }
@@ -500,25 +555,37 @@ class ClientTelemetryManager::Impl {
             reply_count = pending_replies.size();
             request.set_config_hash(config_hash);
             request.set_last_command_timestamp(last_command_timestamp);
-            stub_pointer = &stub;
+            heartbeat_stub = stub;
+            heartbeat_generation = channel_generation;
         }
 
         grpc::ClientContext context;
         context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(10));
         proto::milvus::ClientHeartbeatResponse response;
-        auto grpc_status = (*stub_pointer)->ClientHeartbeat(&context, request, &response);
+        auto grpc_status = heartbeat_stub->ClientHeartbeat(&context, request, &response);
         if (!grpc_status.ok()) {
             std::lock_guard<std::mutex> lock(mutex);
+            if (heartbeat_generation != channel_generation) {
+                return;
+            }
             last_heartbeat_error = grpc_status.error_message();
             if (grpc_status.error_code() == grpc::StatusCode::UNIMPLEMENTED) {
                 ++unsupported_streak;
             }
             return;
         }
-        if (response.status().code() != 0 || response.status().error_code() != proto::common::ErrorCode::Success) {
+        {
             std::lock_guard<std::mutex> lock(mutex);
-            last_heartbeat_error = response.status().reason();
-            return;
+            if (heartbeat_generation != channel_generation) {
+                return;
+            }
+            // Reaching any server implementation proves the RPC exists, even when the
+            // response carries a business error.
+            unsupported_streak = 0;
+            if (response.status().code() != 0 || response.status().error_code() != proto::common::ErrorCode::Success) {
+                last_heartbeat_error = response.status().reason();
+                return;
+            }
         }
         std::vector<TelemetryCommand> commands;
         commands.reserve(response.commands_size());
@@ -528,12 +595,14 @@ class ClientTelemetryManager::Impl {
         }
         {
             std::lock_guard<std::mutex> lock(mutex);
+            if (heartbeat_generation != channel_generation) {
+                return;
+            }
             pending_replies.erase(pending_replies.begin(),
                                   pending_replies.begin() + std::min(reply_count, pending_replies.size()));
-            unsupported_streak = 0;
             last_heartbeat_error.clear();
         }
-        ProcessCommands(commands);
+        ProcessCommands(commands, heartbeat_generation);
     }
 
     TelemetryCommandReply
@@ -555,10 +624,14 @@ class ClientTelemetryManager::Impl {
     }
 
     void
-    ProcessCommands(const std::vector<TelemetryCommand>& commands) {
+    ProcessCommands(const std::vector<TelemetryCommand>& commands, uint64_t expected_generation = 0) {
+        std::lock_guard<std::recursive_mutex> command_lock(command_mutex);
         int64_t previous_timestamp;
         {
             std::lock_guard<std::mutex> lock(mutex);
+            if (expected_generation != 0 && expected_generation != channel_generation) {
+                return;
+            }
             previous_timestamp = last_command_timestamp;
         }
         int64_t max_timestamp = previous_timestamp;
@@ -600,22 +673,71 @@ class ClientTelemetryManager::Impl {
     RegisterDefaultHandlers() {
         handlers["push_config"] = [this](const TelemetryCommand& command) {
             auto payload = command.payload.empty() ? nlohmann::json::object() : nlohmann::json::parse(command.payload);
-            std::lock_guard<std::mutex> lock(mutex);
+            if (!payload.is_object()) {
+                throw std::invalid_argument("push_config payload must be a JSON object");
+            }
+
+            std::vector<std::string> applied;
+            std::vector<std::string> ignored;
+            bool enabled = false;
+            int64_t interval = 0;
+            double sampling_rate = 0;
             if (payload.count("enabled")) {
-                config.enabled = payload["enabled"].get<bool>();
+                if (!payload["enabled"].is_boolean()) {
+                    throw std::invalid_argument("enabled must be a boolean");
+                }
+                enabled = payload["enabled"].get<bool>();
+                applied.push_back("enabled");
             }
             if (payload.count("heartbeat_interval_ms")) {
-                auto interval = payload["heartbeat_interval_ms"].get<int64_t>();
+                if (!payload["heartbeat_interval_ms"].is_number_integer() &&
+                    !payload["heartbeat_interval_ms"].is_number_unsigned()) {
+                    throw std::invalid_argument("heartbeat_interval_ms must be an integer");
+                }
+                interval = payload["heartbeat_interval_ms"].get<int64_t>();
                 if (interval <= 0) {
                     throw std::invalid_argument("heartbeat_interval_ms must be positive");
                 }
-                config.heartbeat_interval_ms = static_cast<uint64_t>(interval);
+                applied.push_back("heartbeat_interval_ms");
             }
             if (payload.count("sampling_rate")) {
-                config.sampling_rate = std::max(0.0, std::min(1.0, payload["sampling_rate"].get<double>()));
+                if (!payload["sampling_rate"].is_number()) {
+                    throw std::invalid_argument("sampling_rate must be a number");
+                }
+                sampling_rate = payload["sampling_rate"].get<double>();
+                if (!std::isfinite(sampling_rate)) {
+                    throw std::invalid_argument("sampling_rate must be finite");
+                }
+                sampling_rate = std::max(0.0, std::min(1.0, sampling_rate));
+                applied.push_back("sampling_rate");
             }
-            condition.notify_all();
-            return SuccessReply(command.command_id);
+            if (payload.count("ttl_seconds")) {
+                if (!payload["ttl_seconds"].is_number_integer() && !payload["ttl_seconds"].is_number_unsigned()) {
+                    throw std::invalid_argument("ttl_seconds must be an integer");
+                }
+                (void)payload["ttl_seconds"].get<int64_t>();
+            }
+            for (auto iterator = payload.begin(); iterator != payload.end(); ++iterator) {
+                if (iterator.key() != "enabled" && iterator.key() != "heartbeat_interval_ms" &&
+                    iterator.key() != "sampling_rate") {
+                    ignored.push_back(iterator.key());
+                }
+            }
+            std::sort(ignored.begin(), ignored.end());
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                if (payload.count("enabled")) {
+                    config.enabled = enabled;
+                }
+                if (payload.count("heartbeat_interval_ms")) {
+                    config.heartbeat_interval_ms = static_cast<uint64_t>(interval);
+                }
+                if (payload.count("sampling_rate")) {
+                    config.sampling_rate = sampling_rate;
+                }
+                condition.notify_all();
+            }
+            return SuccessReply(command.command_id, nlohmann::json{{"applied", applied}, {"ignored", ignored}}.dump());
         };
         handlers["collection_metrics"] = [this](const TelemetryCommand& command) {
             std::lock_guard<std::mutex> lock(mutex);
@@ -627,8 +749,23 @@ class ClientTelemetryManager::Impl {
                 return SuccessReply(command.command_id, result.dump());
             }
             auto payload = nlohmann::json::parse(command.payload);
+            if (!payload.is_object()) {
+                throw std::invalid_argument("collection_metrics payload must be a JSON object");
+            }
+            if (payload.count("enabled") && !payload["enabled"].is_boolean()) {
+                throw std::invalid_argument("enabled must be a boolean");
+            }
+            if (payload.count("collections") && !payload["collections"].is_array()) {
+                throw std::invalid_argument("collections must be an array");
+            }
+            if (payload.count("metrics_types") && !payload["metrics_types"].is_array()) {
+                throw std::invalid_argument("metrics_types must be an array");
+            }
             bool enabled = payload.value("enabled", false);
             auto collections = payload.value("collections", std::vector<std::string>{});
+            if (payload.count("metrics_types")) {
+                (void)payload["metrics_types"].get<std::vector<std::string>>();
+            }
             bool wildcard = std::find(collections.begin(), collections.end(), "*") != collections.end();
             if (enabled) {
                 if (collections.empty()) {
@@ -651,7 +788,15 @@ class ClientTelemetryManager::Impl {
         };
         handlers["show_errors"] = [this](const TelemetryCommand& command) {
             auto payload = command.payload.empty() ? nlohmann::json::object() : nlohmann::json::parse(command.payload);
-            auto max_count = payload.value("max_count", static_cast<size_t>(100));
+            if (!payload.is_object()) {
+                throw std::invalid_argument("show_errors payload must be a JSON object");
+            }
+            if (payload.count("max_count") && !payload["max_count"].is_number_integer() &&
+                !payload["max_count"].is_number_unsigned()) {
+                throw std::invalid_argument("max_count must be an integer");
+            }
+            auto requested = payload.value("max_count", int64_t{100});
+            auto max_count = static_cast<size_t>(requested <= 0 ? 100 : requested);
             std::vector<TelemetryError> values;
             {
                 std::lock_guard<std::mutex> lock(mutex);
@@ -660,13 +805,20 @@ class ClientTelemetryManager::Impl {
                     values.push_back(*iterator);
                 }
             }
+            if (values.empty()) {
+                return SuccessReply(command.command_id);
+            }
             nlohmann::json result = nlohmann::json::array();
             for (const auto& error : values) {
-                result.push_back({{"timestamp", error.timestamp},
-                                  {"operation", error.operation},
-                                  {"error_msg", error.error_message},
-                                  {"collection", error.collection},
-                                  {"request_id", error.request_id}});
+                nlohmann::json detail = {
+                    {"timestamp", error.timestamp}, {"operation", error.operation}, {"error_msg", error.error_message}};
+                if (!error.collection.empty()) {
+                    detail["collection"] = error.collection;
+                }
+                if (!error.request_id.empty()) {
+                    detail["request_id"] = error.request_id;
+                }
+                result.push_back(std::move(detail));
             }
             while (result.dump().size() > kMaxReplyBytes && result.size() > 1) {
                 result.erase(result.begin() + result.size() / 2, result.end());
@@ -675,8 +827,8 @@ class ClientTelemetryManager::Impl {
             while (encoded.size() > kMaxReplyBytes && result.size() == 1 &&
                    result.at(0).value("error_msg", std::string{}).size() > 1) {
                 auto message = result.at(0).at("error_msg").get<std::string>();
-                result.at(0)["error_msg"] = message.substr(0, std::max<size_t>(1, message.size() / 2)) +
-                                               "...(truncated)";
+                result.at(0)["error_msg"] =
+                    message.substr(0, std::max<size_t>(1, message.size() / 2)) + "...(truncated)";
                 encoded = result.dump();
             }
             if (encoded.size() > kMaxReplyBytes) {
@@ -688,15 +840,15 @@ class ClientTelemetryManager::Impl {
             std::lock_guard<std::mutex> lock(mutex);
             std::vector<std::string> collections(enabled_collections.begin(), enabled_collections.end());
             std::sort(collections.begin(), collections.end());
-            nlohmann::json user_config = {{"address", uri},
-                                          {"username", username},
-                                          {"db_name", database},
-                                          {"telemetry_enabled", config.enabled},
-                                          {"telemetry_heartbeat_interval_ms", config.heartbeat_interval_ms},
-                                          {"telemetry_sampling_rate", config.sampling_rate},
-                                          {"enabled_collections",
-                                           all_collections_enabled ? std::vector<std::string>{"*"} : collections},
-                                          {"all_collections_enabled", all_collections_enabled}};
+            nlohmann::json user_config = {
+                {"address", uri},
+                {"username", username},
+                {"db_name", database},
+                {"telemetry_enabled", config.enabled},
+                {"telemetry_heartbeat_interval_ms", config.heartbeat_interval_ms},
+                {"telemetry_sampling_rate", config.sampling_rate},
+                {"enabled_collections", all_collections_enabled ? std::vector<std::string>{"*"} : collections},
+                {"all_collections_enabled", all_collections_enabled}};
             return SuccessReply(command.command_id, nlohmann::json{{"user_config", user_config}}.dump());
         };
         handlers["show_latency_history"] = [this](const TelemetryCommand& command) {
@@ -704,6 +856,12 @@ class ClientTelemetryManager::Impl {
                 throw std::invalid_argument("payload is required with start_time and end_time");
             }
             auto payload = nlohmann::json::parse(command.payload);
+            if (!payload.is_object()) {
+                throw std::invalid_argument("show_latency_history payload must be a JSON object");
+            }
+            if (payload.count("detail") && !payload["detail"].is_boolean()) {
+                throw std::invalid_argument("detail must be a boolean");
+            }
             int64_t start = ParseRfc3339Millis(payload.at("start_time").get<std::string>());
             int64_t end = ParseRfc3339Millis(payload.at("end_time").get<std::string>());
             if (end < start) {
@@ -727,7 +885,7 @@ class ClientTelemetryManager::Impl {
             if (payload.value("detail", false)) {
                 response["snapshots"] = nlohmann::json::array();
                 for (const auto& snapshot : selected) {
-                    nlohmann::json metrics;
+                    nlohmann::json metrics = nlohmann::json::object();
                     for (const auto& operation : snapshot.metrics) {
                         metrics[operation.operation] = MetricJson(operation.global);
                     }
@@ -756,18 +914,16 @@ class ClientTelemetryManager::Impl {
                         total.maximum = std::max(total.maximum, operation.global.max_latency_ms);
                     }
                 }
-                nlohmann::json metrics;
+                nlohmann::json metrics = nlohmann::json::object();
                 for (const auto& entry : totals) {
-                    metrics[entry.first] = {{"request_count", entry.second.requests},
-                                            {"success_count", entry.second.successes},
-                                            {"error_count", entry.second.errors},
-                                            {"avg_latency_ms", entry.second.requests == 0
-                                                                   ? 0
-                                                                   : entry.second.average / entry.second.requests},
-                                            {"p99_latency_ms", entry.second.requests == 0
-                                                                   ? 0
-                                                                   : entry.second.p99 / entry.second.requests},
-                                            {"max_latency_ms", entry.second.maximum}};
+                    metrics[entry.first] = {
+                        {"request_count", entry.second.requests},
+                        {"success_count", entry.second.successes},
+                        {"error_count", entry.second.errors},
+                        {"avg_latency_ms",
+                         entry.second.requests == 0 ? 0 : entry.second.average / entry.second.requests},
+                        {"p99_latency_ms", entry.second.requests == 0 ? 0 : entry.second.p99 / entry.second.requests},
+                        {"max_latency_ms", entry.second.maximum}};
                 }
                 response = {{"aggregated", {{"start_time", start}, {"end_time", end}, {"metrics", metrics}}},
                             {"snapshot_count", selected.size()}};
@@ -783,13 +939,16 @@ class ClientTelemetryManager::Impl {
     mutable std::mutex mutex;
     std::condition_variable condition;
     TelemetryConfig config;
+    const TelemetryConfig connection_config;
     const bool stable_client_id;
     const std::string client_id;
-    std::unique_ptr<proto::milvus::ClientTelemetryService::Stub> stub;
+    std::shared_ptr<proto::milvus::ClientTelemetryService::Stub> stub;
+    uint64_t channel_generation{0};
     std::string username;
     std::string database;
     std::string uri;
     std::string sdk_version;
+    std::string connection_scope;
     std::unordered_map<std::string, OperationCollector> collectors;
     std::deque<TelemetryError> errors;
     std::deque<TelemetrySnapshot> snapshots;
@@ -810,6 +969,7 @@ class ClientTelemetryManager::Impl {
     std::string config_hash;
     std::string last_heartbeat_error;
     std::thread worker;
+    std::recursive_mutex command_mutex;
 };
 
 ClientTelemetryManager::ClientTelemetryManager(const TelemetryConfig& config, const std::string& runtime_client_id)
@@ -821,8 +981,8 @@ ClientTelemetryManager::~ClientTelemetryManager() = default;
 void
 ClientTelemetryManager::AttachChannel(const std::shared_ptr<grpc::Channel>& channel, const std::string& username,
                                       const std::string& database, const std::string& uri,
-                                      const std::string& sdk_version) {
-    impl_->AttachChannel(channel, username, database, uri, sdk_version);
+                                      const std::string& sdk_version, const std::string& connection_scope) {
+    impl_->AttachChannel(channel, username, database, uri, sdk_version, connection_scope);
 }
 
 void
@@ -876,6 +1036,13 @@ ClientTelemetryManager::Config() const {
     return impl_->config;
 }
 
+bool
+ClientTelemetryManager::MatchesConnection(const TelemetryConfig& config, const std::string& connection_scope) const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->connection_scope == connection_scope &&
+           SameTelemetryConfig(impl_->connection_config, NormalizedTelemetryConfig(config));
+}
+
 std::string
 ClientTelemetryManager::LastHeartbeatError() const {
     std::lock_guard<std::mutex> lock(impl_->mutex);
@@ -892,13 +1059,22 @@ void
 ClientTelemetryManager::RecordOperation(const std::string& operation, const google::protobuf::Message& request,
                                         std::chrono::steady_clock::time_point started, bool success,
                                         const std::string& error_message, const std::string& request_id) {
-    static const std::unordered_set<std::string> operations = {"Insert", "Delete", "Upsert", "Search",
-                                                                "HybridSearch", "Query", "RunAnalyzer"};
+    RecordOperation(operation, operation == "RunAnalyzer" ? std::string{} : CollectionName(request), started, success,
+                    error_message, request_id);
+}
+
+void
+ClientTelemetryManager::RecordOperation(const std::string& operation, const std::string& collection,
+                                        std::chrono::steady_clock::time_point started, bool success,
+                                        const std::string& error_message, const std::string& request_id) {
+    static const std::unordered_set<std::string> operations = {"Insert",       "Delete", "Upsert",     "Search",
+                                                               "HybridSearch", "Query",  "RunAnalyzer"};
     if (operations.count(operation) == 0) {
         return;
     }
-    auto latency = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - started).count();
-    auto collection = CollectionName(request);
+    auto latency_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - started).count();
+    auto latency = static_cast<double>(latency_us) / 1000.0;
     std::lock_guard<std::mutex> lock(impl_->mutex);
     if (!impl_->config.enabled) {
         return;
@@ -930,7 +1106,8 @@ ClientTelemetryManager::RecordOperation(const std::string& operation, const goog
         collector.collections[collection].Record(latency, success);
     }
     if (!success) {
-        impl_->errors.push_back({NowMillis(), operation, error_message, collection, request_id});
+        impl_->errors.push_back({NowMillis(), operation, error_message, collection,
+                                 ClientRequestContext::IsValid(request_id) ? request_id : std::string{}});
         while (impl_->errors.size() > impl_->config.error_max_count) {
             impl_->errors.pop_front();
         }
@@ -954,6 +1131,12 @@ ClientTelemetryManager::MetricsSnapshots() const {
     return {impl_->snapshots.begin(), impl_->snapshots.end()};
 }
 
+std::vector<TelemetryCommandReply>
+ClientTelemetryManager::PendingCommandReplies() const {
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+    return impl_->pending_replies;
+}
+
 void
 ClientTelemetryManager::ProcessCommands(const std::vector<TelemetryCommand>& commands) {
     impl_->ProcessCommands(commands);
@@ -970,10 +1153,9 @@ ClientTelemetryManager::CalculateConfigHash(const std::vector<TelemetryCommand>&
     if (persistent.empty()) {
         return "";
     }
-    std::sort(persistent.begin(), persistent.end(),
-              [](const TelemetryCommand& left, const TelemetryCommand& right) {
-                  return left.command_id < right.command_id;
-              });
+    std::sort(persistent.begin(), persistent.end(), [](const TelemetryCommand& left, const TelemetryCommand& right) {
+        return left.command_id < right.command_id;
+    });
     Sha256 hash;
     for (const auto& command : persistent) {
         hash.Update(command.command_id);

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -47,7 +47,11 @@ namespace {
 
 constexpr size_t kSampleBufferSize = 1000;
 constexpr size_t kSnapshotLimit = 120;
-constexpr uint64_t kSamplingDenominator = 10000;
+// Fixed-point unit for accumulating a fractional sampling rate. A rate becomes an integer
+// step of this many units, so the smallest rate that still samples is 1e-9 -- far below
+// anything an operator would set, which is the point: a configured rate must never round
+// down to "off".
+constexpr uint64_t kSamplingScale = 1000000000ULL;
 constexpr size_t kMaxReplyBytes = 1024 * 1024;
 constexpr uint64_t kMaxUnsupportedBackoffMs = 30 * 60 * 1000;
 
@@ -797,7 +801,10 @@ class ClientTelemetryManager::Impl {
     bool ready{false};
     bool stopped{true};
     int unsupported_streak{0};
-    uint64_t sampling_counter{0};
+    // Carries the fractional sampling rate between operations, in kSamplingScale units:
+    // each operation adds the rate and the one that pushes it past a whole unit is the one
+    // sampled.
+    uint64_t sampling_accum{0};
     int64_t last_command_timestamp{0};
     int64_t last_snapshot_end{0};
     std::string config_hash;
@@ -899,8 +906,19 @@ ClientTelemetryManager::RecordOperation(const std::string& operation, const goog
     auto rate = impl_->config.sampling_rate;
     bool sampled = rate >= 1.0;
     if (rate > 0.0 && rate < 1.0) {
-        auto threshold = static_cast<uint64_t>(rate * kSamplingDenominator);
-        sampled = threshold > 0 && ++impl_->sampling_counter % kSamplingDenominator < threshold;
+        // Sample on the operation that carries the accumulator across a whole unit, so the
+        // sampled operations are spread evenly: at 0.25 that is every fourth one. The
+        // ratio has to hold over any stretch of operations, not only over a long one --
+        // metrics are reported per heartbeat window, and a window is tens or hundreds of
+        // operations, so sampling a contiguous run would make each window either complete
+        // or empty. A rate too small to represent still samples rarely rather than never.
+        auto step = static_cast<uint64_t>(rate * kSamplingScale);
+        if (step == 0) {
+            step = 1;
+        }
+        auto before = impl_->sampling_accum;
+        impl_->sampling_accum = before + step;
+        sampled = impl_->sampling_accum / kSamplingScale != before / kSamplingScale;
     }
     if (!sampled) {
         return;

--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -1231,7 +1231,7 @@ ClientTelemetryManager::IsReady() const {
 }
 
 bool
-ClientTelemetryManager::IsWorkerThread() const {
+ClientTelemetryManager::isWorkerThread() const {
     std::lock_guard<std::mutex> lock(impl_->mutex);
     return impl_->worker_running && impl_->worker_id == std::this_thread::get_id();
 }

--- a/src/impl/MilvusClientImpl.cpp
+++ b/src/impl/MilvusClientImpl.cpp
@@ -56,6 +56,11 @@ MilvusClientImpl::Disconnect() {
     return connection_.Disconnect();
 }
 
+ClientTelemetryManagerPtr
+MilvusClientImpl::GetTelemetry() const {
+    return connection_.GetTelemetry();
+}
+
 Status
 MilvusClientImpl::SetRpcDeadlineMs(uint64_t timeout_ms) {
     return connection_.SetRpcDeadlineMs(timeout_ms);

--- a/src/impl/MilvusClientImpl.cpp
+++ b/src/impl/MilvusClientImpl.cpp
@@ -40,7 +40,27 @@ namespace milvus {
 
 std::shared_ptr<MilvusClient>
 MilvusClient::Create() {
-    return std::make_shared<MilvusClientImpl>();
+    return std::shared_ptr<MilvusClient>(new MilvusClientImpl(), [](MilvusClientImpl* client) noexcept {
+        auto telemetry = client->GetTelemetry();
+        if (telemetry != nullptr && telemetry->IsWorkerThread()) {
+            // The global topology refresher may be waiting for this command handler before
+            // it can hand off the telemetry channel. Deleting the embedded ConnectionHandler
+            // here would join that refresher and deadlock. Stop/join the telemetry worker on
+            // another thread, then delete after the handler has returned.
+            try {
+                std::thread([client, telemetry = std::move(telemetry)]() {
+                    telemetry->Stop();
+                    delete client;
+                }).detach();
+            } catch (...) {
+                // A deleter must not throw. If the process cannot create the one-shot
+                // cleanup thread, intentionally retain the client rather than terminate
+                // or re-enter the known refresher/command join cycle.
+            }
+            return;
+        }
+        delete client;
+    });
 }
 
 MilvusClientImpl::~MilvusClientImpl() {

--- a/src/impl/MilvusClientImpl.cpp
+++ b/src/impl/MilvusClientImpl.cpp
@@ -20,7 +20,6 @@
 #include <chrono>
 #include <cstdlib>
 #include <milvus/thirdparty/nlohmann/json.hpp>
-#include <thread>
 #include <type_traits>
 
 #include "rg.pb.h"
@@ -42,24 +41,8 @@ std::shared_ptr<MilvusClient>
 MilvusClient::Create() {
     return std::shared_ptr<MilvusClient>(new MilvusClientImpl(), [](MilvusClientImpl* client) noexcept {
         auto telemetry = client->GetTelemetry();
-        if (telemetry != nullptr && telemetry->IsWorkerThread()) {
-            // The global topology refresher may be waiting for this command handler before
-            // it can hand off the telemetry channel. Deleting the embedded ConnectionHandler
-            // here would join that refresher and deadlock. Stop/join the telemetry worker on
-            // another thread, then delete after the handler has returned.
-            try {
-                std::thread([client, telemetry = std::move(telemetry)]() {
-                    telemetry->Stop();
-                    delete client;
-                }).detach();
-            } catch (...) {
-                // A deleter must not throw. If the process cannot create the one-shot
-                // cleanup thread, intentionally retain the client rather than terminate
-                // or re-enter the known refresher/command join cycle.
-            }
-            return;
-        }
-        delete client;
+        const bool called_from_telemetry_worker = telemetry != nullptr && telemetry->IsWorkerThread();
+        DeleteClientWithTelemetryWorkerSafety(client, std::move(telemetry), called_from_telemetry_worker);
     });
 }
 

--- a/src/impl/MilvusClientImpl.cpp
+++ b/src/impl/MilvusClientImpl.cpp
@@ -31,6 +31,7 @@
 #include "utils/DmlUtils.h"
 #include "utils/DqlUtils.h"
 #include "utils/FieldDataSchema.h"
+#include "utils/TelemetryUtils.h"
 #include "utils/TypeUtils.h"
 #include "utils/cache/CollectionTsCache.h"
 #include "utils/cache/SchemaCache.h"
@@ -983,7 +984,8 @@ MilvusClientImpl::DropIndexProperties(const std::string& collection_name, const 
 Status
 MilvusClientImpl::Insert(const std::string& collection_name, const std::string& partition_name,
                          const std::vector<FieldDataPtr>& fields, DmlResults& results) {
-    return insert(collection_name, partition_name, fields, results, true);
+    return InvokeWithTelemetry(connection_, "Insert", collection_name,
+                               [&]() { return insert(collection_name, partition_name, fields, results, true); });
 }
 
 Status
@@ -1062,7 +1064,8 @@ MilvusClientImpl::insert(const std::string& collection_name, const std::string& 
 Status
 MilvusClientImpl::Insert(const std::string& collection_name, const std::string& partition_name, const EntityRows& rows,
                          DmlResults& results) {
-    return insert(collection_name, partition_name, rows, results, true);
+    return InvokeWithTelemetry(connection_, "Insert", collection_name,
+                               [&]() { return insert(collection_name, partition_name, rows, results, true); });
 }
 
 Status
@@ -1135,7 +1138,8 @@ MilvusClientImpl::insert(const std::string& collection_name, const std::string& 
 Status
 MilvusClientImpl::Upsert(const std::string& collection_name, const std::string& partition_name,
                          const std::vector<FieldDataPtr>& fields, DmlResults& results) {
-    return upsert(collection_name, partition_name, fields, results, true);
+    return InvokeWithTelemetry(connection_, "Upsert", collection_name,
+                               [&]() { return upsert(collection_name, partition_name, fields, results, true); });
 }
 
 Status
@@ -1231,7 +1235,8 @@ MilvusClientImpl::upsert(const std::string& collection_name, const std::string& 
 Status
 MilvusClientImpl::Upsert(const std::string& collection_name, const std::string& partition_name, const EntityRows& rows,
                          DmlResults& results) {
-    return upsert(collection_name, partition_name, rows, results, true);
+    return InvokeWithTelemetry(connection_, "Upsert", collection_name,
+                               [&]() { return upsert(collection_name, partition_name, rows, results, true); });
 }
 
 Status
@@ -1326,8 +1331,10 @@ MilvusClientImpl::Delete(const std::string& collection_name, const std::string& 
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::DeleteRequest, proto::milvus::MutationResult>(
-        pre, &MilvusConnection::Delete, post);
+    return InvokeWithTelemetry(connection_, "Delete", collection_name, [&]() {
+        return connection_.Invoke<proto::milvus::DeleteRequest, proto::milvus::MutationResult>(
+            pre, &MilvusConnection::Delete, post);
+    });
 }
 
 Status
@@ -1355,8 +1362,10 @@ MilvusClientImpl::Search(const SearchArguments& arguments, SearchResults& result
         return ConvertSearchResults(response, pk_name, results);
     };
 
-    return connection_.Invoke<proto::milvus::SearchRequest, proto::milvus::SearchResults>(
-        validate, pre, &MilvusConnection::Search, nullptr, post);
+    return InvokeWithTelemetry(connection_, "Search", arguments.CollectionName(), [&]() {
+        return connection_.Invoke<proto::milvus::SearchRequest, proto::milvus::SearchResults>(
+            validate, pre, &MilvusConnection::Search, nullptr, post);
+    });
 }
 
 Status
@@ -1451,8 +1460,10 @@ MilvusClientImpl::HybridSearch(const HybridSearchArguments& arguments, SearchRes
         return ConvertSearchResults(response, pk_name, results);
     };
 
-    return connection_.Invoke<proto::milvus::HybridSearchRequest, proto::milvus::SearchResults>(
-        validate, pre, &MilvusConnection::HybridSearch, nullptr, post);
+    return InvokeWithTelemetry(connection_, "HybridSearch", arguments.CollectionName(), [&]() {
+        return connection_.Invoke<proto::milvus::HybridSearchRequest, proto::milvus::SearchResults>(
+            validate, pre, &MilvusConnection::HybridSearch, nullptr, post);
+    });
 }
 
 Status
@@ -1466,8 +1477,10 @@ MilvusClientImpl::Query(const QueryArguments& arguments, QueryResults& results) 
     auto post = [&results](const proto::milvus::QueryResults& response) {
         return ConvertQueryResults(response, results);
     };
-    return connection_.Invoke<proto::milvus::QueryRequest, proto::milvus::QueryResults>(pre, &MilvusConnection::Query,
-                                                                                        post);
+    return InvokeWithTelemetry(connection_, "Query", arguments.CollectionName(), [&]() {
+        return connection_.Invoke<proto::milvus::QueryRequest, proto::milvus::QueryResults>(
+            pre, &MilvusConnection::Query, post);
+    });
 }
 
 Status
@@ -1534,8 +1547,10 @@ MilvusClientImpl::RunAnalyzer(const RunAnalyzerArguments& arguments, AnalyzerRes
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::RunAnalyzerRequest, proto::milvus::RunAnalyzerResponse>(
-        pre, &MilvusConnection::RunAnalyzer, post);
+    return InvokeWithTelemetry(connection_, "RunAnalyzer", "", [&]() {
+        return connection_.Invoke<proto::milvus::RunAnalyzerRequest, proto::milvus::RunAnalyzerResponse>(
+            pre, &MilvusConnection::RunAnalyzer, post);
+    });
 }
 
 Status

--- a/src/impl/MilvusClientImpl.cpp
+++ b/src/impl/MilvusClientImpl.cpp
@@ -39,11 +39,11 @@ namespace milvus {
 
 std::shared_ptr<MilvusClient>
 MilvusClient::Create() {
-    return std::shared_ptr<MilvusClient>(new MilvusClientImpl(), [](MilvusClientImpl* client) noexcept {
-        auto telemetry = client->GetTelemetry();
-        const bool called_from_telemetry_worker = telemetry != nullptr && telemetry->IsWorkerThread();
-        DeleteClientWithTelemetryWorkerSafety(client, std::move(telemetry), called_from_telemetry_worker);
-    });
+    return {new MilvusClientImpl(), [](MilvusClientImpl* client) noexcept {
+                auto telemetry = client->GetTelemetry();
+                const bool called_from_telemetry_worker = telemetry != nullptr && telemetry->isWorkerThread();
+                DeleteClientWithTelemetryWorkerSafety(client, std::move(telemetry), called_from_telemetry_worker);
+            }};
 }
 
 MilvusClientImpl::~MilvusClientImpl() {

--- a/src/impl/MilvusClientImpl.h
+++ b/src/impl/MilvusClientImpl.h
@@ -37,6 +37,9 @@ class MilvusClientImpl : public MilvusClient {
     Status
     Disconnect() final;
 
+    ClientTelemetryManagerPtr
+    GetTelemetry() const final;
+
     Status
     SetRpcDeadlineMs(uint64_t timeout_ms) final;
 

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -74,6 +74,11 @@ MilvusClientV2Impl::Disconnect() {
     return connection_.Disconnect();
 }
 
+ClientTelemetryManagerPtr
+MilvusClientV2Impl::GetTelemetry() const {
+    return connection_.GetTelemetry();
+}
+
 Status
 MilvusClientV2Impl::SetRpcDeadlineMs(uint64_t timeout_ms) {
     return connection_.SetRpcDeadlineMs(timeout_ms);

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -43,7 +43,24 @@ namespace milvus {
 
 std::shared_ptr<MilvusClientV2>
 MilvusClientV2::Create() {
-    return std::make_shared<MilvusClientV2Impl>();
+    return std::shared_ptr<MilvusClientV2>(new MilvusClientV2Impl(), [](MilvusClientV2Impl* client) noexcept {
+        auto telemetry = client->GetTelemetry();
+        if (telemetry != nullptr && telemetry->IsWorkerThread()) {
+            // See the V1 factory: destruction from a heartbeat command must not join a
+            // global refresher that is waiting for that same command to finish.
+            try {
+                std::thread([client, telemetry = std::move(telemetry)]() {
+                    telemetry->Stop();
+                    delete client;
+                }).detach();
+            } catch (...) {
+                // A deleter must not throw. If cleanup cannot be deferred safely,
+                // retain the client rather than terminate or deadlock here.
+            }
+            return;
+        }
+        delete client;
+    });
 }
 
 MilvusClientV2Impl::~MilvusClientV2Impl() {

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -42,11 +42,11 @@ namespace milvus {
 
 std::shared_ptr<MilvusClientV2>
 MilvusClientV2::Create() {
-    return std::shared_ptr<MilvusClientV2>(new MilvusClientV2Impl(), [](MilvusClientV2Impl* client) noexcept {
-        auto telemetry = client->GetTelemetry();
-        const bool called_from_telemetry_worker = telemetry != nullptr && telemetry->IsWorkerThread();
-        DeleteClientWithTelemetryWorkerSafety(client, std::move(telemetry), called_from_telemetry_worker);
-    });
+    return {new MilvusClientV2Impl(), [](MilvusClientV2Impl* client) noexcept {
+                auto telemetry = client->GetTelemetry();
+                const bool called_from_telemetry_worker = telemetry != nullptr && telemetry->isWorkerThread();
+                DeleteClientWithTelemetryWorkerSafety(client, std::move(telemetry), called_from_telemetry_worker);
+            }};
 }
 
 MilvusClientV2Impl::~MilvusClientV2Impl() {

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -34,6 +34,7 @@
 #include "utils/DqlUtils.h"
 #include "utils/FieldDataSchema.h"
 #include "utils/MiscUtils.h"
+#include "utils/TelemetryUtils.h"
 #include "utils/TypeUtils.h"
 #include "utils/cache/CollectionTsCache.h"
 #include "utils/cache/SchemaCache.h"
@@ -1717,7 +1718,8 @@ MilvusClientV2Impl::DropIndexProperties(const DropIndexPropertiesRequest& reques
 
 Status
 MilvusClientV2Impl::Insert(const InsertRequest& request, InsertResponse& response) {
-    return insert(request, response, true);
+    return InvokeWithTelemetry(connection_, "Insert", request.CollectionName(),
+                               [&]() { return insert(request, response, true); });
 }
 
 Status
@@ -1835,7 +1837,8 @@ MilvusClientV2Impl::insert(const InsertRequest& request, InsertResponse& respons
 
 Status
 MilvusClientV2Impl::Upsert(const UpsertRequest& request, UpsertResponse& response) {
-    return upsert(request, response, true);
+    return InvokeWithTelemetry(connection_, "Upsert", request.CollectionName(),
+                               [&]() { return upsert(request, response, true); });
 }
 
 Status
@@ -2027,8 +2030,10 @@ MilvusClientV2Impl::Delete(const DeleteRequest& request, DeleteResponse& respons
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::DeleteRequest, proto::milvus::MutationResult>(
-        pre, &MilvusConnection::Delete, post);
+    return InvokeWithTelemetry(connection_, "Delete", request.CollectionName(), [&]() {
+        return connection_.Invoke<proto::milvus::DeleteRequest, proto::milvus::MutationResult>(
+            pre, &MilvusConnection::Delete, post);
+    });
 }
 
 Status
@@ -2088,8 +2093,10 @@ MilvusClientV2Impl::search(const SearchRequest& request, SearchResponse& respons
         return status;
     };
 
-    return connection_.Invoke<proto::milvus::SearchRequest, proto::milvus::SearchResults>(
-        validate, pre, &MilvusConnection::Search, nullptr, post);
+    return InvokeWithTelemetry(connection_, "Search", request.CollectionName(), [&]() {
+        return connection_.Invoke<proto::milvus::SearchRequest, proto::milvus::SearchResults>(
+            validate, pre, &MilvusConnection::Search, nullptr, post);
+    });
 }
 
 Status
@@ -2211,8 +2218,10 @@ MilvusClientV2Impl::hybridSearch(const HybridSearchRequest& request, HybridSearc
         return status;
     };
 
-    return connection_.Invoke<proto::milvus::HybridSearchRequest, proto::milvus::SearchResults>(
-        pre, &MilvusConnection::HybridSearch, post);
+    return InvokeWithTelemetry(connection_, "HybridSearch", request.CollectionName(), [&]() {
+        return connection_.Invoke<proto::milvus::HybridSearchRequest, proto::milvus::SearchResults>(
+            pre, &MilvusConnection::HybridSearch, post);
+    });
 }
 
 Status
@@ -2224,7 +2233,7 @@ MilvusClientV2Impl::Query(const QueryRequest& request, QueryResponse& response) 
 
 Status
 MilvusClientV2Impl::query(const std::string& endpoint, const std::string& database_name, const QueryRequest& request,
-                          QueryResponse& response, const std::string& cluster_id) {
+                          QueryResponse& response, const std::string& cluster_id, bool record_telemetry) {
     auto pre = [this, &endpoint, &database_name, &request, &cluster_id](proto::milvus::QueryRequest& rpc_request) {
         const auto id_count = request.IDs().GetRowCount();
         if (!request.Filter().empty() && id_count != 0) {
@@ -2267,8 +2276,11 @@ MilvusClientV2Impl::query(const std::string& endpoint, const std::string& databa
         return status;
     };
 
-    return connection_.Invoke<proto::milvus::QueryRequest, proto::milvus::QueryResults>(pre, &MilvusConnection::Query,
-                                                                                        post);
+    auto invoke = [&]() {
+        return connection_.Invoke<proto::milvus::QueryRequest, proto::milvus::QueryResults>(
+            pre, &MilvusConnection::Query, post);
+    };
+    return record_telemetry ? InvokeWithTelemetry(connection_, "Query", request.CollectionName(), invoke) : invoke();
 }
 
 Status
@@ -2278,6 +2290,13 @@ MilvusClientV2Impl::Get(const GetRequest& request, GetResponse& response) {
 
 Status
 MilvusClientV2Impl::get(const GetRequest& request, GetResponse& response, const std::string& cluster_id) {
+    return InvokeWithTelemetry(connection_, "Query", request.CollectionName(),
+                               [&]() { return getWithoutTelemetry(request, response, cluster_id); });
+}
+
+Status
+MilvusClientV2Impl::getWithoutTelemetry(const GetRequest& request, GetResponse& response,
+                                        const std::string& cluster_id) {
     const auto endpoint = connection_.CurrentEndpoint();
     const auto database_name = connection_.CurrentDbName(request.DatabaseName());
     CollectionDescPtr collection_desc;
@@ -2313,7 +2332,7 @@ MilvusClientV2Impl::get(const GetRequest& request, GetResponse& response, const 
                               .AddFilterTemplate(ids_key, filter_template)
                               .WithOutputFields(std::move(output_fields));
 
-    return query(endpoint, database_name, actual_request, response, cluster_id);
+    return query(endpoint, database_name, actual_request, response, cluster_id, false);
 }
 
 Status
@@ -2390,8 +2409,10 @@ MilvusClientV2Impl::RunAnalyzer(const RunAnalyzerRequest& request, RunAnalyzerRe
         return Status::OK();
     };
 
-    return connection_.Invoke<proto::milvus::RunAnalyzerRequest, proto::milvus::RunAnalyzerResponse>(
-        pre, &MilvusConnection::RunAnalyzer, post);
+    return InvokeWithTelemetry(connection_, "RunAnalyzer", "", [&]() {
+        return connection_.Invoke<proto::milvus::RunAnalyzerRequest, proto::milvus::RunAnalyzerResponse>(
+            pre, &MilvusConnection::RunAnalyzer, post);
+    });
 }
 
 Status

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -20,7 +20,6 @@
 #include <chrono>
 #include <milvus/thirdparty/nlohmann/json.hpp>
 #include <set>
-#include <thread>
 #include <type_traits>
 #include <unordered_set>
 
@@ -45,21 +44,8 @@ std::shared_ptr<MilvusClientV2>
 MilvusClientV2::Create() {
     return std::shared_ptr<MilvusClientV2>(new MilvusClientV2Impl(), [](MilvusClientV2Impl* client) noexcept {
         auto telemetry = client->GetTelemetry();
-        if (telemetry != nullptr && telemetry->IsWorkerThread()) {
-            // See the V1 factory: destruction from a heartbeat command must not join a
-            // global refresher that is waiting for that same command to finish.
-            try {
-                std::thread([client, telemetry = std::move(telemetry)]() {
-                    telemetry->Stop();
-                    delete client;
-                }).detach();
-            } catch (...) {
-                // A deleter must not throw. If cleanup cannot be deferred safely,
-                // retain the client rather than terminate or deadlock here.
-            }
-            return;
-        }
-        delete client;
+        const bool called_from_telemetry_worker = telemetry != nullptr && telemetry->IsWorkerThread();
+        DeleteClientWithTelemetryWorkerSafety(client, std::move(telemetry), called_from_telemetry_worker);
     });
 }
 

--- a/src/impl/MilvusClientV2Impl.h
+++ b/src/impl/MilvusClientV2Impl.h
@@ -37,6 +37,9 @@ class MilvusClientV2Impl : public MilvusClientV2, public std::enable_shared_from
     Status
     Disconnect() final;
 
+    ClientTelemetryManagerPtr
+    GetTelemetry() const final;
+
     Status
     SetRpcDeadlineMs(uint64_t timeout_ms) final;
 

--- a/src/impl/MilvusClientV2Impl.h
+++ b/src/impl/MilvusClientV2Impl.h
@@ -441,10 +441,13 @@ class MilvusClientV2Impl : public MilvusClientV2, public std::enable_shared_from
 
     Status
     query(const std::string& endpoint, const std::string& database_name, const QueryRequest& request,
-          QueryResponse& response, const std::string& cluster_id);
+          QueryResponse& response, const std::string& cluster_id, bool record_telemetry = true);
 
     Status
     get(const GetRequest& request, GetResponse& response, const std::string& cluster_id);
+
+    Status
+    getWithoutTelemetry(const GetRequest& request, GetResponse& response, const std::string& cluster_id);
 
     Status
     queryIterator(QueryIteratorRequest& request, QueryIteratorPtr& iterator, const std::string& cluster_id);

--- a/src/impl/MilvusConnection.cpp
+++ b/src/impl/MilvusConnection.cpp
@@ -103,7 +103,8 @@ MilvusConnection::StatusCodeFromGrpcStatus(const ::grpc::Status& grpc_status) {
 }
 
 Status
-MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_telemetry_client_id) {
+MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_telemetry_client_id,
+                          ClientTelemetryManagerPtr reusable_telemetry) {
     std::shared_ptr<grpc::Channel> channel;
     try {
         // ParseURI() might throw exceptions when the uri/port is invalid
@@ -154,7 +155,13 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
     auto stub = std::shared_ptr<Stub>(std::move(stub_holder));
     auto reusable_client_id =
         runtime_telemetry_client_id.empty() ? telemetry_client_id_ : runtime_telemetry_client_id;
-    auto telemetry = std::make_shared<ClientTelemetryManager>(param.Telemetry(), reusable_client_id);
+    const auto& configured_client_id = param.Telemetry().client_id;
+    const bool can_reuse_telemetry = reusable_telemetry != nullptr &&
+                                     (configured_client_id.empty() ||
+                                      configured_client_id == reusable_telemetry->ClientId());
+    auto telemetry = can_reuse_telemetry
+                         ? std::move(reusable_telemetry)
+                         : std::make_shared<ClientTelemetryManager>(param.Telemetry(), reusable_client_id);
 
     // grpc channel has been create, now we call the proto::milvus::MilvusClient::Connect() interface
     // to send some basic information of client to the server, including the sdk type, version, etc.
@@ -219,13 +226,13 @@ MilvusConnection::GetTelemetry() const {
 }
 
 Status
-MilvusConnection::Disconnect() {
+MilvusConnection::Disconnect(bool stop_telemetry) {
     ClientTelemetryManagerPtr telemetry;
     {
         std::lock_guard<std::mutex> lock(stub_mtx_);
         telemetry = telemetry_;
     }
-    if (telemetry != nullptr) {
+    if (stop_telemetry && telemetry != nullptr) {
         telemetry->Stop();
     }
     std::lock_guard<std::mutex> lock(stub_mtx_);
@@ -237,9 +244,10 @@ MilvusConnection::Disconnect() {
 
 Status
 MilvusConnection::UseDatabase(const std::string& db_name) {
+    auto telemetry = GetTelemetry();
     Disconnect();
     param_.SetDbName(db_name);
-    return Connect(param_, telemetry_client_id_);
+    return Connect(param_, telemetry_client_id_, std::move(telemetry));
 }
 
 Status

--- a/src/impl/MilvusConnection.cpp
+++ b/src/impl/MilvusConnection.cpp
@@ -103,7 +103,7 @@ MilvusConnection::StatusCodeFromGrpcStatus(const ::grpc::Status& grpc_status) {
 }
 
 Status
-MilvusConnection::Connect(const ConnectParam& param) {
+MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_telemetry_client_id) {
     std::shared_ptr<grpc::Channel> channel;
     try {
         // ParseURI() might throw exceptions when the uri/port is invalid
@@ -152,6 +152,9 @@ MilvusConnection::Connect(const ConnectParam& param) {
 
     auto stub_holder = proto::milvus::MilvusService::NewStub(channel);
     auto stub = std::shared_ptr<Stub>(std::move(stub_holder));
+    auto reusable_client_id =
+        runtime_telemetry_client_id.empty() ? telemetry_client_id_ : runtime_telemetry_client_id;
+    auto telemetry = std::make_shared<ClientTelemetryManager>(param.Telemetry(), reusable_client_id);
 
     // grpc channel has been create, now we call the proto::milvus::MilvusClient::Connect() interface
     // to send some basic information of client to the server, including the sdk type, version, etc.
@@ -189,12 +192,18 @@ MilvusConnection::Connect(const ConnectParam& param) {
         return status;
     }
 
+    auto database = param.DbName().empty() ? "default" : param.DbName();
+    telemetry->AttachChannel(channel, param.Username(), database, param.Host() + ":" + std::to_string(param.Port()),
+                             GetBuildVersion());
     {
         std::lock_guard<std::mutex> lock(stub_mtx_);
         param_ = param;
         channel_ = std::move(channel);
         stub_ = std::move(stub);
+        telemetry_ = telemetry;
+        telemetry_client_id_ = telemetry->ClientId();
     }
+    telemetry->Start();
     return Status::OK();
 }
 
@@ -203,11 +212,26 @@ MilvusConnection::GetConnectParam() {
     return param_;
 }
 
+ClientTelemetryManagerPtr
+MilvusConnection::GetTelemetry() const {
+    std::lock_guard<std::mutex> lock(stub_mtx_);
+    return telemetry_;
+}
+
 Status
 MilvusConnection::Disconnect() {
+    ClientTelemetryManagerPtr telemetry;
+    {
+        std::lock_guard<std::mutex> lock(stub_mtx_);
+        telemetry = telemetry_;
+    }
+    if (telemetry != nullptr) {
+        telemetry->Stop();
+    }
     std::lock_guard<std::mutex> lock(stub_mtx_);
     stub_.reset();
     channel_.reset();
+    telemetry_.reset();
     return Status::OK();
 }
 
@@ -215,7 +239,7 @@ Status
 MilvusConnection::UseDatabase(const std::string& db_name) {
     Disconnect();
     param_.SetDbName(db_name);
-    return Connect(param_);
+    return Connect(param_, telemetry_client_id_);
 }
 
 Status

--- a/src/impl/MilvusConnection.cpp
+++ b/src/impl/MilvusConnection.cpp
@@ -199,8 +199,7 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
         return status;
     }
 
-    auto database = param.DbName().empty() ? "default" : param.DbName();
-    telemetry->AttachChannel(channel, param.Username(), database, telemetry_endpoint, GetBuildVersion(),
+    telemetry->AttachChannel(channel, param.Username(), param.DbName(), telemetry_endpoint, GetBuildVersion(),
                              connection_scope);
     {
         std::lock_guard<std::mutex> lock(stub_mtx_);

--- a/src/impl/MilvusConnection.cpp
+++ b/src/impl/MilvusConnection.cpp
@@ -106,11 +106,12 @@ Status
 MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_telemetry_client_id,
                           ClientTelemetryManagerPtr reusable_telemetry) {
     std::shared_ptr<grpc::Channel> channel;
+    std::string telemetry_endpoint;
     try {
         // ParseURI() might throw exceptions when the uri/port is invalid
         std::shared_ptr<grpc::ChannelCredentials> credentials{nullptr};
         auto uri = ParseURI(param.Uri());
-        auto address = uri.host + ":" + std::to_string(uri.port);
+        telemetry_endpoint = uri.host + ":" + std::to_string(uri.port);
 
         ::grpc::ChannelArguments args;
         args.SetMaxSendMessageSize(-1);     // max send message size: 2GB
@@ -137,7 +138,7 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
             metadata["dbname"] = db_name;
         }
 
-        channel = CreateChannelWithHeaderInterceptor(address, credentials, args, metadata);
+        channel = CreateChannelWithHeaderInterceptor(telemetry_endpoint, credentials, args, metadata);
     } catch (const std::exception& ex) {
         std::string reason = "Exception caught when creating grpc channel: ";
         reason += ex.what();
@@ -153,12 +154,11 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
 
     auto stub_holder = proto::milvus::MilvusService::NewStub(channel);
     auto stub = std::shared_ptr<Stub>(std::move(stub_holder));
-    auto reusable_client_id =
-        runtime_telemetry_client_id.empty() ? telemetry_client_id_ : runtime_telemetry_client_id;
-    const auto& configured_client_id = param.Telemetry().client_id;
-    const bool can_reuse_telemetry = reusable_telemetry != nullptr &&
-                                     (configured_client_id.empty() ||
-                                      configured_client_id == reusable_telemetry->ClientId());
+    auto reusable_client_id = runtime_telemetry_client_id.empty() ? telemetry_client_id_ : runtime_telemetry_client_id;
+    const auto connection_scope =
+        telemetry_endpoint + "#" + std::to_string(std::hash<std::string>{}(param.Authorizations()));
+    const bool can_reuse_telemetry =
+        reusable_telemetry != nullptr && reusable_telemetry->MatchesConnection(param.Telemetry(), connection_scope);
     auto telemetry = can_reuse_telemetry
                          ? std::move(reusable_telemetry)
                          : std::make_shared<ClientTelemetryManager>(param.Telemetry(), reusable_client_id);
@@ -200,8 +200,8 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
     }
 
     auto database = param.DbName().empty() ? "default" : param.DbName();
-    telemetry->AttachChannel(channel, param.Username(), database, param.Host() + ":" + std::to_string(param.Port()),
-                             GetBuildVersion());
+    telemetry->AttachChannel(channel, param.Username(), database, telemetry_endpoint, GetBuildVersion(),
+                             connection_scope);
     {
         std::lock_guard<std::mutex> lock(stub_mtx_);
         param_ = param;

--- a/src/impl/MilvusConnection.cpp
+++ b/src/impl/MilvusConnection.cpp
@@ -152,17 +152,28 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
         return {StatusCode::NOT_CONNECTED, reason};
     }
 
-    auto stub_holder = proto::milvus::MilvusService::NewStub(channel);
-    auto stub = std::shared_ptr<Stub>(std::move(stub_holder));
-    auto reusable_client_id = runtime_telemetry_client_id.empty() ? telemetry_client_id_ : runtime_telemetry_client_id;
-    const auto reported_endpoint = telemetry_logical_endpoint.empty() ? telemetry_endpoint : telemetry_logical_endpoint;
-    const auto connection_scope =
-        reported_endpoint + "#" + std::to_string(std::hash<std::string>{}(param.Authorizations()));
-    const bool can_reuse_telemetry =
-        reusable_telemetry != nullptr && reusable_telemetry->MatchesConnection(param.Telemetry(), connection_scope);
-    auto telemetry = can_reuse_telemetry
-                         ? std::move(reusable_telemetry)
-                         : std::make_shared<ClientTelemetryManager>(param.Telemetry(), reusable_client_id);
+    std::shared_ptr<Stub> stub;
+    ClientTelemetryManagerPtr telemetry;
+    std::string reported_endpoint;
+    std::string connection_scope;
+    try {
+        auto stub_holder = proto::milvus::MilvusService::NewStub(channel);
+        stub = std::shared_ptr<Stub>(std::move(stub_holder));
+        auto reusable_client_id =
+            runtime_telemetry_client_id.empty() ? telemetry_client_id_ : runtime_telemetry_client_id;
+        reported_endpoint = telemetry_logical_endpoint.empty() ? telemetry_endpoint : telemetry_logical_endpoint;
+        connection_scope = reported_endpoint + "#" + std::to_string(std::hash<std::string>{}(param.Authorizations()));
+        const bool can_reuse_telemetry =
+            reusable_telemetry != nullptr && reusable_telemetry->MatchesConnection(param.Telemetry(), connection_scope);
+        telemetry = can_reuse_telemetry
+                        ? std::move(reusable_telemetry)
+                        : std::make_shared<ClientTelemetryManager>(param.Telemetry(), reusable_client_id);
+    } catch (const std::exception& exception) {
+        return {StatusCode::UNKNOWN_ERROR,
+                std::string("Failed to prepare client telemetry transport: ") + exception.what()};
+    } catch (...) {
+        return {StatusCode::UNKNOWN_ERROR, "Failed to prepare client telemetry transport"};
+    }
 
     // grpc channel has been create, now we call the proto::milvus::MilvusClient::Connect() interface
     // to send some basic information of client to the server, including the sdk type, version, etc.
@@ -200,8 +211,15 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
         return status;
     }
 
-    telemetry->AttachChannel(channel, param.Username(), param.DbName(), reported_endpoint, GetBuildVersion(),
-                             connection_scope);
+    try {
+        telemetry->AttachChannel(channel, param.Username(), param.DbName(), reported_endpoint, GetBuildVersion(),
+                                 connection_scope);
+    } catch (const std::exception& exception) {
+        return {StatusCode::UNKNOWN_ERROR,
+                std::string("Failed to attach client telemetry transport: ") + exception.what()};
+    } catch (...) {
+        return {StatusCode::UNKNOWN_ERROR, "Failed to attach client telemetry transport"};
+    }
     {
         std::lock_guard<std::mutex> lock(stub_mtx_);
         param_ = param;
@@ -245,15 +263,23 @@ MilvusConnection::Disconnect(bool stop_telemetry) {
 
 Status
 MilvusConnection::UseDatabase(const std::string& db_name) {
-    auto telemetry = GetTelemetry();
+    ConnectParam candidate_param;
+    ClientTelemetryManagerPtr telemetry;
+    std::string telemetry_client_id;
     std::string telemetry_logical_endpoint;
     {
         std::lock_guard<std::mutex> lock(stub_mtx_);
+        candidate_param = param_;
+        telemetry = telemetry_;
+        telemetry_client_id = telemetry_client_id_;
         telemetry_logical_endpoint = telemetry_logical_endpoint_;
     }
-    Disconnect();
-    param_.SetDbName(db_name);
-    return Connect(param_, telemetry_client_id_, std::move(telemetry), telemetry_logical_endpoint);
+    candidate_param.SetDbName(db_name);
+
+    // Connect builds and validates a private channel/stub, and only replaces this connection's
+    // published transport after the handshake and telemetry handoff both succeed. On failure the
+    // existing database, channel, stub, and telemetry manager remain fully usable.
+    return Connect(candidate_param, telemetry_client_id, std::move(telemetry), telemetry_logical_endpoint);
 }
 
 Status

--- a/src/impl/MilvusConnection.cpp
+++ b/src/impl/MilvusConnection.cpp
@@ -104,7 +104,7 @@ MilvusConnection::StatusCodeFromGrpcStatus(const ::grpc::Status& grpc_status) {
 
 Status
 MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_telemetry_client_id,
-                          ClientTelemetryManagerPtr reusable_telemetry) {
+                          ClientTelemetryManagerPtr reusable_telemetry, const std::string& telemetry_logical_endpoint) {
     std::shared_ptr<grpc::Channel> channel;
     std::string telemetry_endpoint;
     try {
@@ -155,8 +155,9 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
     auto stub_holder = proto::milvus::MilvusService::NewStub(channel);
     auto stub = std::shared_ptr<Stub>(std::move(stub_holder));
     auto reusable_client_id = runtime_telemetry_client_id.empty() ? telemetry_client_id_ : runtime_telemetry_client_id;
+    const auto reported_endpoint = telemetry_logical_endpoint.empty() ? telemetry_endpoint : telemetry_logical_endpoint;
     const auto connection_scope =
-        telemetry_endpoint + "#" + std::to_string(std::hash<std::string>{}(param.Authorizations()));
+        reported_endpoint + "#" + std::to_string(std::hash<std::string>{}(param.Authorizations()));
     const bool can_reuse_telemetry =
         reusable_telemetry != nullptr && reusable_telemetry->MatchesConnection(param.Telemetry(), connection_scope);
     auto telemetry = can_reuse_telemetry
@@ -199,7 +200,7 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
         return status;
     }
 
-    telemetry->AttachChannel(channel, param.Username(), param.DbName(), telemetry_endpoint, GetBuildVersion(),
+    telemetry->AttachChannel(channel, param.Username(), param.DbName(), reported_endpoint, GetBuildVersion(),
                              connection_scope);
     {
         std::lock_guard<std::mutex> lock(stub_mtx_);
@@ -208,6 +209,7 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
         stub_ = std::move(stub);
         telemetry_ = telemetry;
         telemetry_client_id_ = telemetry->ClientId();
+        telemetry_logical_endpoint_ = telemetry_logical_endpoint;
     }
     telemetry->Start();
     return Status::OK();
@@ -244,9 +246,14 @@ MilvusConnection::Disconnect(bool stop_telemetry) {
 Status
 MilvusConnection::UseDatabase(const std::string& db_name) {
     auto telemetry = GetTelemetry();
+    std::string telemetry_logical_endpoint;
+    {
+        std::lock_guard<std::mutex> lock(stub_mtx_);
+        telemetry_logical_endpoint = telemetry_logical_endpoint_;
+    }
     Disconnect();
     param_.SetDbName(db_name);
-    return Connect(param_, telemetry_client_id_, std::move(telemetry));
+    return Connect(param_, telemetry_client_id_, std::move(telemetry), telemetry_logical_endpoint);
 }
 
 Status

--- a/src/impl/MilvusConnection.h
+++ b/src/impl/MilvusConnection.h
@@ -27,11 +27,14 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 
 #include "common.pb.h"
 #include "milvus.grpc.pb.h"
 #include "milvus.pb.h"
 #include "milvus/Status.h"
+#include "milvus/ClientRequestContext.h"
+#include "milvus/ClientTelemetry.h"
 #include "milvus/types/ConnectParam.h"
 #include "schema.pb.h"
 
@@ -45,10 +48,15 @@ class MilvusConnection {
     struct GrpcContextOptions {
         /** timeout in milliseconds */
         uint64_t timeout{0};
+        /** Optional per-call request ID. Falls back to ClientRequestContext. */
+        std::string request_id;
 
         // constructors
         GrpcContextOptions() = default;
         explicit GrpcContextOptions(uint64_t timeout_) : timeout{timeout_} {
+        }
+        GrpcContextOptions(uint64_t timeout_, std::string request_id_)
+            : timeout{timeout_}, request_id{std::move(request_id_)} {
         }
     };
 
@@ -57,10 +65,13 @@ class MilvusConnection {
     virtual ~MilvusConnection();
 
     Status
-    Connect(const ConnectParam& param);
+    Connect(const ConnectParam& param, const std::string& runtime_telemetry_client_id = "");
 
     ConnectParam&
     GetConnectParam();
+
+    ClientTelemetryManagerPtr
+    GetTelemetry() const;
 
     Status
     Disconnect();
@@ -503,10 +514,12 @@ class MilvusConnection {
                           const GrpcContextOptions& options);
 
  private:
-    std::mutex stub_mtx_;
+    mutable std::mutex stub_mtx_;
     std::shared_ptr<proto::milvus::MilvusService::Stub> stub_;
     std::shared_ptr<grpc::Channel> channel_;
     ConnectParam param_;
+    ClientTelemetryManagerPtr telemetry_;
+    std::string telemetry_client_id_;
 
     static Status
     StatusByProtoResponse(const proto::common::Status& status);
@@ -530,20 +543,28 @@ class MilvusConnection {
              grpc::Status (proto::milvus::MilvusService::Stub::*func)(grpc::ClientContext*, const Request&, Response*),
              const Request& request, Response& response, const GrpcContextOptions& options) {
         std::shared_ptr<proto::milvus::MilvusService::Stub> stub;
+        ClientTelemetryManagerPtr telemetry;
         {
             std::lock_guard<std::mutex> lock(stub_mtx_);
             stub = stub_;
+            telemetry = telemetry_;
         }
         if (stub == nullptr) {
             return {StatusCode::NOT_CONNECTED, "Connection is not ready!"};
         }
 
         ::grpc::ClientContext context;
+        const std::string& contextual_request_id = ClientRequestContext::Get();
+        const std::string request_id = options.request_id.empty() ? contextual_request_id : options.request_id;
+        if (!request_id.empty()) {
+            context.AddMetadata("client_request_id", request_id);
+        }
         if (options.timeout > 0) {
             auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds{options.timeout};
             context.set_deadline(deadline);
         }
 
+        auto started = std::chrono::steady_clock::now();
         ::grpc::Status grpc_status = (stub.get()->*func)(&context, request, &response);
 
         // TODO: check the error codes and do retry here
@@ -556,13 +577,22 @@ class MilvusConnection {
         //   grpc::StatusCode::RESOURCE_EXHAUSTED
         //   grpc::StatusCode::UNIMPLEMENTED
         if (!grpc_status.ok()) {
-            return StatusCodeFromGrpcStatus(grpc_status);
+            auto status = StatusCodeFromGrpcStatus(grpc_status);
+            if (telemetry != nullptr) {
+                telemetry->RecordOperation(name, request, started, false, status.Message(), request_id);
+            }
+            return status;
         }
 
         // Some milvus error codes can be retried:
         //   response.status().error_code() == io.milvus.grpc.ErrorCode.RateLimit
         //   or response.status()code() == 8 can be retried
-        return StatusByProtoResponse(response);
+        auto status = StatusByProtoResponse(response);
+        if (telemetry != nullptr) {
+            telemetry->RecordOperation(name, request, started, status.IsOk(), status.IsOk() ? "" : status.Message(),
+                                       request_id);
+        }
+        return status;
     }
 };
 

--- a/src/impl/MilvusConnection.h
+++ b/src/impl/MilvusConnection.h
@@ -65,7 +65,8 @@ class MilvusConnection {
     virtual ~MilvusConnection();
 
     Status
-    Connect(const ConnectParam& param, const std::string& runtime_telemetry_client_id = "");
+    Connect(const ConnectParam& param, const std::string& runtime_telemetry_client_id = "",
+            ClientTelemetryManagerPtr reusable_telemetry = nullptr);
 
     ConnectParam&
     GetConnectParam();
@@ -74,7 +75,7 @@ class MilvusConnection {
     GetTelemetry() const;
 
     Status
-    Disconnect();
+    Disconnect(bool stop_telemetry = true);
 
     Status
     UseDatabase(const std::string& db_name);

--- a/src/impl/MilvusConnection.h
+++ b/src/impl/MilvusConnection.h
@@ -32,9 +32,9 @@
 #include "common.pb.h"
 #include "milvus.grpc.pb.h"
 #include "milvus.pb.h"
-#include "milvus/Status.h"
 #include "milvus/ClientRequestContext.h"
 #include "milvus/ClientTelemetry.h"
+#include "milvus/Status.h"
 #include "milvus/types/ConnectParam.h"
 #include "schema.pb.h"
 
@@ -543,12 +543,11 @@ class MilvusConnection {
     grpcCall(const char* name,
              grpc::Status (proto::milvus::MilvusService::Stub::*func)(grpc::ClientContext*, const Request&, Response*),
              const Request& request, Response& response, const GrpcContextOptions& options) {
+        (void)name;
         std::shared_ptr<proto::milvus::MilvusService::Stub> stub;
-        ClientTelemetryManagerPtr telemetry;
         {
             std::lock_guard<std::mutex> lock(stub_mtx_);
             stub = stub_;
-            telemetry = telemetry_;
         }
         if (stub == nullptr) {
             return {StatusCode::NOT_CONNECTED, "Connection is not ready!"};
@@ -557,7 +556,7 @@ class MilvusConnection {
         ::grpc::ClientContext context;
         const std::string& contextual_request_id = ClientRequestContext::Get();
         const std::string request_id = options.request_id.empty() ? contextual_request_id : options.request_id;
-        if (!request_id.empty()) {
+        if (ClientRequestContext::IsValid(request_id)) {
             context.AddMetadata("client_request_id", request_id);
         }
         if (options.timeout > 0) {
@@ -565,7 +564,6 @@ class MilvusConnection {
             context.set_deadline(deadline);
         }
 
-        auto started = std::chrono::steady_clock::now();
         ::grpc::Status grpc_status = (stub.get()->*func)(&context, request, &response);
 
         // TODO: check the error codes and do retry here
@@ -578,21 +576,13 @@ class MilvusConnection {
         //   grpc::StatusCode::RESOURCE_EXHAUSTED
         //   grpc::StatusCode::UNIMPLEMENTED
         if (!grpc_status.ok()) {
-            auto status = StatusCodeFromGrpcStatus(grpc_status);
-            if (telemetry != nullptr) {
-                telemetry->RecordOperation(name, request, started, false, status.Message(), request_id);
-            }
-            return status;
+            return StatusCodeFromGrpcStatus(grpc_status);
         }
 
         // Some milvus error codes can be retried:
         //   response.status().error_code() == io.milvus.grpc.ErrorCode.RateLimit
         //   or response.status()code() == 8 can be retried
         auto status = StatusByProtoResponse(response);
-        if (telemetry != nullptr) {
-            telemetry->RecordOperation(name, request, started, status.IsOk(), status.IsOk() ? "" : status.Message(),
-                                       request_id);
-        }
         return status;
     }
 };

--- a/src/impl/MilvusConnection.h
+++ b/src/impl/MilvusConnection.h
@@ -66,7 +66,7 @@ class MilvusConnection {
 
     Status
     Connect(const ConnectParam& param, const std::string& runtime_telemetry_client_id = "",
-            ClientTelemetryManagerPtr reusable_telemetry = nullptr);
+            ClientTelemetryManagerPtr reusable_telemetry = nullptr, const std::string& telemetry_logical_endpoint = "");
 
     ConnectParam&
     GetConnectParam();
@@ -521,6 +521,7 @@ class MilvusConnection {
     ConnectParam param_;
     ClientTelemetryManagerPtr telemetry_;
     std::string telemetry_client_id_;
+    std::string telemetry_logical_endpoint_;
 
     static Status
     StatusByProtoResponse(const proto::common::Status& status);

--- a/src/impl/types/ConnectParam.cpp
+++ b/src/impl/types/ConnectParam.cpp
@@ -70,6 +70,7 @@ ConnectParam::operator=(const ConnectParam& other) {
         username_ = other.username_;
         token_ = other.token_;
         db_name_ = other.db_name_;
+        telemetry_config_ = other.telemetry_config_;
     }
     return *this;
 }
@@ -311,6 +312,22 @@ ConnectParam::SetDbName(const std::string& db_name) {
 ConnectParam&
 ConnectParam::WithDbName(const std::string& db_name) {
     SetDbName(db_name);
+    return *this;
+}
+
+const TelemetryConfig&
+ConnectParam::Telemetry() const {
+    return telemetry_config_;
+}
+
+void
+ConnectParam::SetTelemetryConfig(const TelemetryConfig& config) {
+    telemetry_config_ = config;
+}
+
+ConnectParam&
+ConnectParam::WithTelemetryConfig(const TelemetryConfig& config) {
+    SetTelemetryConfig(config);
     return *this;
 }
 

--- a/src/impl/utils/ConnectionHandler.cpp
+++ b/src/impl/utils/ConnectionHandler.cpp
@@ -106,7 +106,8 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
     }
 
     auto new_connection = std::make_shared<MilvusConnection>();
-    auto status = new_connection->Connect(primary_param, telemetry_client_id_, reusable_telemetry);
+    auto status = new_connection->Connect(primary_param, telemetry_client_id_, reusable_telemetry,
+                                          is_global ? connect_param.Uri() : "");
     if (!status.IsOk()) {
         restore();
         return status;
@@ -211,6 +212,7 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
     ConnectParam primary_param;
     ClientTelemetryManagerPtr reusable_telemetry;
     std::string telemetry_client_id;
+    std::string telemetry_logical_endpoint;
     {
         std::lock_guard<std::mutex> lock(mtx_);
         if (!global_mode_) {
@@ -237,6 +239,7 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
             reusable_telemetry = telemetry_;
         }
         telemetry_client_id = telemetry_client_id_;
+        telemetry_logical_endpoint = global_endpoint_;
     }
 
     // abort promptly when the refresher is stopping rather than starting a fresh gRPC connect
@@ -248,7 +251,8 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
     // WaitForConnected() and the Connect RPC for up to ~2x ConnectTimeout, and holding mtx_ that
     // long would stall every other SDK operation that snapshots the connection.
     auto new_connection = std::make_shared<MilvusConnection>();
-    auto status = new_connection->Connect(primary_param, telemetry_client_id, reusable_telemetry);
+    auto status =
+        new_connection->Connect(primary_param, telemetry_client_id, reusable_telemetry, telemetry_logical_endpoint);
     if (!status.IsOk()) {
         // keep the existing connection; report failure so the refresher retries the same version
         return false;
@@ -272,8 +276,7 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
             if (new_connection->GetConnectParam().DbName() != live.DbName()) {
                 // the database changed while reconnecting; drop the stale candidate and retry
                 discard_candidate = true;
-                stop_candidate_telemetry =
-                    new_telemetry == nullptr || connection_->GetTelemetry() != new_telemetry;
+                stop_candidate_telemetry = new_telemetry == nullptr || connection_->GetTelemetry() != new_telemetry;
                 reconnect_result = false;
             }
         }

--- a/src/impl/utils/ConnectionHandler.cpp
+++ b/src/impl/utils/ConnectionHandler.cpp
@@ -35,23 +35,19 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
     // Keep the candidate private until its handshake succeeds, but do not hold mtx_ while
     // AttachChannel waits for an in-flight command handler. The lifecycle lock also fences
     // concurrent explicit connects, disconnects, database switches, and global failovers.
-    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mtx_);
+    // It must remain fail-fast: a command handler holds telemetry's command_mutex and may
+    // re-enter a lifecycle API while an external lifecycle call is waiting in AttachChannel.
+    std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
+    if (!lifecycle_lock.owns_lock()) {
+        return {StatusCode::CLIENT_BUSY, "Connection lifecycle change is already in progress"};
+    }
 
-    // Snapshot the previous global-cluster state so a failed handshake can restore it: the old
-    // primary connection_ is kept until the new handshake succeeds, and tearing down the refresher
-    // before the attempt would otherwise drop global tracking from a still-usable connection.
-    bool was_global = false;
-    std::string prior_endpoint;
-    ConnectParam prior_connect_param;
-    std::unique_ptr<TopologyRefresher> prior_refresher;
+    // Snapshot only reusable resources. The published connection and global state remain untouched
+    // until the candidate handshake succeeds, so every failure is a no-op from callers' perspective.
     ClientTelemetryManagerPtr reusable_telemetry;
     MilvusConnectionPtr old_connection;
     {
         std::lock_guard<std::mutex> lock(mtx_);
-        was_global = global_mode_;
-        prior_endpoint = global_endpoint_;
-        prior_connect_param = global_connect_param_;
-        prior_refresher = std::move(global_refresher_);
         reusable_telemetry = telemetry_;
         old_connection = connection_;
         if (old_connection != nullptr) {
@@ -60,29 +56,7 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
                 reusable_telemetry = std::move(current_telemetry);
             }
         }
-        // mark global mode off first so an in-flight callback cannot reconnect during teardown
-        global_mode_ = false;
     }
-    // join the refresher thread outside the lock (it may be inside reconnectToPrimary waiting on mtx_)
-    if (prior_refresher != nullptr) {
-        prior_refresher->Stop();
-    }
-
-    // Restore the prior global state on the failure path (only when a previous connection is still
-    // live), so cache-key scope and automatic failover are preserved for the old primary.
-    auto restore = [&]() {
-        std::lock_guard<std::mutex> lock(mtx_);
-        if (connection_ == nullptr) {
-            return;
-        }
-        global_mode_ = was_global;
-        global_endpoint_ = prior_endpoint;
-        global_connect_param_ = prior_connect_param;
-        global_refresher_ = std::move(prior_refresher);
-        if (global_refresher_ != nullptr) {
-            global_refresher_->Start();
-        }
-    };
 
     bool is_global = GlobalClusterUtils::IsGlobalEndpoint(connect_param.Uri());
     ConnectParam primary_param = connect_param;
@@ -93,31 +67,54 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
         // the connection under mtx_
         auto status = GlobalClusterUtils::FetchTopology(connect_param.Uri(), connect_param.Token(), initial_topology);
         if (!status.IsOk()) {
-            restore();
             return status;
         }
         const ClusterInfo* primary = initial_topology.Primary();
         if (primary == nullptr) {
-            restore();
             return {StatusCode::SERVER_FAILED, "No primary (writable) cluster found in global topology"};
         }
         primary_param.SetUri(
             GlobalClusterUtils::BuildPrimaryUri(connect_param.Uri(), connect_param.TlsEnabled(), primary->Endpoint()));
     }
 
+    std::unique_ptr<TopologyRefresher> new_refresher;
+    if (is_global) {
+        new_refresher = std::make_unique<TopologyRefresher>(
+            connect_param.Uri(), connect_param.Token(), initial_topology.Version(), std::chrono::seconds(300),
+            [this](const GlobalTopology& topology, const std::function<bool()>& should_stop) {
+                return reconnectToPrimary(topology, should_stop);
+            });
+        // Starting a private refresher cannot observe or mutate the live lifecycle before commit:
+        // its first refresh waits for the configured interval. If thread creation throws, the old
+        // published state is still intact and the exception is converted to a Status below. Starting
+        // it before the candidate attaches shared telemetry also keeps that handoff as the final
+        // infallible step before publication.
+        try {
+            new_refresher->Start();
+        } catch (const std::exception& exception) {
+            return {StatusCode::UNKNOWN_ERROR,
+                    std::string("Failed to start global topology refresher: ") + exception.what()};
+        }
+    }
+
     auto new_connection = std::make_shared<MilvusConnection>();
     auto status = new_connection->Connect(primary_param, telemetry_client_id_, reusable_telemetry,
                                           is_global ? connect_param.Uri() : "");
     if (!status.IsOk()) {
-        restore();
+        if (new_refresher != nullptr) {
+            new_refresher->Stop();
+        }
         return status;
     }
 
     auto telemetry = new_connection->GetTelemetry();
+    std::unique_ptr<TopologyRefresher> old_refresher;
     {
         std::lock_guard<std::mutex> lock(mtx_);
-        global_mode_ = false;
-        global_endpoint_.clear();
+        old_connection = connection_;
+        old_refresher = std::move(global_refresher_);
+        global_mode_ = is_global;
+        global_endpoint_ = is_global ? connect_param.Uri() : std::string{};
         if (telemetry != nullptr) {
             telemetry_ = telemetry;
             telemetry_client_id_ = telemetry->ClientId();
@@ -126,18 +123,16 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
 
         // Commit global-cluster state only after the primary connect succeeds.
         if (is_global) {
-            global_mode_ = true;
-            global_endpoint_ = connect_param.Uri();
             global_connect_param_ = connect_param;
-            global_refresher_ = std::make_unique<TopologyRefresher>(
-                global_endpoint_, global_connect_param_.Token(), initial_topology.Version(), std::chrono::seconds(300),
-                [this](const GlobalTopology& topology, const std::function<bool()>& should_stop) {
-                    return reconnectToPrimary(topology, should_stop);
-                });
-            global_refresher_->Start();
+            global_refresher_ = std::move(new_refresher);
         }
     }
 
+    // The old refresher can be inside its callback. It cannot wait for lifecycle_mtx_ because
+    // reconnectToPrimary also uses try_to_lock, so Stop()/join is safe while this lifecycle owns it.
+    if (old_refresher != nullptr) {
+        old_refresher->Stop();
+    }
     if (old_connection != nullptr) {
         const bool shares_telemetry = telemetry != nullptr && old_connection->GetTelemetry() == telemetry;
         old_connection->Disconnect(!shares_telemetry);

--- a/src/impl/utils/ConnectionHandler.cpp
+++ b/src/impl/utils/ConnectionHandler.cpp
@@ -39,12 +39,20 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
     std::string prior_endpoint;
     ConnectParam prior_connect_param;
     std::unique_ptr<TopologyRefresher> prior_refresher;
+    ClientTelemetryManagerPtr reusable_telemetry;
     {
         std::lock_guard<std::mutex> lock(mtx_);
         was_global = global_mode_;
         prior_endpoint = global_endpoint_;
         prior_connect_param = global_connect_param_;
         prior_refresher = std::move(global_refresher_);
+        reusable_telemetry = telemetry_;
+        if (connection_ != nullptr) {
+            auto current_telemetry = connection_->GetTelemetry();
+            if (current_telemetry != nullptr) {
+                reusable_telemetry = std::move(current_telemetry);
+            }
+        }
         // mark global mode off first so an in-flight callback cannot reconnect during teardown
         global_mode_ = false;
     }
@@ -102,16 +110,18 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
         global_endpoint_.clear();
 
         new_connection = std::make_shared<MilvusConnection>();
-        status = new_connection->Connect(primary_param, telemetry_client_id_);
+        status = new_connection->Connect(primary_param, telemetry_client_id_, reusable_telemetry);
         if (!status.IsOk()) {
             // fall through to restore the prior global state after releasing the lock
         } else {
             auto telemetry = new_connection->GetTelemetry();
             if (telemetry != nullptr) {
+                telemetry_ = telemetry;
                 telemetry_client_id_ = telemetry->ClientId();
             }
             if (connection_ != nullptr) {
-                connection_->Disconnect();
+                const bool shares_telemetry = telemetry != nullptr && connection_->GetTelemetry() == telemetry;
+                connection_->Disconnect(!shares_telemetry);
             }
             connection_ = std::move(new_connection);
 
@@ -145,6 +155,10 @@ ConnectionHandler::Disconnect() {
 
     std::lock_guard<std::mutex> lock(mtx_);
     if (connection_ != nullptr) {
+        auto telemetry = connection_->GetTelemetry();
+        if (telemetry != nullptr) {
+            telemetry_ = std::move(telemetry);
+        }
         return connection_->Disconnect();
     }
     return Status::OK();
@@ -183,6 +197,8 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
     }
 
     ConnectParam primary_param;
+    ClientTelemetryManagerPtr reusable_telemetry;
+    std::string telemetry_client_id;
     {
         std::lock_guard<std::mutex> lock(mtx_);
         if (!global_mode_) {
@@ -203,7 +219,12 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
         if (connection_ != nullptr) {
             primary_param.SetDbName(connection_->GetConnectParam().DbName());
             primary_param.SetRpcDeadlineMs(connection_->GetConnectParam().RpcDeadlineMs());
+            reusable_telemetry = connection_->GetTelemetry();
         }
+        if (reusable_telemetry == nullptr) {
+            reusable_telemetry = telemetry_;
+        }
+        telemetry_client_id = telemetry_client_id_;
     }
 
     // abort promptly when the refresher is stopping rather than starting a fresh gRPC connect
@@ -215,17 +236,19 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
     // WaitForConnected() and the Connect RPC for up to ~2x ConnectTimeout, and holding mtx_ that
     // long would stall every other SDK operation that snapshots the connection.
     auto new_connection = std::make_shared<MilvusConnection>();
-    auto status = new_connection->Connect(primary_param, telemetry_client_id_);
+    auto status = new_connection->Connect(primary_param, telemetry_client_id, reusable_telemetry);
     if (!status.IsOk()) {
         // keep the existing connection; report failure so the refresher retries the same version
         return false;
     }
 
+    auto new_telemetry = new_connection->GetTelemetry();
     {
         std::lock_guard<std::mutex> lock(mtx_);
         if (!global_mode_) {
             // disconnected while reconnecting; discard the unused candidate connection
-            new_connection->Disconnect();
+            const bool shares_telemetry = new_telemetry != nullptr && telemetry_ == new_telemetry;
+            new_connection->Disconnect(!shares_telemetry);
             return true;
         }
         // re-read live configuration in case SetRpcDeadlineMs()/UseDatabase() ran while the
@@ -235,14 +258,21 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
             new_connection->GetConnectParam().SetRpcDeadlineMs(live.RpcDeadlineMs());
             if (new_connection->GetConnectParam().DbName() != live.DbName()) {
                 // the database changed while reconnecting; drop the stale candidate and retry
-                new_connection->Disconnect();
+                const bool shares_telemetry =
+                    new_telemetry != nullptr && connection_->GetTelemetry() == new_telemetry;
+                new_connection->Disconnect(!shares_telemetry);
                 return false;
             }
         }
         auto old_connection = connection_;
         connection_ = std::move(new_connection);
+        if (new_telemetry != nullptr) {
+            telemetry_ = new_telemetry;
+            telemetry_client_id_ = new_telemetry->ClientId();
+        }
         if (old_connection != nullptr) {
-            old_connection->Disconnect();
+            const bool shares_telemetry = new_telemetry != nullptr && old_connection->GetTelemetry() == new_telemetry;
+            old_connection->Disconnect(!shares_telemetry);
         }
     }
     return true;

--- a/src/impl/utils/ConnectionHandler.cpp
+++ b/src/impl/utils/ConnectionHandler.cpp
@@ -32,6 +32,11 @@ ConnectionHandler::~ConnectionHandler() {
 
 Status
 ConnectionHandler::Connect(const ConnectParam& connect_param) {
+    // Keep the candidate private until its handshake succeeds, but do not hold mtx_ while
+    // AttachChannel waits for an in-flight command handler. The lifecycle lock also fences
+    // concurrent explicit connects, disconnects, database switches, and global failovers.
+    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mtx_);
+
     // Snapshot the previous global-cluster state so a failed handshake can restore it: the old
     // primary connection_ is kept until the new handshake succeeds, and tearing down the refresher
     // before the attempt would otherwise drop global tracking from a still-usable connection.
@@ -40,6 +45,7 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
     ConnectParam prior_connect_param;
     std::unique_ptr<TopologyRefresher> prior_refresher;
     ClientTelemetryManagerPtr reusable_telemetry;
+    MilvusConnectionPtr old_connection;
     {
         std::lock_guard<std::mutex> lock(mtx_);
         was_global = global_mode_;
@@ -47,8 +53,9 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
         prior_connect_param = global_connect_param_;
         prior_refresher = std::move(global_refresher_);
         reusable_telemetry = telemetry_;
-        if (connection_ != nullptr) {
-            auto current_telemetry = connection_->GetTelemetry();
+        old_connection = connection_;
+        if (old_connection != nullptr) {
+            auto current_telemetry = old_connection->GetTelemetry();
             if (current_telemetry != nullptr) {
                 reusable_telemetry = std::move(current_telemetry);
             }
@@ -98,70 +105,68 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
             GlobalClusterUtils::BuildPrimaryUri(connect_param.Uri(), connect_param.TlsEnabled(), primary->Endpoint()));
     }
 
-    // Serialize the connection handshake with lifecycle and configuration mutations. The candidate
-    // connection remains private until it succeeds, but setters must not update the current
-    // connection and then be overwritten by the successful swap below.
-    MilvusConnectionPtr new_connection;
-    Status status;
-    {
-        std::lock_guard<std::mutex> lock(mtx_);
-
-        global_mode_ = false;
-        global_endpoint_.clear();
-
-        new_connection = std::make_shared<MilvusConnection>();
-        status = new_connection->Connect(primary_param, telemetry_client_id_, reusable_telemetry);
-        if (!status.IsOk()) {
-            // fall through to restore the prior global state after releasing the lock
-        } else {
-            auto telemetry = new_connection->GetTelemetry();
-            if (telemetry != nullptr) {
-                telemetry_ = telemetry;
-                telemetry_client_id_ = telemetry->ClientId();
-            }
-            if (connection_ != nullptr) {
-                const bool shares_telemetry = telemetry != nullptr && connection_->GetTelemetry() == telemetry;
-                connection_->Disconnect(!shares_telemetry);
-            }
-            connection_ = std::move(new_connection);
-
-            // commit the global-cluster state only after the primary connect succeeded, so a failed
-            // Connect() leaves the handler in non-global mode (consistent with connection_ == null)
-            if (is_global) {
-                global_mode_ = true;
-                global_endpoint_ = connect_param.Uri();
-                global_connect_param_ = connect_param;
-                global_refresher_ = std::make_unique<TopologyRefresher>(
-                    global_endpoint_, global_connect_param_.Token(), initial_topology.Version(),
-                    std::chrono::seconds(300),
-                    [this](const GlobalTopology& topology, const std::function<bool()>& should_stop) {
-                        return reconnectToPrimary(topology, should_stop);
-                    });
-                global_refresher_->Start();
-            }
-        }
-    }
+    auto new_connection = std::make_shared<MilvusConnection>();
+    auto status = new_connection->Connect(primary_param, telemetry_client_id_, reusable_telemetry);
     if (!status.IsOk()) {
         restore();
         return status;
+    }
+
+    auto telemetry = new_connection->GetTelemetry();
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        global_mode_ = false;
+        global_endpoint_.clear();
+        if (telemetry != nullptr) {
+            telemetry_ = telemetry;
+            telemetry_client_id_ = telemetry->ClientId();
+        }
+        connection_ = new_connection;
+
+        // Commit global-cluster state only after the primary connect succeeds.
+        if (is_global) {
+            global_mode_ = true;
+            global_endpoint_ = connect_param.Uri();
+            global_connect_param_ = connect_param;
+            global_refresher_ = std::make_unique<TopologyRefresher>(
+                global_endpoint_, global_connect_param_.Token(), initial_topology.Version(), std::chrono::seconds(300),
+                [this](const GlobalTopology& topology, const std::function<bool()>& should_stop) {
+                    return reconnectToPrimary(topology, should_stop);
+                });
+            global_refresher_->Start();
+        }
+    }
+
+    if (old_connection != nullptr) {
+        const bool shares_telemetry = telemetry != nullptr && old_connection->GetTelemetry() == telemetry;
+        old_connection->Disconnect(!shares_telemetry);
     }
     return Status::OK();
 }
 
 Status
 ConnectionHandler::Disconnect() {
+    std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
+    if (!lifecycle_lock.owns_lock()) {
+        return {StatusCode::UNKNOWN_ERROR, "Connection lifecycle change is already in progress"};
+    }
+
     // stop the refresher without holding the lock; callbacks see global_mode_==false and no-op
     stopGlobalRefresher();
 
-    std::lock_guard<std::mutex> lock(mtx_);
-    if (connection_ != nullptr) {
-        auto telemetry = connection_->GetTelemetry();
+    MilvusConnectionPtr connection;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        connection = std::move(connection_);
+        if (connection == nullptr) {
+            return Status::OK();
+        }
+        auto telemetry = connection->GetTelemetry();
         if (telemetry != nullptr) {
             telemetry_ = std::move(telemetry);
         }
-        return connection_->Disconnect();
     }
-    return Status::OK();
+    return connection->Disconnect();
 }
 
 void
@@ -189,6 +194,13 @@ ConnectionHandler::TriggerGlobalRefresh() {
 
 bool
 ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std::function<bool()>& should_stop) {
+    // A refresher callback must never wait behind Connect()/Disconnect() while those methods
+    // are stopping and joining the refresher thread.
+    std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
+    if (!lifecycle_lock.owns_lock()) {
+        return false;
+    }
+
     const ClusterInfo* primary = topology.Primary();
     if (primary == nullptr) {
         // no writable cluster in this topology; report failure so the refresher retries the
@@ -243,37 +255,46 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
     }
 
     auto new_telemetry = new_connection->GetTelemetry();
+    MilvusConnectionPtr old_connection;
+    bool discard_candidate = false;
+    bool stop_candidate_telemetry = true;
+    bool reconnect_result = true;
     {
         std::lock_guard<std::mutex> lock(mtx_);
         if (!global_mode_) {
             // disconnected while reconnecting; discard the unused candidate connection
-            const bool shares_telemetry = new_telemetry != nullptr && telemetry_ == new_telemetry;
-            new_connection->Disconnect(!shares_telemetry);
-            return true;
-        }
-        // re-read live configuration in case SetRpcDeadlineMs()/UseDatabase() ran while the
-        // candidate was being built outside the lock, so it is not silently dropped on swap
-        if (connection_ != nullptr) {
+            discard_candidate = true;
+            stop_candidate_telemetry = new_telemetry == nullptr || telemetry_ != new_telemetry;
+        } else if (connection_ != nullptr) {
+            // Re-read live configuration before swapping the candidate.
             const ConnectParam& live = connection_->GetConnectParam();
             new_connection->GetConnectParam().SetRpcDeadlineMs(live.RpcDeadlineMs());
             if (new_connection->GetConnectParam().DbName() != live.DbName()) {
                 // the database changed while reconnecting; drop the stale candidate and retry
-                const bool shares_telemetry =
-                    new_telemetry != nullptr && connection_->GetTelemetry() == new_telemetry;
-                new_connection->Disconnect(!shares_telemetry);
-                return false;
+                discard_candidate = true;
+                stop_candidate_telemetry =
+                    new_telemetry == nullptr || connection_->GetTelemetry() != new_telemetry;
+                reconnect_result = false;
             }
         }
-        auto old_connection = connection_;
-        connection_ = std::move(new_connection);
-        if (new_telemetry != nullptr) {
-            telemetry_ = new_telemetry;
-            telemetry_client_id_ = new_telemetry->ClientId();
+
+        if (!discard_candidate) {
+            old_connection = connection_;
+            connection_ = new_connection;
+            if (new_telemetry != nullptr) {
+                telemetry_ = new_telemetry;
+                telemetry_client_id_ = new_telemetry->ClientId();
+            }
         }
-        if (old_connection != nullptr) {
-            const bool shares_telemetry = new_telemetry != nullptr && old_connection->GetTelemetry() == new_telemetry;
-            old_connection->Disconnect(!shares_telemetry);
-        }
+    }
+
+    if (discard_candidate) {
+        new_connection->Disconnect(stop_candidate_telemetry);
+        return reconnect_result;
+    }
+    if (old_connection != nullptr) {
+        const bool shares_telemetry = new_telemetry != nullptr && old_connection->GetTelemetry() == new_telemetry;
+        old_connection->Disconnect(!shares_telemetry);
     }
     return true;
 }
@@ -287,11 +308,15 @@ ConnectionHandler::GetConnection() const {
 ClientTelemetryManagerPtr
 ConnectionHandler::GetTelemetry() const {
     std::lock_guard<std::mutex> lock(mtx_);
-    return connection_ == nullptr ? nullptr : connection_->GetTelemetry();
+    return connection_ == nullptr ? telemetry_ : connection_->GetTelemetry();
 }
 
 Status
 ConnectionHandler::SetRpcDeadlineMs(uint64_t timeout_ms) {
+    std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
+    if (!lifecycle_lock.owns_lock()) {
+        return {StatusCode::UNKNOWN_ERROR, "Connection lifecycle change is already in progress"};
+    }
     std::lock_guard<std::mutex> lock(mtx_);
     if (connection_ == nullptr) {
         return {StatusCode::NOT_CONNECTED, "Connection is not created!"};
@@ -311,6 +336,10 @@ ConnectionHandler::GetRpcDeadlineMs() const {
 
 Status
 ConnectionHandler::SetRetryParam(const RetryParam& retry_param) {
+    std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
+    if (!lifecycle_lock.owns_lock()) {
+        return {StatusCode::UNKNOWN_ERROR, "Connection lifecycle change is already in progress"};
+    }
     std::lock_guard<std::mutex> lock(mtx_);
     if (connection_ == nullptr) {
         return {StatusCode::NOT_CONNECTED, "Connection is not created!"};
@@ -327,12 +356,12 @@ ConnectionHandler::GetRetryParam() const {
 
 Status
 ConnectionHandler::UseDatabase(const std::string& db_name) {
-    std::lock_guard<std::mutex> lock(mtx_);
-    if (connection_ != nullptr) {
-        return connection_->UseDatabase(db_name);
+    std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
+    if (!lifecycle_lock.owns_lock()) {
+        return {StatusCode::UNKNOWN_ERROR, "Connection lifecycle change is already in progress"};
     }
-
-    return Status::OK();
+    auto connection = GetConnection();
+    return connection == nullptr ? Status::OK() : connection->UseDatabase(db_name);
 }
 
 std::string

--- a/src/impl/utils/ConnectionHandler.cpp
+++ b/src/impl/utils/ConnectionHandler.cpp
@@ -148,7 +148,7 @@ Status
 ConnectionHandler::Disconnect() {
     std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
     if (!lifecycle_lock.owns_lock()) {
-        return {StatusCode::UNKNOWN_ERROR, "Connection lifecycle change is already in progress"};
+        return {StatusCode::CLIENT_BUSY, "Connection lifecycle change is already in progress"};
     }
 
     // stop the refresher without holding the lock; callbacks see global_mode_==false and no-op
@@ -315,7 +315,7 @@ Status
 ConnectionHandler::SetRpcDeadlineMs(uint64_t timeout_ms) {
     std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
     if (!lifecycle_lock.owns_lock()) {
-        return {StatusCode::UNKNOWN_ERROR, "Connection lifecycle change is already in progress"};
+        return {StatusCode::CLIENT_BUSY, "Connection lifecycle change is already in progress"};
     }
     std::lock_guard<std::mutex> lock(mtx_);
     if (connection_ == nullptr) {
@@ -338,7 +338,7 @@ Status
 ConnectionHandler::SetRetryParam(const RetryParam& retry_param) {
     std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
     if (!lifecycle_lock.owns_lock()) {
-        return {StatusCode::UNKNOWN_ERROR, "Connection lifecycle change is already in progress"};
+        return {StatusCode::CLIENT_BUSY, "Connection lifecycle change is already in progress"};
     }
     std::lock_guard<std::mutex> lock(mtx_);
     if (connection_ == nullptr) {
@@ -358,7 +358,7 @@ Status
 ConnectionHandler::UseDatabase(const std::string& db_name) {
     std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mtx_, std::try_to_lock);
     if (!lifecycle_lock.owns_lock()) {
-        return {StatusCode::UNKNOWN_ERROR, "Connection lifecycle change is already in progress"};
+        return {StatusCode::CLIENT_BUSY, "Connection lifecycle change is already in progress"};
     }
     auto connection = GetConnection();
     return connection == nullptr ? Status::OK() : connection->UseDatabase(db_name);

--- a/src/impl/utils/ConnectionHandler.cpp
+++ b/src/impl/utils/ConnectionHandler.cpp
@@ -102,10 +102,14 @@ ConnectionHandler::Connect(const ConnectParam& connect_param) {
         global_endpoint_.clear();
 
         new_connection = std::make_shared<MilvusConnection>();
-        status = new_connection->Connect(primary_param);
+        status = new_connection->Connect(primary_param, telemetry_client_id_);
         if (!status.IsOk()) {
             // fall through to restore the prior global state after releasing the lock
         } else {
+            auto telemetry = new_connection->GetTelemetry();
+            if (telemetry != nullptr) {
+                telemetry_client_id_ = telemetry->ClientId();
+            }
             if (connection_ != nullptr) {
                 connection_->Disconnect();
             }
@@ -211,7 +215,7 @@ ConnectionHandler::reconnectToPrimary(const GlobalTopology& topology, const std:
     // WaitForConnected() and the Connect RPC for up to ~2x ConnectTimeout, and holding mtx_ that
     // long would stall every other SDK operation that snapshots the connection.
     auto new_connection = std::make_shared<MilvusConnection>();
-    auto status = new_connection->Connect(primary_param);
+    auto status = new_connection->Connect(primary_param, telemetry_client_id_);
     if (!status.IsOk()) {
         // keep the existing connection; report failure so the refresher retries the same version
         return false;
@@ -248,6 +252,12 @@ MilvusConnectionPtr
 ConnectionHandler::GetConnection() const {
     std::lock_guard<std::mutex> lock(mtx_);
     return connection_;
+}
+
+ClientTelemetryManagerPtr
+ConnectionHandler::GetTelemetry() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return connection_ == nullptr ? nullptr : connection_->GetTelemetry();
 }
 
 Status

--- a/src/impl/utils/ConnectionHandler.h
+++ b/src/impl/utils/ConnectionHandler.h
@@ -280,6 +280,14 @@ class ConnectionHandler {
     }
 
  private:
+    // Lifecycle lock order and re-entrancy contract:
+    // 1. Every state-mutating lifecycle entry acquires lifecycle_mtx_ with try_to_lock.
+    // 2. While it owns lifecycle_mtx_, it may briefly acquire mtx_ to snapshot or commit state.
+    // 3. mtx_ is never held across network I/O, TopologyRefresher::Stop(), telemetry Stop(),
+    //    AttachChannel(), or ProcessCommands().
+    // A telemetry command handler already owns command_mutex and may re-enter a lifecycle API.
+    // Fail-fast lifecycle acquisition prevents a command_mutex -> lifecycle_mtx_ wait from
+    // forming a cycle with an external lifecycle_mtx_ -> AttachChannel(command_mutex) handoff.
     mutable std::mutex lifecycle_mtx_;
     mutable std::mutex mtx_;
     MilvusConnectionPtr connection_;

--- a/src/impl/utils/ConnectionHandler.h
+++ b/src/impl/utils/ConnectionHandler.h
@@ -282,6 +282,7 @@ class ConnectionHandler {
  private:
     mutable std::mutex mtx_;
     MilvusConnectionPtr connection_;
+    ClientTelemetryManagerPtr telemetry_;
     RetryParam retry_param_;
     std::string telemetry_client_id_;
 

--- a/src/impl/utils/ConnectionHandler.h
+++ b/src/impl/utils/ConnectionHandler.h
@@ -49,6 +49,9 @@ class ConnectionHandler {
     MilvusConnectionPtr
     GetConnection() const;
 
+    ClientTelemetryManagerPtr
+    GetTelemetry() const;
+
     Status
     SetRpcDeadlineMs(uint64_t timeout_ms);
 
@@ -280,6 +283,7 @@ class ConnectionHandler {
     mutable std::mutex mtx_;
     MilvusConnectionPtr connection_;
     RetryParam retry_param_;
+    std::string telemetry_client_id_;
 
     // global-cluster state
     bool global_mode_{false};

--- a/src/impl/utils/ConnectionHandler.h
+++ b/src/impl/utils/ConnectionHandler.h
@@ -280,6 +280,7 @@ class ConnectionHandler {
     }
 
  private:
+    mutable std::mutex lifecycle_mtx_;
     mutable std::mutex mtx_;
     MilvusConnectionPtr connection_;
     ClientTelemetryManagerPtr telemetry_;

--- a/src/impl/utils/TelemetryUtils.h
+++ b/src/impl/utils/TelemetryUtils.h
@@ -12,12 +12,37 @@
 
 #include <chrono>
 #include <string>
+#include <thread>
 #include <utility>
 
 #include "ConnectionHandler.h"
 #include "milvus/ClientRequestContext.h"
 
 namespace milvus {
+
+template <typename Client>
+void
+DeleteClientWithTelemetryWorkerSafety(Client* client, ClientTelemetryManagerPtr telemetry,
+                                      bool called_from_telemetry_worker) noexcept {
+    if (!called_from_telemetry_worker) {
+        delete client;
+        return;
+    }
+
+    // The global topology refresher may be waiting for the current command handler before
+    // it can hand off the telemetry channel. Stop/join the worker on another thread, then
+    // delete the client after the handler has returned and released the command lock.
+    try {
+        std::thread([client, telemetry = std::move(telemetry)]() {
+            telemetry->Stop();
+            delete client;
+        }).detach();
+    } catch (...) {
+        // A deleter must not throw. If the one-shot cleanup thread cannot be created,
+        // intentionally retain the client rather than terminate or re-enter the known
+        // refresher/command join cycle.
+    }
+}
 
 template <typename Callable>
 Status

--- a/src/impl/utils/TelemetryUtils.h
+++ b/src/impl/utils/TelemetryUtils.h
@@ -1,0 +1,37 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <utility>
+
+#include "ConnectionHandler.h"
+#include "milvus/ClientRequestContext.h"
+
+namespace milvus {
+
+template <typename Callable>
+Status
+InvokeWithTelemetry(ConnectionHandler& connection, const std::string& operation, const std::string& collection,
+                    Callable&& callable) {
+    auto started = std::chrono::steady_clock::now();
+    auto telemetry = connection.GetTelemetry();
+    auto status = std::forward<Callable>(callable)();
+    if (telemetry != nullptr) {
+        const auto& request_id = ClientRequestContext::Get();
+        telemetry->RecordOperation(operation, collection, started, status.IsOk(),
+                                   status.IsOk() ? std::string{} : status.Message(), request_id);
+    }
+    return status;
+}
+
+}  // namespace milvus

--- a/src/include/milvus/ClientRequestContext.h
+++ b/src/include/milvus/ClientRequestContext.h
@@ -1,0 +1,50 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include <string>
+
+#include "milvus/Export.h"
+
+namespace milvus {
+
+/** Per-thread request ID propagated as the client_request_id gRPC metadata. */
+class MILVUS_SDK_API ClientRequestContext {
+ public:
+    static void
+    Set(const std::string& request_id);
+
+    static const std::string&
+    Get();
+
+    static void
+    Clear();
+
+    /** Returns a lowercase 32-character OpenTelemetry-compatible trace ID. */
+    static std::string
+    NewRequestId();
+};
+
+/** Restores the previous thread-local request ID when it leaves scope. */
+class MILVUS_SDK_API ScopedClientRequestId {
+ public:
+    explicit ScopedClientRequestId(const std::string& request_id);
+    ~ScopedClientRequestId();
+
+    ScopedClientRequestId(const ScopedClientRequestId&) = delete;
+    ScopedClientRequestId&
+    operator=(const ScopedClientRequestId&) = delete;
+
+ private:
+    std::string previous_;
+};
+
+}  // namespace milvus

--- a/src/include/milvus/ClientRequestContext.h
+++ b/src/include/milvus/ClientRequestContext.h
@@ -31,6 +31,10 @@ class MILVUS_SDK_API ClientRequestContext {
     /** Returns a lowercase 32-character OpenTelemetry-compatible trace ID. */
     static std::string
     NewRequestId();
+
+    /** Returns true for a lowercase, non-zero, 32-character OpenTelemetry trace ID. */
+    static bool
+    IsValid(const std::string& request_id);
 };
 
 /** Restores the previous thread-local request ID when it leaves scope. */

--- a/src/include/milvus/ClientTelemetry.h
+++ b/src/include/milvus/ClientTelemetry.h
@@ -1,0 +1,155 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "milvus/Export.h"
+#include "milvus/types/TelemetryConfig.h"
+
+namespace grpc {
+class Channel;
+}
+
+namespace google {
+namespace protobuf {
+class Message;
+}
+}  // namespace google
+
+namespace milvus {
+
+struct MILVUS_SDK_API TelemetryMetric {
+    int64_t request_count{0};
+    int64_t success_count{0};
+    int64_t error_count{0};
+    double avg_latency_ms{0};
+    double p99_latency_ms{0};
+    double max_latency_ms{0};
+};
+
+struct MILVUS_SDK_API TelemetryOperationMetrics {
+    std::string operation;
+    TelemetryMetric global;
+    std::unordered_map<std::string, TelemetryMetric> collection_metrics;
+};
+
+struct MILVUS_SDK_API TelemetrySnapshot {
+    int64_t timestamp{0};
+    int64_t end_time{0};
+    std::vector<TelemetryOperationMetrics> metrics;
+};
+
+struct MILVUS_SDK_API TelemetryError {
+    int64_t timestamp{0};
+    std::string operation;
+    std::string error_message;
+    std::string collection;
+    std::string request_id;
+};
+
+struct MILVUS_SDK_API TelemetryCommand {
+    std::string command_id;
+    std::string command_type;
+    std::string payload;
+    int64_t create_time{0};
+    bool persistent{false};
+    std::string target_scope;
+};
+
+struct MILVUS_SDK_API TelemetryCommandReply {
+    std::string command_id;
+    bool success{false};
+    std::string error_message;
+    std::string payload;
+};
+
+/** Client-side metrics, heartbeat, command, and diagnostic manager. */
+class MILVUS_SDK_API ClientTelemetryManager {
+ public:
+    using CommandHandler = std::function<TelemetryCommandReply(const TelemetryCommand&)>;
+
+    explicit ClientTelemetryManager(const TelemetryConfig& config = TelemetryConfig{},
+                                    const std::string& runtime_client_id = "");
+    ~ClientTelemetryManager();
+
+    ClientTelemetryManager(const ClientTelemetryManager&) = delete;
+    ClientTelemetryManager&
+    operator=(const ClientTelemetryManager&) = delete;
+
+    void
+    AttachChannel(const std::shared_ptr<grpc::Channel>& channel, const std::string& username,
+                  const std::string& database, const std::string& uri, const std::string& sdk_version);
+
+    void
+    UpdateDatabase(const std::string& database);
+
+    void
+    Start();
+
+    void
+    Stop();
+
+    bool
+    IsReady() const;
+
+    bool
+    IsSupported() const;
+
+    const std::string&
+    ClientId() const;
+
+    std::string
+    ConfigHash() const;
+
+    int64_t
+    LastCommandTimestamp() const;
+
+    TelemetryConfig
+    Config() const;
+
+    std::string
+    LastHeartbeatError() const;
+
+    void
+    RegisterCommandHandler(const std::string& command_type, CommandHandler handler);
+
+    void
+    RecordOperation(const std::string& operation, const google::protobuf::Message& request,
+                    std::chrono::steady_clock::time_point started, bool success, const std::string& error_message,
+                    const std::string& request_id = "");
+
+    std::vector<TelemetryError>
+    RecentErrors(size_t max_count = 100) const;
+
+    std::vector<TelemetrySnapshot>
+    MetricsSnapshots() const;
+
+    void
+    ProcessCommands(const std::vector<TelemetryCommand>& commands);
+
+    static std::string
+    CalculateConfigHash(const std::vector<TelemetryCommand>& commands);
+
+ private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+using ClientTelemetryManagerPtr = std::shared_ptr<ClientTelemetryManager>;
+
+}  // namespace milvus

--- a/src/include/milvus/ClientTelemetry.h
+++ b/src/include/milvus/ClientTelemetry.h
@@ -93,7 +93,8 @@ class MILVUS_SDK_API ClientTelemetryManager {
 
     void
     AttachChannel(const std::shared_ptr<grpc::Channel>& channel, const std::string& username,
-                  const std::string& database, const std::string& uri, const std::string& sdk_version);
+                  const std::string& database, const std::string& uri, const std::string& sdk_version,
+                  const std::string& connection_scope = "");
 
     void
     UpdateDatabase(const std::string& database);
@@ -122,6 +123,10 @@ class MILVUS_SDK_API ClientTelemetryManager {
     TelemetryConfig
     Config() const;
 
+    /** Whether a reconnect can reuse this manager without changing user-supplied telemetry settings. */
+    bool
+    MatchesConnection(const TelemetryConfig& config, const std::string& connection_scope) const;
+
     std::string
     LastHeartbeatError() const;
 
@@ -133,11 +138,19 @@ class MILVUS_SDK_API ClientTelemetryManager {
                     std::chrono::steady_clock::time_point started, bool success, const std::string& error_message,
                     const std::string& request_id = "");
 
+    void
+    RecordOperation(const std::string& operation, const std::string& collection,
+                    std::chrono::steady_clock::time_point started, bool success, const std::string& error_message,
+                    const std::string& request_id = "");
+
     std::vector<TelemetryError>
     RecentErrors(size_t max_count = 100) const;
 
     std::vector<TelemetrySnapshot>
     MetricsSnapshots() const;
+
+    std::vector<TelemetryCommandReply>
+    PendingCommandReplies() const;
 
     void
     ProcessCommands(const std::vector<TelemetryCommand>& commands);

--- a/src/include/milvus/ClientTelemetry.h
+++ b/src/include/milvus/ClientTelemetry.h
@@ -157,7 +157,7 @@ class MILVUS_SDK_API ClientTelemetryManager {
 
  private:
     class Impl;
-    std::unique_ptr<Impl> impl_;
+    std::shared_ptr<Impl> impl_;
 };
 
 using ClientTelemetryManagerPtr = std::shared_ptr<ClientTelemetryManager>;

--- a/src/include/milvus/ClientTelemetry.h
+++ b/src/include/milvus/ClientTelemetry.h
@@ -160,7 +160,7 @@ class MILVUS_SDK_API ClientTelemetryManager {
     friend class MilvusClientV2;
 
     bool
-    IsWorkerThread() const;
+    isWorkerThread() const;
 
     class Impl;
     std::shared_ptr<Impl> impl_;

--- a/src/include/milvus/ClientTelemetry.h
+++ b/src/include/milvus/ClientTelemetry.h
@@ -156,6 +156,12 @@ class MILVUS_SDK_API ClientTelemetryManager {
     CalculateConfigHash(const std::vector<TelemetryCommand>& commands);
 
  private:
+    friend class MilvusClient;
+    friend class MilvusClientV2;
+
+    bool
+    IsWorkerThread() const;
+
     class Impl;
     std::shared_ptr<Impl> impl_;
 };

--- a/src/include/milvus/ClientTelemetry.h
+++ b/src/include/milvus/ClientTelemetry.h
@@ -97,9 +97,6 @@ class MILVUS_SDK_API ClientTelemetryManager {
                   const std::string& connection_scope = "");
 
     void
-    UpdateDatabase(const std::string& database);
-
-    void
     Start();
 
     void

--- a/src/include/milvus/MilvusClient.h
+++ b/src/include/milvus/MilvusClient.h
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "Status.h"
+#include "ClientTelemetry.h"
 #include "milvus/Export.h"
 #include "types/AliasDesc.h"
 #include "types/AnalyzerResults.h"
@@ -101,6 +102,10 @@ class MILVUS_SDK_API MilvusClient {
      */
     virtual Status
     Disconnect() = 0;
+
+    /** Returns the telemetry manager for diagnostics and custom command handlers. */
+    virtual ClientTelemetryManagerPtr
+    GetTelemetry() const = 0;
 
     /**
      * @brief Change timeout value in milliseconds for each RPC call.

--- a/src/include/milvus/MilvusClient.h
+++ b/src/include/milvus/MilvusClient.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "ClientRequestContext.h"
 #include "ClientTelemetry.h"
 #include "Status.h"
 #include "milvus/Export.h"
@@ -98,6 +99,7 @@ class MILVUS_SDK_API MilvusClient {
     /**
      * @brief Break connections between client and server.
      *
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      * @return Status operation successfully or not
      */
     virtual Status
@@ -106,6 +108,7 @@ class MILVUS_SDK_API MilvusClient {
     /**
      * @brief Change timeout value in milliseconds for each RPC call.
      *
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      */
     virtual Status
     SetRpcDeadlineMs(uint64_t timeout_ms) = 0;
@@ -114,6 +117,7 @@ class MILVUS_SDK_API MilvusClient {
      * @brief Reset retry rules for each RPC call.
      *
      *  @param [in] retry_param retry rules
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      */
     virtual Status
     SetRetryParam(const RetryParam& retry_param) = 0;
@@ -456,6 +460,7 @@ class MILVUS_SDK_API MilvusClient {
      * @brief Switch connection to another database.
      *
      * @param [in] db_name name of the database
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      * @return Status operation successfully or not
      */
     virtual Status

--- a/src/include/milvus/MilvusClient.h
+++ b/src/include/milvus/MilvusClient.h
@@ -18,8 +18,8 @@
 
 #include <memory>
 
-#include "Status.h"
 #include "ClientTelemetry.h"
+#include "Status.h"
 #include "milvus/Export.h"
 #include "types/AliasDesc.h"
 #include "types/AnalyzerResults.h"
@@ -102,10 +102,6 @@ class MILVUS_SDK_API MilvusClient {
      */
     virtual Status
     Disconnect() = 0;
-
-    /** Returns the telemetry manager for diagnostics and custom command handlers. */
-    virtual ClientTelemetryManagerPtr
-    GetTelemetry() const = 0;
 
     /**
      * @brief Change timeout value in milliseconds for each RPC call.
@@ -1150,6 +1146,12 @@ class MILVUS_SDK_API MilvusClient {
      */
     virtual Status
     RemovePrivilegesFromGroup(const std::string& group_name, const std::vector<std::string>& privileges) = 0;
+
+    /** Returns the telemetry manager for diagnostics and custom command handlers. */
+    virtual ClientTelemetryManagerPtr
+    GetTelemetry() const {
+        return nullptr;
+    }
 };
 
 using MilvusClientPtr = std::shared_ptr<MilvusClient>;

--- a/src/include/milvus/MilvusClient.h
+++ b/src/include/milvus/MilvusClient.h
@@ -91,6 +91,7 @@ class MILVUS_SDK_API MilvusClient {
      * @brief Connect to Milvus server.
      *
      * @param [in] connect_param server address and port
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      * @return Status operation successfully or not
      */
     virtual Status

--- a/src/include/milvus/MilvusClientV2.h
+++ b/src/include/milvus/MilvusClientV2.h
@@ -20,6 +20,7 @@
 
 #include "MilvusClientV2Session.h"
 #include "Status.h"
+#include "ClientTelemetry.h"
 #include "milvus/Export.h"
 #include "request/alias/AlterAliasRequest.h"
 #include "request/alias/CreateAliasRequest.h"
@@ -230,6 +231,10 @@ class MILVUS_SDK_API MilvusClientV2 {
      */
     virtual Status
     Disconnect() = 0;
+
+    /** Returns the telemetry manager for diagnostics and custom command handlers. */
+    virtual ClientTelemetryManagerPtr
+    GetTelemetry() const = 0;
 
     /**
      * @brief Change timeout value in milliseconds for each RPC call.

--- a/src/include/milvus/MilvusClientV2.h
+++ b/src/include/milvus/MilvusClientV2.h
@@ -18,6 +18,7 @@
 
 #include <functional>
 
+#include "ClientRequestContext.h"
 #include "ClientTelemetry.h"
 #include "MilvusClientV2Session.h"
 #include "Status.h"
@@ -227,6 +228,7 @@ class MILVUS_SDK_API MilvusClientV2 {
     /**
      * @brief Close connections between client and server.
      *
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      * @return Status operation successfully or not
      */
     virtual Status
@@ -235,6 +237,7 @@ class MILVUS_SDK_API MilvusClientV2 {
     /**
      * @brief Change timeout value in milliseconds for each RPC call.
      *
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      */
     virtual Status
     SetRpcDeadlineMs(uint64_t timeout_ms) = 0;
@@ -243,6 +246,7 @@ class MILVUS_SDK_API MilvusClientV2 {
      * @brief Reset retry rules for each RPC call.
      *
      *  @param [in] retry_param retry rules
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      */
     virtual Status
     SetRetryParam(const RetryParam& retry_param) = 0;
@@ -657,6 +661,7 @@ class MILVUS_SDK_API MilvusClientV2 {
      * @brief Switch connection to another database.
      *
      * @param [in] db_name name of the database
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      * @return Status operation successfully or not
      */
     virtual Status

--- a/src/include/milvus/MilvusClientV2.h
+++ b/src/include/milvus/MilvusClientV2.h
@@ -18,9 +18,9 @@
 
 #include <functional>
 
+#include "ClientTelemetry.h"
 #include "MilvusClientV2Session.h"
 #include "Status.h"
-#include "ClientTelemetry.h"
 #include "milvus/Export.h"
 #include "request/alias/AlterAliasRequest.h"
 #include "request/alias/CreateAliasRequest.h"
@@ -231,10 +231,6 @@ class MILVUS_SDK_API MilvusClientV2 {
      */
     virtual Status
     Disconnect() = 0;
-
-    /** Returns the telemetry manager for diagnostics and custom command handlers. */
-    virtual ClientTelemetryManagerPtr
-    GetTelemetry() const = 0;
 
     /**
      * @brief Change timeout value in milliseconds for each RPC call.
@@ -1440,6 +1436,12 @@ class MILVUS_SDK_API MilvusClientV2 {
      */
     virtual Status
     Session(const std::string& cluster_id, MilvusClientV2SessionPtr& session) = 0;
+
+    /** Returns the telemetry manager for diagnostics and custom command handlers. */
+    virtual ClientTelemetryManagerPtr
+    GetTelemetry() const {
+        return nullptr;
+    }
 };
 
 using MilvusClientV2Ptr = std::shared_ptr<MilvusClientV2>;

--- a/src/include/milvus/MilvusClientV2.h
+++ b/src/include/milvus/MilvusClientV2.h
@@ -220,6 +220,7 @@ class MILVUS_SDK_API MilvusClientV2 {
      * @brief Connect to Milvus server.
      *
      * @param [in] connect_param server address and port
+     * @retval StatusCode::CLIENT_BUSY another connection lifecycle change is in progress; the operation may be retried
      * @return Status operation successfully or not
      */
     virtual Status

--- a/src/include/milvus/Status.h
+++ b/src/include/milvus/Status.h
@@ -35,6 +35,7 @@ enum class StatusCode {
     UNKNOWN_ERROR = 1,
     NOT_SUPPORTED,
     NOT_CONNECTED,
+    CLIENT_BUSY,
 
     // function error section
     INVALID_ARGUMENT = 1000,

--- a/src/include/milvus/types/ConnectParam.h
+++ b/src/include/milvus/types/ConnectParam.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "milvus/Export.h"
+#include "milvus/types/TelemetryConfig.h"
 
 namespace milvus {
 
@@ -338,6 +339,16 @@ class MILVUS_SDK_API ConnectParam {
     ConnectParam&
     WithDbName(const std::string& db_name);
 
+    /** Client telemetry and command configuration. */
+    const TelemetryConfig&
+    Telemetry() const;
+
+    void
+    SetTelemetryConfig(const TelemetryConfig& config);
+
+    ConnectParam&
+    WithTelemetryConfig(const TelemetryConfig& config);
+
  private:
     std::string uri_ = "http://localhost:19530";
 
@@ -357,6 +368,7 @@ class MILVUS_SDK_API ConnectParam {
     std::string username_;
     std::string token_;
     std::string db_name_;
+    TelemetryConfig telemetry_config_;
 };
 
 }  // namespace milvus

--- a/src/include/milvus/types/TelemetryConfig.h
+++ b/src/include/milvus/types/TelemetryConfig.h
@@ -1,0 +1,32 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "milvus/Export.h"
+
+namespace milvus {
+
+/** Client metrics, heartbeat, and server-pushed command configuration. */
+struct MILVUS_SDK_API TelemetryConfig {
+    bool enabled{true};
+    uint64_t heartbeat_interval_ms{30000};
+    double sampling_rate{1.0};
+    size_t error_max_count{100};
+
+    /** Optional stable identity. A random UUID is used when empty. */
+    std::string client_id;
+};
+
+}  // namespace milvus

--- a/src/include/milvus/types/TelemetryConfig.h
+++ b/src/include/milvus/types/TelemetryConfig.h
@@ -21,7 +21,11 @@ namespace milvus {
 /** Client metrics, heartbeat, and server-pushed command configuration. */
 struct MILVUS_SDK_API TelemetryConfig {
     bool enabled{true};
-    uint64_t heartbeat_interval_ms{30000};
+    // Milliseconds between heartbeats, and therefore the metrics window: each heartbeat
+    // carries the operations since the last one. The coordinator answers a telemetry query
+    // from the window before the newest, so what a caller reads is between one and two
+    // intervals old.
+    uint64_t heartbeat_interval_ms{10000};
     double sampling_rate{1.0};
     size_t error_max_count{100};
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,6 +76,11 @@ add_executable(testing-it ${it_files})
 target_compile_options(testing-it PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
 link_milvus_test(testing-it)
 
+if (CMAKE_SYSTEM_NAME MATCHES "(Linux|Darwin)")
+    add_executable(testing-telemetry-e2e e2e/ClientTelemetryE2E.cpp)
+    target_link_libraries(testing-telemetry-e2e PRIVATE milvus_sdk)
+endif()
+
 # st only available under linux/macos
 if (CMAKE_SYSTEM_NAME MATCHES "(Linux|Darwin)")
 set(ST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/st")

--- a/test/e2e/ClientTelemetryE2E.cpp
+++ b/test/e2e/ClientTelemetryE2E.cpp
@@ -265,7 +265,7 @@ Run() {
 
         status = default_client->UseDatabase("default");
         Require(status.IsOk(), "Default telemetry reconnect failed: " + status.Message());
-        default_manager = default_client->GetTelemetry();
+        Require(default_client->GetTelemetry() == default_manager, "Reconnect replaced the telemetry manager");
         Require(default_manager->ClientId() == default_client_id, "Reconnect changed the runtime client ID");
         Require(default_manager->Config().client_id.empty(), "Reconnect marked the runtime client ID as stable");
         WaitFor("default client reconnect", default_client_id,

--- a/test/e2e/ClientTelemetryE2E.cpp
+++ b/test/e2e/ClientTelemetryE2E.cpp
@@ -1,0 +1,375 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "milvus/ClientRequestContext.h"
+#include "milvus/ClientTelemetry.h"
+#include "milvus/MilvusClient.h"
+#include "milvus/MilvusClientV2.h"
+#include "milvus/thirdparty/nlohmann/json.hpp"
+
+namespace {
+
+using Json = nlohmann::json;
+
+const std::string kTelemetryHost = std::getenv("MILVUS_TELEMETRY_HOST") == nullptr
+                                       ? "127.0.0.1"
+                                       : std::getenv("MILVUS_TELEMETRY_HOST");
+const uint16_t kTelemetryPort = static_cast<uint16_t>(
+    std::getenv("MILVUS_TELEMETRY_PORT") == nullptr ? 9091 : std::stoi(std::getenv("MILVUS_TELEMETRY_PORT")));
+const std::string kTelemetryBase = "/api/v1/_telemetry";
+
+void
+Require(bool condition, const std::string& message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+std::string
+ToLower(std::string value) {
+    for (auto& character : value) {
+        if (character >= 'A' && character <= 'Z') {
+            character = static_cast<char>(character - 'A' + 'a');
+        }
+    }
+    return value;
+}
+
+std::string
+DecodeChunked(const std::string& body) {
+    std::string decoded;
+    size_t offset = 0;
+    while (offset < body.size()) {
+        auto line_end = body.find("\r\n", offset);
+        Require(line_end != std::string::npos, "Malformed chunked HTTP response");
+        auto size_text = body.substr(offset, line_end - offset);
+        auto extension = size_text.find(';');
+        if (extension != std::string::npos) {
+            size_text.resize(extension);
+        }
+        size_t chunk_size = std::stoul(size_text, nullptr, 16);
+        offset = line_end + 2;
+        if (chunk_size == 0) {
+            break;
+        }
+        Require(offset + chunk_size <= body.size(), "Truncated chunked HTTP response");
+        decoded.append(body, offset, chunk_size);
+        offset += chunk_size + 2;
+    }
+    return decoded;
+}
+
+std::string
+HttpRequest(const std::string& method, const std::string& path, const std::string& body = "") {
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    addrinfo* addresses = nullptr;
+    auto port = std::to_string(kTelemetryPort);
+    int lookup = getaddrinfo(kTelemetryHost.c_str(), port.c_str(), &hints, &addresses);
+    Require(lookup == 0, std::string("getaddrinfo failed: ") + gai_strerror(lookup));
+
+    int socket_fd = -1;
+    for (auto* address = addresses; address != nullptr; address = address->ai_next) {
+        socket_fd = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
+        if (socket_fd >= 0 && connect(socket_fd, address->ai_addr, address->ai_addrlen) == 0) {
+            break;
+        }
+        if (socket_fd >= 0) {
+            close(socket_fd);
+        }
+        socket_fd = -1;
+    }
+    freeaddrinfo(addresses);
+    Require(socket_fd >= 0, "Unable to connect to Milvus telemetry HTTP endpoint");
+
+    std::ostringstream request;
+    request << method << " " << path << " HTTP/1.1\r\n"
+            << "Host: " << kTelemetryHost << ':' << kTelemetryPort << "\r\n"
+            << "Accept: application/json\r\n"
+            << "Connection: close\r\n";
+    if (!body.empty()) {
+        request << "Content-Type: application/json\r\n" << "Content-Length: " << body.size() << "\r\n";
+    }
+    request << "\r\n" << body;
+    auto wire = request.str();
+    size_t sent = 0;
+    while (sent < wire.size()) {
+        auto count = send(socket_fd, wire.data() + sent, wire.size() - sent, 0);
+        if (count <= 0) {
+            close(socket_fd);
+            throw std::runtime_error("Failed to send telemetry HTTP request");
+        }
+        sent += static_cast<size_t>(count);
+    }
+
+    std::string response;
+    char buffer[8192];
+    while (true) {
+        auto count = recv(socket_fd, buffer, sizeof(buffer), 0);
+        if (count < 0) {
+            close(socket_fd);
+            throw std::runtime_error("Failed to read telemetry HTTP response");
+        }
+        if (count == 0) {
+            break;
+        }
+        response.append(buffer, static_cast<size_t>(count));
+    }
+    close(socket_fd);
+
+    auto headers_end = response.find("\r\n\r\n");
+    Require(headers_end != std::string::npos, "Malformed telemetry HTTP response");
+    auto headers = response.substr(0, headers_end);
+    auto status_end = headers.find("\r\n");
+    auto status_line = headers.substr(0, status_end);
+    Require(status_line.find(" 200 ") != std::string::npos, "Telemetry HTTP request failed: " + status_line);
+    auto response_body = response.substr(headers_end + 4);
+    if (ToLower(headers).find("transfer-encoding: chunked") != std::string::npos) {
+        response_body = DecodeChunked(response_body);
+    }
+    return response_body;
+}
+
+Json
+ClientState(const std::string& client_id) {
+    auto response = Json::parse(HttpRequest(
+        "GET", kTelemetryBase + "/clients?client_id=" + client_id + "&include_metrics=true"));
+    auto clients = response.value("clients", Json::array());
+    return clients.empty() ? Json() : clients.at(0);
+}
+
+Json
+WaitFor(const std::string& label, const std::string& client_id, const std::function<bool(const Json&)>& predicate) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
+    Json last;
+    while (std::chrono::steady_clock::now() < deadline) {
+        last = ClientState(client_id);
+        if (!last.is_null() && predicate(last)) {
+            std::cout << "PASS " << label << std::endl;
+            return last;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
+    throw std::runtime_error("Timed out waiting for " + label + "; last=" + last.dump());
+}
+
+std::string
+PushCommand(const std::string& client_id, const std::string& command_type, const Json& payload,
+            bool persistent = false) {
+    Json request = {{"command_type", command_type},
+                    {"target_client_id", client_id},
+                    {"payload", payload},
+                    {"ttl_seconds", 30},
+                    {"persistent", persistent}};
+    auto response = Json::parse(HttpRequest("POST", kTelemetryBase + "/commands", request.dump()));
+    return response.at("command_id").get<std::string>();
+}
+
+Json
+FindReply(const Json& state, const std::string& command_id) {
+    auto replies = state.value("command_replies", Json::array());
+    for (const auto& reply : replies) {
+        if (reply.value("command_id", "") == command_id) {
+            return reply;
+        }
+    }
+    return Json();
+}
+
+Json
+WaitForReply(const std::string& client_id, const std::string& command_id) {
+    auto state = WaitFor("command reply " + command_id, client_id,
+                         [&command_id](const Json& candidate) { return !FindReply(candidate, command_id).is_null(); });
+    return FindReply(state, command_id);
+}
+
+bool
+HasMetric(const Json& state, const std::string& operation, const std::string& counter, int64_t minimum,
+          const std::string& collection = "") {
+    auto metrics = state.value("metrics", Json::array());
+    for (const auto& metric : metrics) {
+        if (metric.value("operation", "") != operation) {
+            continue;
+        }
+        auto global = metric.value("global", Json::object());
+        if (global.value(counter, static_cast<int64_t>(0)) < minimum) {
+            continue;
+        }
+        if (collection.empty()) {
+            return true;
+        }
+        auto collections = metric.value("collection_metrics", Json::object());
+        return collections.find(collection) != collections.end();
+    }
+    return false;
+}
+
+int
+Run() {
+    auto milvus_host = std::getenv("MILVUS_HOST") == nullptr ? "127.0.0.1" : std::getenv("MILVUS_HOST");
+    auto milvus_port = static_cast<uint16_t>(
+        std::getenv("MILVUS_PORT") == nullptr ? 19530 : std::stoi(std::getenv("MILVUS_PORT")));
+
+    {
+        auto legacy_client_id = "e2e-cpp-legacy-" + milvus::ClientRequestContext::NewRequestId();
+        milvus::TelemetryConfig legacy_telemetry;
+        legacy_telemetry.client_id = legacy_client_id;
+        legacy_telemetry.heartbeat_interval_ms = 500;
+        milvus::ConnectParam legacy_param{milvus_host, milvus_port};
+        legacy_param.WithTelemetryConfig(legacy_telemetry);
+        auto legacy_client = milvus::MilvusClient::Create();
+        auto status = legacy_client->Connect(legacy_param);
+        Require(status.IsOk(), "Legacy telemetry connect failed: " + status.Message());
+        Require(legacy_client->GetTelemetry()->ClientId() == legacy_client_id,
+                "Unexpected legacy telemetry client ID");
+        WaitFor("legacy client registration", legacy_client_id,
+                [](const Json& state) { return state.value("status", "") == "active"; });
+        status = legacy_client->Disconnect();
+        Require(status.IsOk(), "Legacy telemetry disconnect failed: " + status.Message());
+    }
+
+    {
+        milvus::ConnectParam default_param{milvus_host, milvus_port};
+        auto default_client = milvus::MilvusClientV2::Create();
+        auto status = default_client->Connect(default_param);
+        Require(status.IsOk(), "Default telemetry connect failed: " + status.Message());
+        auto default_manager = default_client->GetTelemetry();
+        Require(default_manager != nullptr, "Default telemetry manager is missing");
+        Require(default_manager->Config().client_id.empty(), "Generated client ID was marked as stable");
+        auto default_client_id = default_manager->ClientId();
+        WaitFor("default client registration", default_client_id,
+                [](const Json& state) { return state.value("status", "") == "active"; });
+
+        status = default_client->UseDatabase("default");
+        Require(status.IsOk(), "Default telemetry reconnect failed: " + status.Message());
+        default_manager = default_client->GetTelemetry();
+        Require(default_manager->ClientId() == default_client_id, "Reconnect changed the runtime client ID");
+        Require(default_manager->Config().client_id.empty(), "Reconnect marked the runtime client ID as stable");
+        WaitFor("default client reconnect", default_client_id,
+                [](const Json& state) { return state.value("status", "") == "active"; });
+        status = default_client->Disconnect();
+        Require(status.IsOk(), "Default telemetry disconnect failed: " + status.Message());
+    }
+
+    auto trace_suffix = milvus::ClientRequestContext::NewRequestId();
+    auto client_id = "e2e-cpp-" + trace_suffix;
+    milvus::TelemetryConfig telemetry_config;
+    telemetry_config.client_id = client_id;
+    telemetry_config.heartbeat_interval_ms = 500;
+    telemetry_config.sampling_rate = 1.0;
+
+    milvus::ConnectParam connect_param{milvus_host, milvus_port};
+    connect_param.WithTelemetryConfig(telemetry_config);
+
+    auto client = milvus::MilvusClientV2::Create();
+    auto status = client->Connect(connect_param);
+    Require(status.IsOk(), "Milvus connect failed: " + status.Message());
+    try {
+        auto manager = client->GetTelemetry();
+        Require(manager != nullptr, "Telemetry manager is missing");
+        Require(manager->ClientId() == client_id, "Unexpected telemetry client ID");
+        WaitFor("client registration", client_id,
+                [](const Json& state) { return state.value("status", "") == "active"; });
+
+        milvus::RunAnalyzerRequest analyzer_request;
+        analyzer_request.AddText("hello milvus telemetry")
+            .WithAnalyzerParams({{"type", "standard"}})
+            .WithDetail(true);
+        milvus::RunAnalyzerResponse analyzer_response;
+        status = client->RunAnalyzer(analyzer_request, analyzer_response);
+        Require(status.IsOk(), "RunAnalyzer failed: " + status.Message());
+        const auto& tokens = analyzer_response.Results().at(0).Tokens();
+        Require(tokens.size() == 3 && tokens[0].token_ == "hello" && tokens[1].token_ == "milvus" &&
+                    tokens[2].token_ == "telemetry",
+                "Unexpected RunAnalyzer tokens");
+        WaitFor("RunAnalyzer metric", client_id,
+                [](const Json& state) { return HasMetric(state, "RunAnalyzer", "success_count", 1); });
+
+        auto collection_command =
+            PushCommand(client_id, "collection_metrics", {{"collections", {"*"}}, {"enabled", true}});
+        Require(WaitForReply(client_id, collection_command).value("success", false),
+                "collection_metrics command failed");
+
+        auto request_id = milvus::ClientRequestContext::NewRequestId();
+        {
+            milvus::ScopedClientRequestId scoped(request_id);
+            milvus::QueryRequest query_request;
+            query_request.WithCollectionName("telemetry_e2e_missing").WithFilter("id > 0");
+            milvus::QueryResponse query_response;
+            status = client->Query(query_request, query_response);
+        }
+        Require(!status.IsOk(), "Query against missing collection unexpectedly succeeded");
+        WaitFor("failed Query collection metric", client_id, [](const Json& state) {
+            return HasMetric(state, "Query", "error_count", 1, "telemetry_e2e_missing");
+        });
+
+        auto errors_reply = WaitForReply(client_id, PushCommand(client_id, "show_errors", {{"max_count", 10}}));
+        Require(errors_reply.value("success", false), "show_errors command failed");
+        auto errors = Json::parse(errors_reply.at("payload").get<std::string>());
+        bool trace_found = false;
+        for (const auto& error : errors) {
+            trace_found = trace_found || (error.value("operation", "") == "Query" &&
+                                          error.value("request_id", "") == request_id);
+        }
+        Require(trace_found, "show_errors did not include the request ID");
+        std::cout << "PASS request-id in show_errors" << std::endl;
+
+        Json config_payload = {{"sampling_rate", 0.75}, {"heartbeat_interval_ms", 600}};
+        auto config_command = PushCommand(client_id, "push_config", config_payload, true);
+        Require(WaitForReply(client_id, config_command).value("success", false), "push_config command failed");
+        milvus::TelemetryCommand expected_config{config_command, "push_config", config_payload.dump(), 0, true, ""};
+        Require(manager->ConfigHash() == milvus::ClientTelemetryManager::CalculateConfigHash({expected_config}),
+                "Persistent config hash mismatch");
+        Require(manager->LastCommandTimestamp() > 0, "Command timestamp was not updated");
+
+        auto get_config_reply = WaitForReply(client_id, PushCommand(client_id, "get_config", Json::object()));
+        Require(get_config_reply.value("success", false), "get_config command failed");
+        auto user_config = Json::parse(get_config_reply.at("payload").get<std::string>()).at("user_config");
+        Require(user_config.value("telemetry_sampling_rate", 0.0) == 0.75, "Sampling rate was not applied");
+        Require(user_config.value("telemetry_heartbeat_interval_ms", 0) == 600,
+                "Heartbeat interval was not applied");
+        Require(user_config.value("all_collections_enabled", false), "Collection metrics wildcard was not applied");
+        std::cout << "CPP_E2E_OK " << client_id << std::endl;
+    } catch (...) {
+        client->Disconnect();
+        throw;
+    }
+    status = client->Disconnect();
+    Require(status.IsOk(), "Milvus disconnect failed: " + status.Message());
+    return 0;
+}
+
+}  // namespace
+
+int
+main() {
+    try {
+        return Run();
+    } catch (const std::exception& exception) {
+        std::cerr << "CPP_E2E_FAILED: " << exception.what() << std::endl;
+        return 1;
+    }
+}

--- a/test/it/v1/TestConnection.cpp
+++ b/test/it/v1/TestConnection.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <condition_variable>
+#include <milvus/thirdparty/nlohmann/json.hpp>
 #include <mutex>
 #include <thread>
 
@@ -65,6 +66,11 @@ TEST_F(UnconnectMilvusMockedTest, ResolveDatabaseNamePreservesEmptyForRpc) {
     ASSERT_TRUE(empty_db_handler.Connect(milvus::ConnectParam{"127.0.0.1", server_.ListenPort()}).IsOk());
     EXPECT_EQ(empty_db_handler.CurrentDbName(""), "");
     EXPECT_EQ(empty_db_handler.CurrentDbName("request_db"), "request_db");
+    auto empty_db_telemetry = empty_db_handler.GetTelemetry();
+    empty_db_telemetry->ProcessCommands({{"empty-db", "get_config", "", 1, false, ""}});
+    auto empty_db_replies = empty_db_telemetry->PendingCommandReplies();
+    ASSERT_FALSE(empty_db_replies.empty());
+    EXPECT_EQ(nlohmann::json::parse(empty_db_replies.back().payload)["user_config"]["db_name"], "");
 
     milvus::ConnectParam explicit_db_param{"127.0.0.1", server_.ListenPort()};
     explicit_db_param.SetDbName("connected_db");
@@ -72,6 +78,11 @@ TEST_F(UnconnectMilvusMockedTest, ResolveDatabaseNamePreservesEmptyForRpc) {
     ASSERT_TRUE(explicit_db_handler.Connect(explicit_db_param).IsOk());
     EXPECT_EQ(explicit_db_handler.CurrentDbName(""), "connected_db");
     EXPECT_EQ(explicit_db_handler.CurrentDbName("request_db"), "request_db");
+    auto explicit_db_telemetry = explicit_db_handler.GetTelemetry();
+    explicit_db_telemetry->ProcessCommands({{"explicit-db", "get_config", "", 1, false, ""}});
+    auto explicit_db_replies = explicit_db_telemetry->PendingCommandReplies();
+    ASSERT_FALSE(explicit_db_replies.empty());
+    EXPECT_EQ(nlohmann::json::parse(explicit_db_replies.back().payload)["user_config"]["db_name"], "connected_db");
 }
 
 TEST_F(UnconnectMilvusMockedTest, ConnectServerRejected) {
@@ -145,7 +156,7 @@ TEST_F(UnconnectMilvusMockedTest, FailedReconnectPreservesExistingConnection) {
     EXPECT_TRUE(has_collection);
 }
 
-TEST_F(UnconnectMilvusMockedTest, ConnectionMutationWaitsForConnectAndAppliesToNewConnection) {
+TEST_F(UnconnectMilvusMockedTest, ConnectionMutationFailsFastDuringConnectAndCanBeRetried) {
     milvus::ConnectionHandler handler;
     milvus::ConnectParam connect_param{"127.0.0.1", server_.ListenPort()};
 
@@ -195,7 +206,7 @@ TEST_F(UnconnectMilvusMockedTest, ConnectionMutationWaitsForConnectAndAppliesToN
     {
         std::unique_lock<std::mutex> lock(setter_mutex);
         setter_cv.wait(lock, [&] { return setter_started; });
-        EXPECT_FALSE(setter_cv.wait_for(lock, std::chrono::milliseconds(50), [&] { return setter_finished; }));
+        EXPECT_TRUE(setter_cv.wait_for(lock, std::chrono::seconds(1), [&] { return setter_finished; }));
     }
 
     {
@@ -207,7 +218,8 @@ TEST_F(UnconnectMilvusMockedTest, ConnectionMutationWaitsForConnectAndAppliesToN
     connect_thread.join();
     setter_thread.join();
     EXPECT_TRUE(connect_status.IsOk());
-    EXPECT_TRUE(setter_status.IsOk());
+    EXPECT_EQ(setter_status.Code(), StatusCode::CLIENT_BUSY);
+    EXPECT_TRUE(handler.SetRpcDeadlineMs(1234).IsOk());
     EXPECT_EQ(handler.GetRpcDeadlineMs(), 1234);
 }
 

--- a/test/it/v1/TestUseDatabase.cpp
+++ b/test/it/v1/TestUseDatabase.cpp
@@ -41,9 +41,12 @@ TEST_F(UnconnectMilvusMockedTest, UseDatabase) {
     status = client_->CurrentUsedDatabase(db_name);
     EXPECT_TRUE(status.IsOk());
     EXPECT_EQ(db_name, "AAA");
+    auto telemetry = client_->GetTelemetry();
+    ASSERT_NE(telemetry, nullptr);
 
     status = client_->UseDatabase("BBB");
     EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(client_->GetTelemetry(), telemetry);
 
     status = client_->CurrentUsedDatabase(db_name);
     EXPECT_TRUE(status.IsOk());

--- a/test/ut/TestClientRequestContextV1Aggregate.cpp
+++ b/test/ut/TestClientRequestContextV1Aggregate.cpp
@@ -1,0 +1,24 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "milvus/MilvusClient.h"
+
+TEST(ClientRequestContextAggregateTest, V1HeaderExportsRequestContext) {
+    milvus::ScopedClientRequestId scoped("v1-aggregate");
+    EXPECT_EQ(milvus::ClientRequestContext::Get(), "v1-aggregate");
+}

--- a/test/ut/TestClientRequestContextV2Aggregate.cpp
+++ b/test/ut/TestClientRequestContextV2Aggregate.cpp
@@ -1,0 +1,24 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "milvus/MilvusClientV2.h"
+
+TEST(ClientRequestContextAggregateTest, V2HeaderExportsRequestContext) {
+    milvus::ScopedClientRequestId scoped("v2-aggregate");
+    EXPECT_EQ(milvus::ClientRequestContext::Get(), "v2-aggregate");
+}

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -52,6 +52,31 @@ TEST(ClientTelemetryTest, AppliesCommandsAndDeduplicatesIds) {
     EXPECT_EQ(calls, 1);
 }
 
+TEST(ClientTelemetryTest, StopAndRestartPreserveCommandState) {
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    milvus::ClientTelemetryManager manager(config);
+    int calls = 0;
+    manager.RegisterCommandHandler("custom", [&calls](const milvus::TelemetryCommand& command) {
+        ++calls;
+        return milvus::TelemetryCommandReply{command.command_id, true, "", ""};
+    });
+    const milvus::TelemetryCommand command{"custom", "custom", "", 2, false, ""};
+
+    manager.ProcessCommands({command});
+    manager.Start();
+    EXPECT_TRUE(manager.IsReady());
+    manager.Stop();
+    EXPECT_FALSE(manager.IsReady());
+    manager.Start();
+    EXPECT_TRUE(manager.IsReady());
+    manager.ProcessCommands({command});
+
+    EXPECT_EQ(calls, 1);
+    EXPECT_EQ(manager.LastCommandTimestamp(), 2);
+    manager.Stop();
+}
+
 TEST(ClientRequestContextTest, GeneratesAndScopesTraceIds) {
     auto request_id = milvus::ClientRequestContext::NewRequestId();
     EXPECT_EQ(request_id.size(), 32U);

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -1,0 +1,68 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#include <gtest/gtest.h>
+
+#include "milvus/ClientRequestContext.h"
+#include "milvus/ClientTelemetry.h"
+
+TEST(ClientTelemetryTest, MatchesCrossSdkConfigHashVector) {
+    std::vector<milvus::TelemetryCommand> commands = {
+        {"cfg-b", "push_config", "{\"sampling_rate\":0.5}", 0, true, ""},
+        {"cfg-a", "push_config", "{\"heartbeat_interval_ms\":5000}", 0, true, ""},
+    };
+    EXPECT_EQ(milvus::ClientTelemetryManager::CalculateConfigHash(commands), "a271ff0bb1941777");
+}
+
+TEST(ClientTelemetryTest, RuntimeClientIdDoesNotBecomeStableConfiguration) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config, "runtime-client-id");
+
+    EXPECT_EQ(manager.ClientId(), "runtime-client-id");
+    EXPECT_TRUE(manager.Config().client_id.empty());
+}
+
+TEST(ClientTelemetryTest, AppliesCommandsAndDeduplicatesIds) {
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    milvus::ClientTelemetryManager manager(config);
+    int calls = 0;
+    manager.RegisterCommandHandler("custom", [&calls](const milvus::TelemetryCommand& command) {
+        ++calls;
+        return milvus::TelemetryCommandReply{command.command_id, true, "", ""};
+    });
+
+    manager.ProcessCommands({
+        {"config", "push_config", "{\"heartbeat_interval_ms\":5000,\"sampling_rate\":0.25}", 1, true, ""},
+        {"custom", "custom", "", 2, false, ""},
+    });
+    manager.ProcessCommands({{"custom", "custom", "", 2, false, ""}});
+
+    EXPECT_EQ(manager.Config().heartbeat_interval_ms, 5000U);
+    EXPECT_DOUBLE_EQ(manager.Config().sampling_rate, 0.25);
+    EXPECT_EQ(manager.LastCommandTimestamp(), 2);
+    EXPECT_FALSE(manager.ConfigHash().empty());
+    EXPECT_EQ(calls, 1);
+}
+
+TEST(ClientRequestContextTest, GeneratesAndScopesTraceIds) {
+    auto request_id = milvus::ClientRequestContext::NewRequestId();
+    EXPECT_EQ(request_id.size(), 32U);
+    EXPECT_EQ(request_id.find_first_not_of("0123456789abcdef"), std::string::npos);
+    EXPECT_NE(request_id, std::string(32, '0'));
+
+    milvus::ClientRequestContext::Set("outer");
+    {
+        milvus::ScopedClientRequestId scoped("inner");
+        EXPECT_EQ(milvus::ClientRequestContext::Get(), "inner");
+    }
+    EXPECT_EQ(milvus::ClientRequestContext::Get(), "outer");
+    milvus::ClientRequestContext::Clear();
+}

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -28,6 +28,7 @@
 #include "milvus/ClientRequestContext.h"
 #include "milvus/ClientTelemetry.h"
 #include "milvus/MilvusClient.h"
+#include "milvus/MilvusClientV2.h"
 
 namespace {
 
@@ -132,8 +133,24 @@ class LifecycleTelemetryService final : public milvus::proto::milvus::MilvusServ
 
     grpc::Status
     Connect(grpc::ServerContext*, const milvus::proto::milvus::ConnectRequest*,
-            milvus::proto::milvus::ConnectResponse*) override {
-        ++connects;
+            milvus::proto::milvus::ConnectResponse* response) override {
+        {
+            std::lock_guard<std::mutex> lock(connect_mutex_);
+            ++connects;
+            if (fail_next_connect_) {
+                fail_next_connect_ = false;
+                response->mutable_status()->set_code(1);
+                response->mutable_status()->set_reason("rejected connect");
+            }
+        }
+        connect_condition_.notify_all();
+        return grpc::Status::OK;
+    }
+
+    grpc::Status
+    HasCollection(grpc::ServerContext*, const milvus::proto::milvus::HasCollectionRequest*,
+                  milvus::proto::milvus::BoolResponse*) override {
+        ++has_collections;
         return grpc::Status::OK;
     }
 
@@ -144,6 +161,11 @@ class LifecycleTelemetryService final : public milvus::proto::milvus::MilvusServ
         const auto database = request->client_info().reserved().find("db_name");
         if (database != request->client_info().reserved().end() && database->second == "secondary") {
             saw_secondary_database = true;
+        }
+        for (const auto& reply : request->command_replies()) {
+            if (reply.command_id() == command_type_ && !reply.success()) {
+                saw_failed_command_reply = true;
+            }
         }
         if (commands_enabled.load() && !command_sent.exchange(true)) {
             auto* command = response->add_commands();
@@ -156,17 +178,67 @@ class LifecycleTelemetryService final : public milvus::proto::milvus::MilvusServ
 
     std::atomic<int> connects{0};
     std::atomic<int> heartbeats{0};
+    std::atomic<int> has_collections{0};
     std::atomic<bool> saw_secondary_database{false};
+    std::atomic<bool> saw_failed_command_reply{false};
 
     void
     EnableCommands() {
         commands_enabled = true;
     }
 
+    void
+    FailNextConnect() {
+        std::lock_guard<std::mutex> lock(connect_mutex_);
+        fail_next_connect_ = true;
+    }
+
+    bool
+    WaitForConnects(int count) {
+        std::unique_lock<std::mutex> lock(connect_mutex_);
+        return connect_condition_.wait_for(lock, std::chrono::seconds(2),
+                                           [this, count]() { return connects.load() >= count; });
+    }
+
  private:
     std::string command_type_;
     std::atomic<bool> commands_enabled{false};
     std::atomic<bool> command_sent{false};
+    std::mutex connect_mutex_;
+    std::condition_variable connect_condition_;
+    bool fail_next_connect_{false};
+};
+
+class RequestMetadataService final : public milvus::proto::milvus::MilvusService::Service {
+ public:
+    grpc::Status
+    Connect(grpc::ServerContext*, const milvus::proto::milvus::ConnectRequest*,
+            milvus::proto::milvus::ConnectResponse*) override {
+        return grpc::Status::OK;
+    }
+
+    grpc::Status
+    HasCollection(grpc::ServerContext* context, const milvus::proto::milvus::HasCollectionRequest*,
+                  milvus::proto::milvus::BoolResponse*) override {
+        const auto& metadata = context->client_metadata();
+        const auto request_id = metadata.find("client_request_id");
+        std::lock_guard<std::mutex> lock(mutex_);
+        request_ids_.emplace_back(request_id != metadata.end(),
+                                  request_id == metadata.end()
+                                      ? std::string{}
+                                      : std::string(request_id->second.data(), request_id->second.size()));
+        return grpc::Status::OK;
+    }
+
+    std::vector<std::pair<bool, std::string>>
+    RequestIds() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return request_ids_;
+    }
+
+ private:
+    mutable std::mutex mutex_;
+    std::vector<std::pair<bool, std::string>> request_ids_;
 };
 
 class DestructionSignal final {
@@ -532,6 +604,172 @@ TEST(ClientTelemetryTest, UseDatabaseFromHeartbeatCommandReusesWorker) {
     server->Shutdown();
 }
 
+TEST(ClientTelemetryTest, AllLifecycleEntriesFailFastWhenConcurrentConnectWaitsForCommandLock) {
+    LifecycleTelemetryService service("connect");
+    int port = 0;
+    auto server = StartLifecycleServer(service, port);
+    ASSERT_NE(server, nullptr);
+
+    const auto connect_param = TelemetryConnectParam(port);
+    auto client = milvus::MilvusClient::Create();
+    ASSERT_TRUE(client->Connect(connect_param).IsOk());
+
+    std::atomic<bool> handler_started{false};
+    auto handler_finished = std::make_shared<std::promise<std::vector<milvus::StatusCode>>>();
+    auto handler_future = handler_finished->get_future();
+    client->GetTelemetry()->RegisterCommandHandler(
+        "connect", [&, handler_finished](const milvus::TelemetryCommand& command) {
+            handler_started = true;
+            if (!service.WaitForConnects(2)) {
+                handler_finished->set_value({milvus::StatusCode::UNKNOWN_ERROR});
+                return milvus::TelemetryCommandReply{command.command_id, false, "concurrent connect did not run", ""};
+            }
+
+            // The external Connect has completed its server handshake and owns lifecycle_mtx_,
+            // but its AttachChannel is blocked on this handler's command_mutex. Every re-entrant
+            // lifecycle entry must fail fast rather than wait and complete the lock cycle.
+            std::vector<milvus::StatusCode> codes;
+            codes.push_back(client->Connect(connect_param).Code());
+            codes.push_back(client->UseDatabase("other").Code());
+            codes.push_back(client->Disconnect().Code());
+            codes.push_back(client->SetRpcDeadlineMs(1234).Code());
+            codes.push_back(client->SetRetryParam(milvus::RetryParam{}).Code());
+            bool all_busy = true;
+            for (auto code : codes) {
+                all_busy = all_busy && code == milvus::StatusCode::CLIENT_BUSY;
+            }
+            handler_finished->set_value(codes);
+            return milvus::TelemetryCommandReply{command.command_id, all_busy, "", ""};
+        });
+
+    service.EnableCommands();
+    for (int retry = 0; retry < 2000 && !handler_started.load(); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(handler_started.load());
+
+    milvus::Status concurrent_status;
+    std::thread concurrent_connect([&]() { concurrent_status = client->Connect(connect_param); });
+    const bool handler_failed_fast = handler_future.wait_for(std::chrono::seconds(1)) == std::future_status::ready;
+    concurrent_connect.join();
+
+    EXPECT_TRUE(handler_failed_fast);
+    ASSERT_EQ(handler_future.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    const auto codes = handler_future.get();
+    ASSERT_EQ(codes.size(), 5U);
+    for (auto code : codes) {
+        EXPECT_EQ(code, milvus::StatusCode::CLIENT_BUSY);
+    }
+    EXPECT_TRUE(concurrent_status.IsOk()) << concurrent_status.Message();
+
+    EXPECT_TRUE(client->Disconnect().IsOk());
+    client.reset();
+    server->Shutdown();
+}
+
+TEST(ClientTelemetryTest, FailedUseDatabasePreservesPublishedConnectionAndTelemetry) {
+    LifecycleTelemetryService service("");
+    int port = 0;
+    auto server = StartLifecycleServer(service, port);
+    ASSERT_NE(server, nullptr);
+
+    auto connect_param = TelemetryConnectParam(port);
+    connect_param.SetDbName("primary");
+    auto client = milvus::MilvusClient::Create();
+    ASSERT_TRUE(client->Connect(connect_param).IsOk());
+    auto manager = client->GetTelemetry();
+    ASSERT_NE(manager, nullptr);
+    const auto client_id = manager->ClientId();
+
+    service.FailNextConnect();
+    const auto status = client->UseDatabase("secondary");
+    EXPECT_EQ(status.Code(), milvus::StatusCode::SERVER_FAILED);
+    ASSERT_EQ(client->GetTelemetry(), manager);
+    EXPECT_EQ(manager->ClientId(), client_id);
+
+    bool has_collection = false;
+    EXPECT_TRUE(client->HasCollection("still-connected", has_collection).IsOk());
+    EXPECT_EQ(service.has_collections.load(), 1);
+
+    manager->ProcessCommands({{"config-after-failure", "get_config", "", 10, false, ""}});
+    const auto replies = manager->PendingCommandReplies();
+    ASSERT_FALSE(replies.empty());
+    ASSERT_TRUE(replies.back().success) << replies.back().error_message;
+    const auto user_config = nlohmann::json::parse(replies.back().payload).at("user_config");
+    EXPECT_EQ(user_config.at("db_name"), "primary");
+
+    EXPECT_TRUE(client->Disconnect().IsOk());
+    client.reset();
+    server->Shutdown();
+}
+
+TEST(ClientTelemetryTest, FailedConnectPreservesPublishedConnectionAndTelemetry) {
+    LifecycleTelemetryService first_service("");
+    LifecycleTelemetryService rejected_service("");
+    int first_port = 0;
+    int rejected_port = 0;
+    auto first_server = StartLifecycleServer(first_service, first_port);
+    auto rejected_server = StartLifecycleServer(rejected_service, rejected_port);
+    ASSERT_NE(first_server, nullptr);
+    ASSERT_NE(rejected_server, nullptr);
+
+    auto first_param = TelemetryConnectParam(first_port);
+    first_param.SetDbName("primary");
+    auto client = milvus::MilvusClient::Create();
+    ASSERT_TRUE(client->Connect(first_param).IsOk());
+    auto manager = client->GetTelemetry();
+    ASSERT_NE(manager, nullptr);
+    const auto client_id = manager->ClientId();
+
+    rejected_service.FailNextConnect();
+    const auto status = client->Connect(TelemetryConnectParam(rejected_port));
+    EXPECT_EQ(status.Code(), milvus::StatusCode::SERVER_FAILED);
+    ASSERT_EQ(client->GetTelemetry(), manager);
+    EXPECT_EQ(manager->ClientId(), client_id);
+
+    bool has_collection = false;
+    EXPECT_TRUE(client->HasCollection("still-on-first", has_collection).IsOk());
+    EXPECT_EQ(first_service.has_collections.load(), 1);
+    EXPECT_EQ(rejected_service.has_collections.load(), 0);
+
+    manager->ProcessCommands({{"config-after-rejected-connect", "get_config", "", 10, false, ""}});
+    const auto replies = manager->PendingCommandReplies();
+    ASSERT_FALSE(replies.empty());
+    ASSERT_TRUE(replies.back().success) << replies.back().error_message;
+    const auto user_config = nlohmann::json::parse(replies.back().payload).at("user_config");
+    EXPECT_EQ(user_config.at("address"), "127.0.0.1:" + std::to_string(first_port));
+    EXPECT_EQ(user_config.at("db_name"), "primary");
+
+    EXPECT_TRUE(client->Disconnect().IsOk());
+    client.reset();
+    first_server->Shutdown();
+    rejected_server->Shutdown();
+}
+
+TEST(ClientTelemetryTest, NonStandardCommandExceptionReturnsFailureAndHeartbeatContinues) {
+    LifecycleTelemetryService service("throw_non_standard");
+    int port = 0;
+    auto server = StartLifecycleServer(service, port);
+    ASSERT_NE(server, nullptr);
+
+    auto client = milvus::MilvusClient::Create();
+    ASSERT_TRUE(client->Connect(TelemetryConnectParam(port)).IsOk());
+    client->GetTelemetry()->RegisterCommandHandler(
+        "throw_non_standard", [](const milvus::TelemetryCommand&) -> milvus::TelemetryCommandReply { throw 42; });
+    service.EnableCommands();
+
+    for (int retry = 0; retry < 3000 && (service.heartbeats.load() < 3 || !service.saw_failed_command_reply.load());
+         ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_GE(service.heartbeats.load(), 3);
+    EXPECT_TRUE(service.saw_failed_command_reply.load());
+
+    EXPECT_TRUE(client->Disconnect().IsOk());
+    client.reset();
+    server->Shutdown();
+}
+
 TEST(ClientTelemetryTest, LastManagerReferenceCanBeDestroyedByHeartbeatCommand) {
     LifecycleTelemetryService service("disconnect_and_destroy");
     int port = 0;
@@ -554,6 +792,74 @@ TEST(ClientTelemetryTest, LastManagerReferenceCanBeDestroyedByHeartbeatCommand) 
 
     ASSERT_EQ(destroyed_future.wait_for(std::chrono::seconds(3)), std::future_status::ready);
     EXPECT_EQ(client, nullptr);
+    server->Shutdown();
+}
+
+TEST(ClientTelemetryTest, V2LastManagerReferenceCanBeDestroyedByHeartbeatCommand) {
+    LifecycleTelemetryService service("disconnect_and_destroy_v2");
+    int port = 0;
+    auto server = StartLifecycleServer(service, port);
+    ASSERT_NE(server, nullptr);
+
+    auto client = milvus::MilvusClientV2::Create();
+    ASSERT_TRUE(client->Connect(TelemetryConnectParam(port)).IsOk());
+    auto destroyed = std::make_shared<std::promise<void>>();
+    auto destroyed_future = destroyed->get_future();
+    auto marker = std::make_shared<DestructionSignal>(destroyed);
+    client->GetTelemetry()->RegisterCommandHandler(
+        "disconnect_and_destroy_v2", [&client, marker](const milvus::TelemetryCommand& command) {
+            auto status = client->Disconnect();
+            client.reset();
+            return milvus::TelemetryCommandReply{command.command_id, status.IsOk(), "", ""};
+        });
+    marker.reset();
+    service.EnableCommands();
+
+    ASSERT_EQ(destroyed_future.wait_for(std::chrono::seconds(3)), std::future_status::ready);
+    EXPECT_EQ(client, nullptr);
+    server->Shutdown();
+}
+
+TEST(ClientRequestContextTest, PropagatesOnlyValidTraceIdMetadataOnWire) {
+    RequestMetadataService service;
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    auto client = milvus::MilvusClient::Create();
+    auto connect_param = TelemetryConnectParam(port);
+    milvus::TelemetryConfig telemetry_config;
+    telemetry_config.enabled = false;
+    connect_param.SetTelemetryConfig(telemetry_config);
+    ASSERT_TRUE(client->Connect(connect_param).IsOk());
+
+    bool has_collection = false;
+    constexpr const char* valid_request_id = "4bf92f3577b34da6a3ce929d0e0e4736";
+    {
+        milvus::ScopedClientRequestId request_id(valid_request_id);
+        EXPECT_TRUE(client->HasCollection("valid", has_collection).IsOk());
+    }
+    {
+        milvus::ScopedClientRequestId request_id("");
+        EXPECT_TRUE(client->HasCollection("empty", has_collection).IsOk());
+    }
+    {
+        milvus::ScopedClientRequestId request_id("ABCDEF0123456789ABCDEF0123456789");
+        EXPECT_TRUE(client->HasCollection("invalid", has_collection).IsOk());
+    }
+
+    const auto request_ids = service.RequestIds();
+    ASSERT_EQ(request_ids.size(), 3U);
+    EXPECT_TRUE(request_ids[0].first);
+    EXPECT_EQ(request_ids[0].second, valid_request_id);
+    EXPECT_FALSE(request_ids[1].first);
+    EXPECT_FALSE(request_ids[2].first);
+
+    EXPECT_TRUE(client->Disconnect().IsOk());
+    client.reset();
     server->Shutdown();
 }
 

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -10,6 +10,12 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <milvus/thirdparty/nlohmann/json.hpp>
+#include <thread>
+
+#include "milvus.pb.h"
 #include "milvus/ClientRequestContext.h"
 #include "milvus/ClientTelemetry.h"
 
@@ -52,6 +58,121 @@ TEST(ClientTelemetryTest, AppliesCommandsAndDeduplicatesIds) {
     EXPECT_EQ(calls, 1);
 }
 
+TEST(ClientTelemetryTest, ReconnectReuseMatchesOriginalUserConfig) {
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    config.sampling_rate = 0.5;
+    milvus::ClientTelemetryManager manager(config);
+
+    manager.ProcessCommands({{"remote", "push_config", R"({"sampling_rate":0.25})", 1, true, ""}});
+    EXPECT_DOUBLE_EQ(manager.Config().sampling_rate, 0.25);
+    EXPECT_TRUE(manager.MatchesConnection(config, ""));
+
+    auto changed = config;
+    changed.enabled = true;
+    EXPECT_FALSE(manager.MatchesConnection(changed, ""));
+}
+
+TEST(ClientTelemetryTest, PushConfigIsAtomicAndReportsAppliedAndIgnoredKeys) {
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    milvus::ClientTelemetryManager manager(config);
+
+    manager.ProcessCommands(
+        {{"invalid", "push_config", R"({"enabled":true,"heartbeat_interval_ms":0})", 1, false, ""}});
+    EXPECT_FALSE(manager.Config().enabled);
+    ASSERT_EQ(manager.PendingCommandReplies().size(), 1U);
+    EXPECT_FALSE(manager.PendingCommandReplies().back().success);
+
+    manager.ProcessCommands(
+        {{"valid", "push_config",
+          R"({"unknown_b":1,"sampling_rate":2,"enabled":true,"ttl_seconds":3,"heartbeat_interval_ms":2500,"unknown_a":2})",
+          2, false, ""}});
+    auto updated = manager.Config();
+    EXPECT_TRUE(updated.enabled);
+    EXPECT_EQ(updated.heartbeat_interval_ms, 2500U);
+    EXPECT_DOUBLE_EQ(updated.sampling_rate, 1.0);
+
+    auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 2U);
+    ASSERT_TRUE(replies.back().success);
+    auto payload = nlohmann::json::parse(replies.back().payload);
+    EXPECT_EQ(payload["applied"], nlohmann::json({"enabled", "heartbeat_interval_ms", "sampling_rate"}));
+    EXPECT_EQ(payload["ignored"], nlohmann::json({"ttl_seconds", "unknown_a", "unknown_b"}));
+}
+
+TEST(ClientTelemetryTest, RejectsWrongCommandPayloadTypes) {
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    milvus::ClientTelemetryManager manager(config);
+
+    manager.ProcessCommands(
+        {{"push", "push_config", R"({"enabled":"false"})", 1, false, ""},
+         {"collection", "collection_metrics", R"({"enabled":false,"collections":"books"})", 2, false, ""},
+         {"ttl", "push_config", R"({"enabled":true,"ttl_seconds":"bad"})", 3, false, ""}});
+
+    auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 3U);
+    EXPECT_FALSE(replies[0].success);
+    EXPECT_FALSE(replies[1].success);
+    EXPECT_FALSE(replies[2].success);
+    EXPECT_FALSE(manager.Config().enabled);
+}
+
+TEST(ClientTelemetryTest, SerializesConcurrentCommandBatches) {
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    milvus::ClientTelemetryManager manager(config);
+    std::atomic<int> calls{0};
+    std::atomic<bool> release{false};
+    manager.RegisterCommandHandler("custom", [&calls, &release](const milvus::TelemetryCommand& command) {
+        ++calls;
+        while (!release.load()) {
+            std::this_thread::yield();
+        }
+        return milvus::TelemetryCommandReply{command.command_id, true, "", ""};
+    });
+    const milvus::TelemetryCommand command{"same", "custom", "", 1, false, ""};
+
+    std::thread first([&]() { manager.ProcessCommands({command}); });
+    while (calls.load() == 0) {
+        std::this_thread::yield();
+    }
+    std::thread second([&]() { manager.ProcessCommands({command}); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    release = true;
+    first.join();
+    second.join();
+
+    EXPECT_EQ(calls.load(), 1);
+}
+
+TEST(ClientTelemetryTest, UsesOneFixedPointSamplerAcrossOperations) {
+    milvus::TelemetryConfig config;
+    config.sampling_rate = 0.25;
+    milvus::ClientTelemetryManager manager(config);
+    milvus::proto::milvus::SearchRequest request;
+    request.set_collection_name("books");
+
+    for (int index = 0; index < 12; ++index) {
+        manager.RecordOperation(index % 2 == 0 ? "Search" : "Query", request, std::chrono::steady_clock::now(), true,
+                                "");
+    }
+    manager.Start();
+    for (int retry = 0; retry < 100 && manager.MetricsSnapshots().empty(); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+
+    auto snapshots = manager.MetricsSnapshots();
+    ASSERT_FALSE(snapshots.empty());
+    int64_t sampled = 0;
+    for (const auto& operation : snapshots.back().metrics) {
+        sampled += operation.global.request_count;
+    }
+    EXPECT_EQ(sampled, 3);
+}
+
 TEST(ClientTelemetryTest, StopAndRestartPreserveCommandState) {
     milvus::TelemetryConfig config;
     config.enabled = false;
@@ -82,6 +203,10 @@ TEST(ClientRequestContextTest, GeneratesAndScopesTraceIds) {
     EXPECT_EQ(request_id.size(), 32U);
     EXPECT_EQ(request_id.find_first_not_of("0123456789abcdef"), std::string::npos);
     EXPECT_NE(request_id, std::string(32, '0'));
+    EXPECT_TRUE(milvus::ClientRequestContext::IsValid(request_id));
+    EXPECT_FALSE(milvus::ClientRequestContext::IsValid(std::string(32, '0')));
+    EXPECT_FALSE(milvus::ClientRequestContext::IsValid("ABCDEF0123456789ABCDEF0123456789"));
+    EXPECT_FALSE(milvus::ClientRequestContext::IsValid("short"));
 
     milvus::ClientRequestContext::Set("outer");
     {

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <future>
 #include <iomanip>
 #include <milvus/thirdparty/nlohmann/json.hpp>
@@ -58,6 +59,69 @@ class ReconnectTelemetryService final : public milvus::proto::milvus::ClientTele
     }
 
     std::atomic<int> heartbeats{0};
+};
+
+class ControlPlaneTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest* request,
+                    milvus::proto::milvus::ClientHeartbeatResponse* response) override {
+        std::unique_lock<std::mutex> lock(mutex_);
+        requests_.push_back(*request);
+        const auto heartbeat = requests_.size();
+        condition_.notify_all();
+        if (heartbeat == 1) {
+            auto* command = response->add_commands();
+            command->set_command_id("disable");
+            command->set_command_type("push_config");
+            command->set_payload(R"({"enabled":false})");
+            command->set_create_time(1);
+            command->set_persistent(true);
+        } else if (heartbeat == 2) {
+            condition_.wait(lock, [this]() { return allow_enable_; });
+            auto* command = response->add_commands();
+            command->set_command_id("enable");
+            command->set_command_type("push_config");
+            command->set_payload(R"({"enabled":true})");
+            command->set_create_time(2);
+            command->set_persistent(true);
+        }
+        return grpc::Status::OK;
+    }
+
+    bool
+    WaitForHeartbeats(size_t count) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        return condition_.wait_for(lock, std::chrono::seconds(2),
+                                   [this, count]() { return requests_.size() >= count; });
+    }
+
+    void
+    AllowEnable() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            allow_enable_ = true;
+        }
+        condition_.notify_all();
+    }
+
+    std::vector<milvus::proto::milvus::ClientHeartbeatRequest>
+    Requests() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return requests_;
+    }
+
+    size_t
+    RequestCount() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return requests_.size();
+    }
+
+ private:
+    mutable std::mutex mutex_;
+    std::condition_variable condition_;
+    bool allow_enable_{false};
+    std::vector<milvus::proto::milvus::ClientHeartbeatRequest> requests_;
 };
 
 class LifecycleTelemetryService final : public milvus::proto::milvus::MilvusService::Service,
@@ -352,6 +416,85 @@ TEST(ClientTelemetryTest, ExternalStopWinsRaceWithHeartbeatSelfRestart) {
 
     EXPECT_FALSE(self_restart_ready.load());
     EXPECT_FALSE(manager.IsReady());
+}
+
+TEST(ClientTelemetryTest, DisabledTelemetryKeepsControlPlaneHeartbeatAlive) {
+    ControlPlaneTelemetryService service;
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = 100;
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials()),
+                          "", "", "", "", "");
+    milvus::proto::milvus::SearchRequest request;
+    manager.RecordOperation("Search", request, std::chrono::steady_clock::now(), true, "");
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && manager.Config().enabled; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_FALSE(manager.Config().enabled);
+    manager.Stop();
+    manager.Start();
+    ASSERT_TRUE(service.WaitForHeartbeats(2));
+    ASSERT_FALSE(manager.Config().enabled);
+    manager.RecordOperation("Search", request, std::chrono::steady_clock::now(), true, "");
+    service.AllowEnable();
+    ASSERT_TRUE(service.WaitForHeartbeats(3));
+    manager.Stop();
+
+    const auto requests = service.Requests();
+    ASSERT_GE(requests.size(), 3U);
+    EXPECT_EQ(requests[0].metrics_size(), 1);
+    EXPECT_EQ(requests[1].metrics_size(), 0);
+    ASSERT_EQ(requests[1].command_replies_size(), 1);
+    EXPECT_EQ(requests[1].command_replies(0).command_id(), "disable");
+    EXPECT_TRUE(requests[1].command_replies(0).success());
+    const milvus::TelemetryCommand disable{"disable", "push_config", R"({"enabled":false})", 1, true, ""};
+    EXPECT_EQ(requests[1].config_hash(), milvus::ClientTelemetryManager::CalculateConfigHash({disable}));
+
+    EXPECT_EQ(requests[2].metrics_size(), 0);
+    ASSERT_EQ(requests[2].command_replies_size(), 1);
+    EXPECT_EQ(requests[2].command_replies(0).command_id(), "enable");
+    EXPECT_TRUE(requests[2].command_replies(0).success());
+    const milvus::TelemetryCommand enable{"enable", "push_config", R"({"enabled":true})", 2, true, ""};
+    EXPECT_EQ(requests[2].config_hash(), milvus::ClientTelemetryManager::CalculateConfigHash({enable}));
+    EXPECT_TRUE(manager.Config().enabled);
+
+    server->Shutdown();
+}
+
+TEST(ClientTelemetryTest, InitialDisabledConfigDoesNotActivateControlPlane) {
+    ControlPlaneTelemetryService service;
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    config.heartbeat_interval_ms = 1;
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials()),
+                          "", "", "", "", "");
+
+    manager.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    manager.Stop();
+    manager.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    manager.Stop();
+
+    EXPECT_EQ(service.RequestCount(), 0U);
+    server->Shutdown();
 }
 
 TEST(ClientTelemetryTest, UseDatabaseFromHeartbeatCommandReusesWorker) {

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -119,6 +119,26 @@ TEST(ClientTelemetryTest, RejectsWrongCommandPayloadTypes) {
     EXPECT_FALSE(manager.Config().enabled);
 }
 
+TEST(ClientTelemetryTest, RejectsInvalidRfc3339CalendarTimes) {
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    milvus::ClientTelemetryManager manager(config);
+
+    manager.ProcessCommands(
+        {{"invalid-day", "show_latency_history",
+          R"({"start_time":"2026-02-30T00:00:00Z","end_time":"2026-03-01T00:00:00Z","detail":false})", 1, false, ""},
+         {"leap-second", "show_latency_history",
+          R"({"start_time":"2026-02-28T23:59:60Z","end_time":"2026-03-01T00:00:00Z","detail":false})", 2, false, ""},
+         {"missing-seconds", "show_latency_history",
+          R"({"start_time":"2026-02-28T23:59Z","end_time":"2026-03-01T00:00:00Z","detail":false})", 3, false, ""}});
+
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 3U);
+    EXPECT_FALSE(replies[0].success);
+    EXPECT_FALSE(replies[1].success);
+    EXPECT_FALSE(replies[2].success);
+}
+
 TEST(ClientTelemetryTest, SerializesConcurrentCommandBatches) {
     milvus::TelemetryConfig config;
     config.enabled = false;

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -25,6 +25,7 @@
 #include "milvus.pb.h"
 #include "milvus/ClientRequestContext.h"
 #include "milvus/ClientTelemetry.h"
+#include "milvus/MilvusClient.h"
 
 namespace {
 
@@ -57,6 +58,82 @@ class ReconnectTelemetryService final : public milvus::proto::milvus::ClientTele
 
     std::atomic<int> heartbeats{0};
 };
+
+class LifecycleTelemetryService final : public milvus::proto::milvus::MilvusService::Service,
+                                        public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    explicit LifecycleTelemetryService(std::string command_type) : command_type_(std::move(command_type)) {
+    }
+
+    grpc::Status
+    Connect(grpc::ServerContext*, const milvus::proto::milvus::ConnectRequest*,
+            milvus::proto::milvus::ConnectResponse*) override {
+        ++connects;
+        return grpc::Status::OK;
+    }
+
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest* request,
+                    milvus::proto::milvus::ClientHeartbeatResponse* response) override {
+        ++heartbeats;
+        const auto database = request->client_info().reserved().find("db_name");
+        if (database != request->client_info().reserved().end() && database->second == "secondary") {
+            saw_secondary_database = true;
+        }
+        if (commands_enabled.load() && !command_sent.exchange(true)) {
+            auto* command = response->add_commands();
+            command->set_command_id(command_type_);
+            command->set_command_type(command_type_);
+            command->set_create_time(1);
+        }
+        return grpc::Status::OK;
+    }
+
+    std::atomic<int> connects{0};
+    std::atomic<int> heartbeats{0};
+    std::atomic<bool> saw_secondary_database{false};
+
+    void
+    EnableCommands() {
+        commands_enabled = true;
+    }
+
+ private:
+    std::string command_type_;
+    std::atomic<bool> commands_enabled{false};
+    std::atomic<bool> command_sent{false};
+};
+
+class DestructionSignal final {
+ public:
+    explicit DestructionSignal(std::shared_ptr<std::promise<void>> signal) : signal_(std::move(signal)) {
+    }
+
+    ~DestructionSignal() {
+        signal_->set_value();
+    }
+
+ private:
+    std::shared_ptr<std::promise<void>> signal_;
+};
+
+std::unique_ptr<grpc::Server>
+StartLifecycleServer(LifecycleTelemetryService& service, int& port) {
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(static_cast<milvus::proto::milvus::MilvusService::Service*>(&service));
+    builder.RegisterService(static_cast<milvus::proto::milvus::ClientTelemetryService::Service*>(&service));
+    return builder.BuildAndStart();
+}
+
+milvus::ConnectParam
+TelemetryConnectParam(int port) {
+    milvus::ConnectParam param("http://127.0.0.1:" + std::to_string(port));
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = 1;
+    param.SetTelemetryConfig(config);
+    return param;
+}
 
 }  // namespace
 
@@ -274,6 +351,66 @@ TEST(ClientTelemetryTest, ExternalStopWinsRaceWithHeartbeatSelfRestart) {
 
     EXPECT_FALSE(self_restart_ready.load());
     EXPECT_FALSE(manager.IsReady());
+}
+
+TEST(ClientTelemetryTest, UseDatabaseFromHeartbeatCommandReusesWorker) {
+    LifecycleTelemetryService service("use_database");
+    int port = 0;
+    auto server = StartLifecycleServer(service, port);
+    ASSERT_NE(server, nullptr);
+
+    auto client = milvus::MilvusClient::Create();
+    ASSERT_TRUE(client->Connect(TelemetryConnectParam(port)).IsOk());
+    std::atomic<bool> command_finished{false};
+    std::atomic<bool> use_database_succeeded{false};
+    std::weak_ptr<milvus::MilvusClient> weak_client = client;
+    client->GetTelemetry()->RegisterCommandHandler("use_database", [&](const milvus::TelemetryCommand& command) {
+        auto current_client = weak_client.lock();
+        use_database_succeeded = current_client != nullptr && current_client->UseDatabase("secondary").IsOk();
+        command_finished = true;
+        return milvus::TelemetryCommandReply{command.command_id, use_database_succeeded.load(), "", ""};
+    });
+    service.EnableCommands();
+
+    for (int retry = 0; retry < 3000 && (!command_finished.load() || service.heartbeats.load() < 2 ||
+                                         !service.saw_secondary_database.load());
+         ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    EXPECT_TRUE(command_finished.load());
+    EXPECT_TRUE(use_database_succeeded.load());
+    EXPECT_GE(service.connects.load(), 2);
+    EXPECT_GE(service.heartbeats.load(), 2);
+    EXPECT_TRUE(service.saw_secondary_database.load());
+    EXPECT_TRUE(client->Disconnect().IsOk());
+    client.reset();
+    server->Shutdown();
+}
+
+TEST(ClientTelemetryTest, LastManagerReferenceCanBeDestroyedByHeartbeatCommand) {
+    LifecycleTelemetryService service("disconnect_and_destroy");
+    int port = 0;
+    auto server = StartLifecycleServer(service, port);
+    ASSERT_NE(server, nullptr);
+
+    auto client = milvus::MilvusClient::Create();
+    ASSERT_TRUE(client->Connect(TelemetryConnectParam(port)).IsOk());
+    auto destroyed = std::make_shared<std::promise<void>>();
+    auto destroyed_future = destroyed->get_future();
+    auto marker = std::make_shared<DestructionSignal>(destroyed);
+    client->GetTelemetry()->RegisterCommandHandler(
+        "disconnect_and_destroy", [&client, marker](const milvus::TelemetryCommand& command) {
+            auto status = client->Disconnect();
+            client.reset();
+            return milvus::TelemetryCommandReply{command.command_id, status.IsOk(), "", ""};
+        });
+    marker.reset();
+    service.EnableCommands();
+
+    ASSERT_EQ(destroyed_future.wait_for(std::chrono::seconds(3)), std::future_status::ready);
+    EXPECT_EQ(client, nullptr);
+    server->Shutdown();
 }
 
 TEST(ClientTelemetryTest, ReconnectReuseMatchesOriginalUserConfig) {

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -8,16 +8,57 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
+#include <grpcpp/create_channel.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
 #include <gtest/gtest.h>
 
 #include <atomic>
 #include <chrono>
+#include <future>
+#include <iomanip>
 #include <milvus/thirdparty/nlohmann/json.hpp>
+#include <sstream>
 #include <thread>
 
+#include "milvus.grpc.pb.h"
 #include "milvus.pb.h"
 #include "milvus/ClientRequestContext.h"
 #include "milvus/ClientTelemetry.h"
+
+namespace {
+
+std::string
+Rfc3339(std::chrono::system_clock::time_point value) {
+    auto raw = std::chrono::system_clock::to_time_t(value);
+    std::tm utc{};
+#ifdef _WIN32
+    gmtime_s(&utc, &raw);
+#else
+    gmtime_r(&raw, &utc);
+#endif
+    std::ostringstream stream;
+    stream << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+    return stream.str();
+}
+
+class ReconnectTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest*,
+                    milvus::proto::milvus::ClientHeartbeatResponse* response) override {
+        ++heartbeats;
+        auto* command = response->add_commands();
+        command->set_command_id("reconnect");
+        command->set_command_type("reconnect");
+        command->set_create_time(1);
+        return grpc::Status::OK;
+    }
+
+    std::atomic<int> heartbeats{0};
+};
+
+}  // namespace
 
 TEST(ClientTelemetryTest, MatchesCrossSdkConfigHashVector) {
     std::vector<milvus::TelemetryCommand> commands = {
@@ -50,12 +91,189 @@ TEST(ClientTelemetryTest, AppliesCommandsAndDeduplicatesIds) {
         {"custom", "custom", "", 2, false, ""},
     });
     manager.ProcessCommands({{"custom", "custom", "", 2, false, ""}});
+    manager.ProcessCommands({{"custom", "custom", "", 2, false, ""}});
 
     EXPECT_EQ(manager.Config().heartbeat_interval_ms, 5000U);
     EXPECT_DOUBLE_EQ(manager.Config().sampling_rate, 0.25);
     EXPECT_EQ(manager.LastCommandTimestamp(), 2);
     EXPECT_FALSE(manager.ConfigHash().empty());
     EXPECT_EQ(calls, 1);
+}
+
+TEST(ClientTelemetryTest, RetainsMoreThanOneHundredTwentySnapshotsWithinOneHour) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config);
+    milvus::proto::milvus::SearchRequest request;
+
+    constexpr size_t expected_snapshots = 121;
+    for (size_t index = 0; index < expected_snapshots; ++index) {
+        manager.RecordOperation("Search", request, std::chrono::steady_clock::now(), true, "");
+        manager.Start();
+        for (int retry = 0; retry < 1000 && manager.MetricsSnapshots().size() <= index; ++retry) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        manager.Stop();
+        ASSERT_GT(manager.MetricsSnapshots().size(), index);
+    }
+
+    EXPECT_EQ(manager.MetricsSnapshots().size(), expected_snapshots);
+}
+
+TEST(ClientTelemetryTest, BoundsHighFrequencySnapshotHistoryAndSkipsEmptyIntervals) {
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = 1;
+    milvus::ClientTelemetryManager manager(config);
+    milvus::proto::milvus::SearchRequest request;
+
+    manager.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    manager.Stop();
+    EXPECT_TRUE(manager.MetricsSnapshots().empty());
+
+    constexpr size_t generated_snapshots = 520;
+    constexpr size_t retained_snapshots = 512;
+    for (size_t index = 0; index < generated_snapshots; ++index) {
+        manager.RecordOperation("Search", request, std::chrono::steady_clock::now(), true, "");
+        manager.Start();
+        manager.Stop();
+    }
+
+    EXPECT_EQ(manager.MetricsSnapshots().size(), retained_snapshots);
+}
+
+TEST(ClientTelemetryTest, AggregatesP99FromRetainedLatencySamples) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config);
+    milvus::proto::milvus::SearchRequest request;
+
+    for (int index = 0; index < 100; ++index) {
+        manager.RecordOperation("Search", request, std::chrono::steady_clock::now() - std::chrono::milliseconds(1),
+                                true, "");
+    }
+    manager.Start();
+    for (int retry = 0; retry < 1000 && manager.MetricsSnapshots().empty(); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+
+    for (int index = 0; index < 100; ++index) {
+        manager.RecordOperation("Search", request, std::chrono::steady_clock::now() - std::chrono::milliseconds(100),
+                                true, "");
+    }
+    manager.Start();
+    for (int retry = 0; retry < 1000 && manager.MetricsSnapshots().size() < 2; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+
+    const auto now = std::chrono::system_clock::now();
+    const auto payload = nlohmann::json{
+        {"start_time", Rfc3339(now - std::chrono::minutes(1))},
+        {"end_time", Rfc3339(now + std::chrono::minutes(1))},
+        {"detail", false}}.dump();
+    manager.ProcessCommands({{"history", "show_latency_history", payload, 1, false, ""}});
+
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_FALSE(replies.empty());
+    ASSERT_TRUE(replies.back().success) << replies.back().error_message;
+    const auto response = nlohmann::json::parse(replies.back().payload);
+    EXPECT_GT(response["aggregated"]["metrics"]["Search"]["p99_latency_ms"].get<double>(), 90.0);
+}
+
+TEST(ClientTelemetryTest, ReusesHeartbeatWorkerWhenReconnectRunsInCommandHandler) {
+    ReconnectTelemetryService service;
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    std::atomic<int> reconnects{0};
+    {
+        milvus::TelemetryConfig config;
+        config.heartbeat_interval_ms = 1;
+        milvus::ClientTelemetryManager manager(config);
+        manager.AttachChannel(
+            grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials()), "", "", "",
+            "", "");
+        manager.RegisterCommandHandler("reconnect", [&manager, &reconnects](const milvus::TelemetryCommand& command) {
+            ++reconnects;
+            manager.Stop();
+            manager.Start();
+            return milvus::TelemetryCommandReply{command.command_id, true, "", ""};
+        });
+
+        manager.Start();
+        for (int retry = 0; retry < 2000 && service.heartbeats.load() < 2; ++retry) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        manager.Stop();
+    }
+    server->Shutdown();
+
+    EXPECT_GE(service.heartbeats.load(), 2);
+    EXPECT_EQ(reconnects.load(), 1);
+}
+
+TEST(ClientTelemetryTest, ExternalStopWinsRaceWithHeartbeatSelfRestart) {
+    ReconnectTelemetryService service;
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = 1;
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials()),
+                          "", "", "", "", "");
+
+    std::atomic<bool> handler_entered{false};
+    std::atomic<bool> allow_self_restart{false};
+    std::atomic<bool> self_restart_ready{true};
+    manager.RegisterCommandHandler("reconnect", [&](const milvus::TelemetryCommand& command) {
+        handler_entered = true;
+        while (!allow_self_restart.load()) {
+            std::this_thread::yield();
+        }
+        manager.Stop();
+        manager.Start();
+        self_restart_ready = manager.IsReady();
+        return milvus::TelemetryCommandReply{command.command_id, true, "", ""};
+    });
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && !handler_entered.load(); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(handler_entered.load());
+    ASSERT_TRUE(manager.IsReady());
+
+    std::promise<void> external_stop_finished;
+    auto external_stop_future = external_stop_finished.get_future();
+    std::thread external_stopper([&]() {
+        manager.Stop();
+        external_stop_finished.set_value();
+    });
+
+    // ready=false is written before Stop() releases the manager mutex to join,
+    // so observing it makes the intended race ordering deterministic.
+    for (int retry = 0; retry < 2000 && manager.IsReady(); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_FALSE(manager.IsReady());
+    EXPECT_EQ(external_stop_future.wait_for(std::chrono::milliseconds(10)), std::future_status::timeout);
+
+    allow_self_restart = true;
+    EXPECT_EQ(external_stop_future.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    external_stopper.join();
+    server->Shutdown();
+
+    EXPECT_FALSE(self_restart_ready.load());
+    EXPECT_FALSE(manager.IsReady());
 }
 
 TEST(ClientTelemetryTest, ReconnectReuseMatchesOriginalUserConfig) {

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <thread>
 
+#include "MilvusConnection.h"
 #include "milvus.grpc.pb.h"
 #include "milvus.pb.h"
 #include "milvus/ClientRequestContext.h"
@@ -426,6 +427,67 @@ TEST(ClientTelemetryTest, ReconnectReuseMatchesOriginalUserConfig) {
     auto changed = config;
     changed.enabled = true;
     EXPECT_FALSE(manager.MatchesConnection(changed, ""));
+}
+
+TEST(ClientTelemetryTest, GlobalPhysicalHandoffAndUseDatabaseKeepLogicalIdentityAndState) {
+    LifecycleTelemetryService first_service("");
+    LifecycleTelemetryService second_service("");
+    int first_port = 0;
+    int second_port = 0;
+    auto first_server = StartLifecycleServer(first_service, first_port);
+    auto second_server = StartLifecycleServer(second_service, second_port);
+    ASSERT_NE(first_server, nullptr);
+    ASSERT_NE(second_server, nullptr);
+
+    constexpr const char* logical_endpoint = "https://tenant.global-cluster.example.com";
+    milvus::ConnectParam first_param("http://127.0.0.1:" + std::to_string(first_port));
+    first_param.SetDbName("primary_db");
+    milvus::TelemetryConfig telemetry_config;
+    telemetry_config.enabled = false;
+    first_param.SetTelemetryConfig(telemetry_config);
+
+    auto first_connection = std::make_shared<milvus::MilvusConnection>();
+    ASSERT_TRUE(first_connection->Connect(first_param, "", nullptr, logical_endpoint).IsOk());
+    auto manager = first_connection->GetTelemetry();
+    ASSERT_NE(manager, nullptr);
+    const auto client_id = manager->ClientId();
+    manager->ProcessCommands({
+        {"config", "push_config", R"({"sampling_rate":0.25})", 1, true, ""},
+        {"collections", "collection_metrics", R"({"enabled":true,"collections":["before_failover"]})", 2, false, ""},
+    });
+    const auto config_hash = manager->ConfigHash();
+    const auto replies_before_failover = manager->PendingCommandReplies();
+    ASSERT_EQ(replies_before_failover.size(), 2U);
+
+    milvus::ConnectParam second_param = first_param;
+    second_param.SetUri("http://127.0.0.1:" + std::to_string(second_port));
+    auto second_connection = std::make_shared<milvus::MilvusConnection>();
+    ASSERT_TRUE(second_connection->Connect(second_param, client_id, manager, logical_endpoint).IsOk());
+    ASSERT_EQ(second_connection->GetTelemetry(), manager);
+    EXPECT_EQ(manager->ClientId(), client_id);
+    EXPECT_EQ(manager->ConfigHash(), config_hash);
+    EXPECT_EQ(manager->LastCommandTimestamp(), 2);
+    EXPECT_DOUBLE_EQ(manager->Config().sampling_rate, 0.25);
+    EXPECT_EQ(manager->PendingCommandReplies().size(), replies_before_failover.size());
+    EXPECT_TRUE(first_connection->Disconnect(false).IsOk());
+
+    ASSERT_TRUE(second_connection->UseDatabase("secondary_db").IsOk());
+    ASSERT_EQ(second_connection->GetTelemetry(), manager);
+    EXPECT_EQ(manager->ClientId(), client_id);
+    EXPECT_EQ(manager->ConfigHash(), config_hash);
+    EXPECT_EQ(manager->LastCommandTimestamp(), 2);
+
+    manager->ProcessCommands({{"config-after-use-db", "get_config", "", 3, false, ""}});
+    const auto replies = manager->PendingCommandReplies();
+    ASSERT_FALSE(replies.empty());
+    ASSERT_TRUE(replies.back().success) << replies.back().error_message;
+    const auto user_config = nlohmann::json::parse(replies.back().payload).at("user_config");
+    EXPECT_EQ(user_config.at("address"), logical_endpoint);
+    EXPECT_EQ(user_config.at("db_name"), "secondary_db");
+
+    EXPECT_TRUE(second_connection->Disconnect().IsOk());
+    first_server->Shutdown();
+    second_server->Shutdown();
 }
 
 TEST(ClientTelemetryTest, PushConfigIsAtomicAndReportsAppliedAndIgnoredKeys) {

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -333,7 +333,7 @@ TEST(ClientTelemetryTest, RetainsMoreThanOneHundredTwentySnapshotsWithinOneHour)
     EXPECT_EQ(manager.MetricsSnapshots().size(), expected_snapshots);
 }
 
-TEST(ClientTelemetryTest, BoundsHighFrequencySnapshotHistoryAndSkipsEmptyIntervals) {
+TEST(ClientTelemetryTest, RetainsOneSecondHeartbeatWindowAndSkipsEmptyIntervals) {
     milvus::TelemetryConfig config;
     config.heartbeat_interval_ms = 1;
     milvus::ClientTelemetryManager manager(config);
@@ -344,8 +344,8 @@ TEST(ClientTelemetryTest, BoundsHighFrequencySnapshotHistoryAndSkipsEmptyInterva
     manager.Stop();
     EXPECT_TRUE(manager.MetricsSnapshots().empty());
 
-    constexpr size_t generated_snapshots = 520;
-    constexpr size_t retained_snapshots = 512;
+    constexpr size_t generated_snapshots = 4104;
+    constexpr size_t retained_snapshots = 4096;
     for (size_t index = 0; index < generated_snapshots; ++index) {
         manager.RecordOperation("Search", request, std::chrono::steady_clock::now(), true, "");
         manager.Start();
@@ -392,6 +392,50 @@ TEST(ClientTelemetryTest, AggregatesP99FromRetainedLatencySamples) {
     ASSERT_TRUE(replies.back().success) << replies.back().error_message;
     const auto response = nlohmann::json::parse(replies.back().payload);
     EXPECT_GT(response["aggregated"]["metrics"]["Search"]["p99_latency_ms"].get<double>(), 90.0);
+}
+
+TEST(ClientTelemetryTest, CompressedQuantileHistoryPreservesEndpointsAndSlowTail) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config);
+    milvus::proto::milvus::SearchRequest request;
+
+    // The exact per-window p99 is still in the fast group (indices 0..990), while
+    // the 128-point history compression must include the slow endpoint/tail that
+    // starts at evenly-spaced source index 991.
+    for (int index = 0; index < 991; ++index) {
+        manager.RecordOperation("Search", request, std::chrono::steady_clock::now() - std::chrono::milliseconds(1),
+                                true, "");
+    }
+    for (int index = 0; index < 9; ++index) {
+        manager.RecordOperation("Search", request, std::chrono::steady_clock::now() - std::chrono::milliseconds(250),
+                                true, "");
+    }
+    manager.Start();
+    for (int retry = 0; retry < 1000 && manager.MetricsSnapshots().empty(); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+
+    const auto snapshots = manager.MetricsSnapshots();
+    ASSERT_EQ(snapshots.size(), 1U);
+    ASSERT_EQ(snapshots.front().metrics.size(), 1U);
+    EXPECT_LT(snapshots.front().metrics.front().global.p99_latency_ms, 50.0);
+    EXPECT_GT(snapshots.front().metrics.front().global.max_latency_ms, 200.0);
+
+    const auto now = std::chrono::system_clock::now();
+    const auto payload = nlohmann::json{
+        {"start_time", Rfc3339(now - std::chrono::minutes(1))},
+        {"end_time", Rfc3339(now + std::chrono::minutes(1))},
+        {"detail", false}}.dump();
+    manager.ProcessCommands({{"compressed-history", "show_latency_history", payload, 1, false, ""}});
+
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_FALSE(replies.empty());
+    ASSERT_TRUE(replies.back().success) << replies.back().error_message;
+    const auto response = nlohmann::json::parse(replies.back().payload);
+    const auto metric = response["aggregated"]["metrics"]["Search"];
+    EXPECT_GT(metric["p99_latency_ms"].get<double>(), 200.0);
+    EXPECT_GT(metric["max_latency_ms"].get<double>(), 200.0);
 }
 
 TEST(ClientTelemetryTest, ReusesHeartbeatWorkerWhenReconnectRunsInCommandHandler) {

--- a/test/ut/utils/TestGlobalCluster.cpp
+++ b/test/ut/utils/TestGlobalCluster.cpp
@@ -309,17 +309,21 @@ TEST(GlobalClusterTelemetryTest, FailoverAndUseDatabasePreserveLogicalTelemetryS
     httplib::Server topology_server;
     std::atomic<int64_t> served_version{1};
     std::atomic<int> served_primary_port{first_port};
-    topology_server.Get("/global-cluster/topology", [&](const httplib::Request&, httplib::Response& response) {
-        response.set_content(
-            TopologyBody(served_version.load(), "127.0.0.1:" + std::to_string(served_primary_port.load())),
-            "application/json");
-    });
+    // Put the global-cluster marker in the path rather than a localhost subdomain. Windows does
+    // not consistently resolve arbitrary *.localhost names, while a numeric loopback address is
+    // portable across all CI runners.
+    topology_server.Get(
+        "/global-cluster-test/global-cluster/topology", [&](const httplib::Request&, httplib::Response& response) {
+            response.set_content(
+                TopologyBody(served_version.load(), "127.0.0.1:" + std::to_string(served_primary_port.load())),
+                "application/json");
+        });
     const auto topology_port = topology_server.bind_to_any_port("127.0.0.1");
     ASSERT_TRUE(topology_server.is_valid());
     std::thread topology_thread([&topology_server]() { topology_server.listen_after_bind(); });
     topology_server.wait_until_ready();
 
-    const auto logical_endpoint = "http://telemetry.global-cluster.localhost:" + std::to_string(topology_port);
+    const auto logical_endpoint = "http://127.0.0.1:" + std::to_string(topology_port) + "/global-cluster-test";
     milvus::ConnectParam connect_param(logical_endpoint);
     connect_param.SetDbName("primary_db");
     milvus::TelemetryConfig telemetry_config;

--- a/test/ut/utils/TestGlobalCluster.cpp
+++ b/test/ut/utils/TestGlobalCluster.cpp
@@ -14,24 +14,54 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
 #include <gtest/gtest.h>
 
 #include <atomic>
 #include <chrono>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 
 #include "cpp-httplib/httplib.h"
+#include "milvus.grpc.pb.h"
+#include "milvus.pb.h"
+#include "milvus/ClientTelemetry.h"
+#include "milvus/thirdparty/nlohmann/json.hpp"
+#include "milvus/types/ConnectParam.h"
 #include "types/GlobalCluster.h"
+#include "utils/ConnectionHandler.h"
 #include "utils/GlobalClusterUtils.h"
 #include "utils/TopologyRefresher.h"
 
 namespace {
 
 std::string
-TopologyBody(int64_t version) {
+TopologyBody(int64_t version, const std::string& endpoint = "a:19530") {
     return R"({"code":0,"data":{"version":)" + std::to_string(version) +
-           R"(,"clusters":[{"clusterId":"a","endpoint":"a:19530","capability":3}]}})";
+           R"(,"clusters":[{"clusterId":"a","endpoint":")" + endpoint + R"(","capability":3}]}})";
+}
+
+class GlobalMilvusService final : public milvus::proto::milvus::MilvusService::Service {
+ public:
+    grpc::Status
+    Connect(grpc::ServerContext*, const milvus::proto::milvus::ConnectRequest*,
+            milvus::proto::milvus::ConnectResponse*) override {
+        ++connects;
+        return grpc::Status::OK;
+    }
+
+    std::atomic<int> connects{0};
+};
+
+std::unique_ptr<grpc::Server>
+StartGlobalMilvusServer(GlobalMilvusService& service, int& port) {
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    return builder.BuildAndStart();
 }
 
 }  // namespace
@@ -264,4 +294,87 @@ TEST(TopologyRefresherTest, CallbackOnVersionChange) {
 
     server.stop();
     srv.join();
+}
+
+TEST(GlobalClusterTelemetryTest, FailoverAndUseDatabasePreserveLogicalTelemetryState) {
+    GlobalMilvusService first_service;
+    GlobalMilvusService second_service;
+    int first_port = 0;
+    int second_port = 0;
+    auto first_server = StartGlobalMilvusServer(first_service, first_port);
+    auto second_server = StartGlobalMilvusServer(second_service, second_port);
+    ASSERT_NE(first_server, nullptr);
+    ASSERT_NE(second_server, nullptr);
+
+    httplib::Server topology_server;
+    std::atomic<int64_t> served_version{1};
+    std::atomic<int> served_primary_port{first_port};
+    topology_server.Get("/global-cluster/topology", [&](const httplib::Request&, httplib::Response& response) {
+        response.set_content(
+            TopologyBody(served_version.load(), "127.0.0.1:" + std::to_string(served_primary_port.load())),
+            "application/json");
+    });
+    const auto topology_port = topology_server.bind_to_any_port("127.0.0.1");
+    ASSERT_TRUE(topology_server.is_valid());
+    std::thread topology_thread([&topology_server]() { topology_server.listen_after_bind(); });
+    topology_server.wait_until_ready();
+
+    const auto logical_endpoint = "http://telemetry.global-cluster.localhost:" + std::to_string(topology_port);
+    milvus::ConnectParam connect_param(logical_endpoint);
+    connect_param.SetDbName("primary_db");
+    milvus::TelemetryConfig telemetry_config;
+    telemetry_config.enabled = false;
+    connect_param.SetTelemetryConfig(telemetry_config);
+
+    milvus::ConnectionHandler handler;
+    ASSERT_TRUE(handler.Connect(connect_param).IsOk());
+    auto manager = handler.GetTelemetry();
+    ASSERT_NE(manager, nullptr);
+    const auto client_id = manager->ClientId();
+    manager->ProcessCommands({
+        {"config", "push_config", R"({"sampling_rate":0.25})", 1, true, ""},
+        {"collections", "collection_metrics", R"({"enabled":true,"collections":["before_failover"]})", 2, false, ""},
+    });
+    const auto config_hash = manager->ConfigHash();
+    const auto reply_count = manager->PendingCommandReplies().size();
+    ASSERT_EQ(reply_count, 2U);
+
+    served_primary_port = second_port;
+    served_version = 2;
+    handler.TriggerGlobalRefresh();
+    const auto second_uri = "http://127.0.0.1:" + std::to_string(second_port);
+    for (int retry = 0; retry < 3000; ++retry) {
+        auto connection = handler.GetConnection();
+        if (connection != nullptr && connection->GetConnectParam().Uri() == second_uri) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_NE(handler.GetConnection(), nullptr);
+    EXPECT_EQ(handler.GetConnection()->GetConnectParam().Uri(), second_uri);
+    EXPECT_EQ(handler.CurrentEndpoint(), logical_endpoint);
+    EXPECT_EQ(handler.GetTelemetry(), manager);
+    EXPECT_EQ(manager->ClientId(), client_id);
+    EXPECT_EQ(manager->ConfigHash(), config_hash);
+    EXPECT_EQ(manager->LastCommandTimestamp(), 2);
+    EXPECT_DOUBLE_EQ(manager->Config().sampling_rate, 0.25);
+    EXPECT_EQ(manager->PendingCommandReplies().size(), reply_count);
+
+    ASSERT_TRUE(handler.UseDatabase("secondary_db").IsOk());
+    ASSERT_EQ(handler.GetTelemetry(), manager);
+    manager->ProcessCommands({{"config-after-use-db", "get_config", "", 3, false, ""}});
+    const auto replies = manager->PendingCommandReplies();
+    ASSERT_FALSE(replies.empty());
+    ASSERT_TRUE(replies.back().success) << replies.back().error_message;
+    const auto user_config = nlohmann::json::parse(replies.back().payload).at("user_config");
+    EXPECT_EQ(user_config.at("address"), logical_endpoint);
+    EXPECT_EQ(user_config.at("db_name"), "secondary_db");
+    EXPECT_EQ(manager->ClientId(), client_id);
+    EXPECT_EQ(manager->ConfigHash(), config_hash);
+
+    EXPECT_TRUE(handler.Disconnect().IsOk());
+    topology_server.stop();
+    topology_thread.join();
+    first_server->Shutdown();
+    second_server->Shutdown();
 }

--- a/test/ut/utils/TestGlobalCluster.cpp
+++ b/test/ut/utils/TestGlobalCluster.cpp
@@ -64,6 +64,28 @@ StartGlobalMilvusServer(GlobalMilvusService& service, int& port) {
     return builder.BuildAndStart();
 }
 
+class ScopedTopologyServerThread {
+ public:
+    explicit ScopedTopologyServerThread(httplib::Server& server)
+        : server_(server), thread_([&server]() { server.listen_after_bind(); }) {
+    }
+
+    ~ScopedTopologyServerThread() {
+        server_.stop();
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    ScopedTopologyServerThread(const ScopedTopologyServerThread&) = delete;
+    ScopedTopologyServerThread&
+    operator=(const ScopedTopologyServerThread&) = delete;
+
+ private:
+    httplib::Server& server_;
+    std::thread thread_;
+};
+
 }  // namespace
 
 TEST(GlobalClusterUtilsTest, IsGlobalEndpoint) {
@@ -320,7 +342,7 @@ TEST(GlobalClusterTelemetryTest, FailoverAndUseDatabasePreserveLogicalTelemetryS
         });
     const auto topology_port = topology_server.bind_to_any_port("127.0.0.1");
     ASSERT_TRUE(topology_server.is_valid());
-    std::thread topology_thread([&topology_server]() { topology_server.listen_after_bind(); });
+    ScopedTopologyServerThread topology_thread(topology_server);
     topology_server.wait_until_ready();
 
     const auto logical_endpoint = "http://127.0.0.1:" + std::to_string(topology_port) + "/global-cluster-test";
@@ -377,8 +399,6 @@ TEST(GlobalClusterTelemetryTest, FailoverAndUseDatabasePreserveLogicalTelemetryS
     EXPECT_EQ(manager->ConfigHash(), config_hash);
 
     EXPECT_TRUE(handler.Disconnect().IsOk());
-    topology_server.stop();
-    topology_thread.join();
     first_server->Shutdown();
     second_server->Shutdown();
 }


### PR DESCRIPTION
## Summary

- implement the shared client telemetry heartbeat and command protocol in the C++ SDK
- report one metric per public logical Search, Query/Get, HybridSearch, RunAnalyzer, Insert, Delete, and Upsert call
- preserve telemetry state across reconnects, database switches, and global-cluster topology failover within the same logical endpoint/user/config scope
- make heartbeat Stop/restart and last-owner destruction safe, including destruction from the heartbeat callback thread
- keep the command heartbeat active across dynamic disable and Stop/Start reconnects so ACK and re-enable can flow, while an initial user opt-out starts no worker
- retain a bounded one-hour default history, aggregate P99 from retained samples, and skip empty high-frequency history entries
- align deterministic sampling, collection filtering, strict atomic command handling, RFC3339 validation, reply acknowledgement, unsupported backoff, request IDs, unset-database reporting, and command cursor idempotency with the Go SDK
- expose retryable CLIENT_BUSY lifecycle failures and add focused unit plus opt-in end-to-end coverage

## Related work

- Design: https://github.com/milvus-io/milvus/blob/master/docs/design-docs/design_docs/20260131-client_side_telemetry.md
- Server and Go SDK correctness follow-up: https://github.com/milvus-io/milvus/pull/52597
- Go SDK conformance follow-up: https://github.com/milvus-io/milvus/pull/52804

## Verification

- full C++ unit test suite: 842/842 passed
- focused telemetry and global/lifecycle suites passed
- end-to-end test target builds successfully
- LLVM 17 clang-format dry run and git diff --check

## Compatibility note

ConnectParam gains telemetry configuration state. Consumers should rebuild against this SDK revision rather than mixing binaries compiled against the previous object layout.
