### PR TITLE
fix: treat ttl_seconds as an ignored push_config field

### DIFF
--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -884,12 +884,6 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                 sampling_rate = std::max(0.0, std::min(1.0, sampling_rate));
                 applied.emplace_back("sampling_rate");
             }
-            if (payload.count("ttl_seconds")) {
-                if (!payload["ttl_seconds"].is_number_integer() && !payload["ttl_seconds"].is_number_unsigned()) {
-                    throw std::invalid_argument("ttl_seconds must be an integer");
-                }
-                (void)payload["ttl_seconds"].get<int64_t>();
-            }
             for (auto iterator = payload.begin(); iterator != payload.end(); ++iterator) {
                 if (iterator.key() != "enabled" && iterator.key() != "heartbeat_interval_ms" &&
                     iterator.key() != "sampling_rate") {

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -1019,13 +1019,16 @@ TEST(ClientTelemetryTest, RejectsWrongCommandPayloadTypes) {
     manager.ProcessCommands(
         {{"push", "push_config", R"({"enabled":"false"})", 1, false, ""},
          {"collection", "collection_metrics", R"({"enabled":false,"collections":"books"})", 2, false, ""},
-         {"ttl", "push_config", R"({"enabled":true,"ttl_seconds":"bad"})", 3, false, ""}});
+         {"ttl", "push_config", R"({"ttl_seconds":"bad"})", 3, true, ""}});
 
     auto replies = manager.PendingCommandReplies();
     ASSERT_EQ(replies.size(), 3U);
     EXPECT_FALSE(replies[0].success);
     EXPECT_FALSE(replies[1].success);
-    EXPECT_FALSE(replies[2].success);
+    // ttl_seconds belongs to the server-side push API and never reaches clients by design:
+    // it is reported as ignored, never validated.
+    EXPECT_TRUE(replies[2].success);
+    EXPECT_EQ(nlohmann::json::parse(replies[2].payload)["ignored"], nlohmann::json({"ttl_seconds"}));
     EXPECT_FALSE(manager.Config().enabled);
 }
 


### PR DESCRIPTION
## Summary
- `ttl_seconds` is a field of the server-side push API (`PushClientCommandRequest` / `POST /_telemetry/commands`), not of `ClientCommand`, so it never reaches clients by design (see the TTL section of the design doc).
- Stop type-validating it in the `push_config` command handler and report it as ignored like any other unknown field, so a stray value can no longer fail the whole command.
- Update `RejectsWrongCommandPayloadTypes` accordingly: an invalid `ttl_seconds` now succeeds with `ignored: ["ttl_seconds"]` and leaves the applied config untouched.

This is a follow-up to #585 (the change was pushed to the head branch shortly after merge and did not land).

pr: #585

## Related work
- Design: https://github.com/milvus-io/milvus/blob/master/docs/design-docs/design_docs/20260131-client_side_telemetry.md

## Verification
- focused unit tests: `ClientTelemetryTest.*` 26/26 passed
- full unit suite rebuilt against latest master