### PR TITLE
fix: harden client telemetry control flow

### DIFF
--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -68,12 +68,18 @@ constexpr size_t kSnapshotLimit = 4096;
 constexpr uint64_t kSamplingScale = 1000000000ULL;
 constexpr size_t kMaxReplyBytes = 1024 * 1024;
 constexpr uint64_t kMaxUnsupportedBackoffMs = 30 * 60 * 1000;
+constexpr uint64_t kMaxHeartbeatIntervalMs = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+// condition_variable implementations commonly form an absolute deadline internally.
+// Keep each addition comfortably inside every supported platform clock and represent
+// longer intervals as stop/rebind-aware chunks.
+constexpr uint64_t kMaxWaitChunkMs = 24ULL * 60 * 60 * 1000;
 
 TelemetryConfig
 NormalizedTelemetryConfig(TelemetryConfig config) {
     if (config.heartbeat_interval_ms == 0) {
         config.heartbeat_interval_ms = 10000;
     }
+    config.heartbeat_interval_ms = std::min(config.heartbeat_interval_ms, kMaxHeartbeatIntervalMs);
     config.sampling_rate = std::max(0.0, std::min(1.0, config.sampling_rate));
     if (config.error_max_count == 0) {
         config.error_max_count = 100;
@@ -92,6 +98,27 @@ int64_t
 NowMillis() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
         .count();
+}
+
+int64_t
+SaturatingWindowStart(int64_t end_time, uint64_t interval_ms) {
+    const auto signed_interval = static_cast<int64_t>(std::min(interval_ms, kMaxHeartbeatIntervalMs));
+    if (end_time < std::numeric_limits<int64_t>::min() + signed_interval) {
+        return std::numeric_limits<int64_t>::min();
+    }
+    return end_time - signed_interval;
+}
+
+size_t
+Utf8SafePrefixLength(const std::string& value, size_t requested) {
+    auto length = std::min(requested, value.size());
+    if (length == value.size()) {
+        return length;
+    }
+    while (length > 0 && (static_cast<unsigned char>(value[length]) & 0xC0) == 0x80) {
+        --length;
+    }
+    return length;
 }
 
 std::string
@@ -473,11 +500,17 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
         std::lock_guard<std::mutex> lock(mutex);
         stub = std::move(new_stub);
         ++channel_generation;
+        // A newly attached transport must be probed immediately. Carrying an
+        // UNIMPLEMENTED backoff from the retired endpoint can otherwise keep a
+        // supporting endpoint silent for up to thirty minutes.
+        unsupported_streak = 0;
+        ++wait_revision;
         username = std::move(new_username);
         database = std::move(new_database);
         uri = std::move(new_uri);
         sdk_version = std::move(new_sdk_version);
         connection_scope = std::move(new_connection_scope);
+        condition.notify_all();
     }
 
     void
@@ -586,6 +619,11 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
     void
     HeartbeatLoop() {
         while (true) {
+            uint64_t heartbeat_revision;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                heartbeat_revision = wait_revision;
+            }
             try {
                 CreateSnapshot();
                 SendHeartbeat();
@@ -604,6 +642,12 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             if (stopped) {
                 break;
             }
+            if (heartbeat_revision != wait_revision) {
+                // AttachChannel may have replaced the transport while the RPC
+                // was in flight, before there was a waiter to notify. Probe the
+                // replacement immediately instead of sleeping the old interval.
+                continue;
+            }
             uint64_t delay = config.heartbeat_interval_ms;
             if (unsupported_streak > 0) {
                 uint64_t backed_off = std::min(delay, kMaxUnsupportedBackoffMs);
@@ -612,7 +656,16 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                 }
                 delay = std::max(delay, backed_off);
             }
-            condition.wait_for(lock, std::chrono::milliseconds(delay), [this]() { return stopped; });
+            const auto observed_revision = wait_revision;
+            while (!stopped && observed_revision == wait_revision && delay > 0) {
+                const auto chunk = std::min(delay, kMaxWaitChunkMs);
+                if (condition.wait_for(
+                        lock, std::chrono::milliseconds(static_cast<int64_t>(chunk)),
+                        [this, observed_revision]() { return stopped || wait_revision != observed_revision; })) {
+                    break;
+                }
+                delay -= chunk;
+            }
             if (stopped) {
                 break;
             }
@@ -639,7 +692,7 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
         auto& snapshot = stored.snapshot;
         snapshot.end_time = NowMillis();
         snapshot.timestamp = last_snapshot_end == 0 || last_snapshot_end > snapshot.end_time
-                                 ? snapshot.end_time - config.heartbeat_interval_ms
+                                 ? SaturatingWindowStart(snapshot.end_time, config.heartbeat_interval_ms)
                                  : last_snapshot_end;
         last_snapshot_end = snapshot.end_time;
         for (auto& entry : collectors) {
@@ -786,7 +839,11 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             handler = iterator->second;
         }
         try {
-            return handler(command);
+            auto reply = handler(command);
+            // The incoming command ID is the protocol correlation key. Extension
+            // handlers control the result, but cannot redirect or drop its ACK.
+            reply.command_id = command.command_id;
+            return reply;
         } catch (const std::exception& exception) {
             return FailedReply(command.command_id, exception.what());
         } catch (...) {
@@ -815,6 +872,9 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             bool skip = false;
             {
                 std::lock_guard<std::mutex> lock(mutex);
+                if (expected_generation != 0 && expected_generation != channel_generation) {
+                    return;
+                }
                 skip = command.create_time < previous_timestamp || executed_commands.count(command.command_id) > 0;
                 if (skip) {
                     pending_replies.push_back(SuccessReply(command.command_id));
@@ -824,9 +884,18 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                 continue;
             }
             auto reply = HandleCommand(command);
-            std::lock_guard<std::mutex> lock(mutex);
-            executed_commands[command.command_id] = command.create_time;
-            pending_replies.push_back(std::move(reply));
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                executed_commands[command.command_id] = command.create_time;
+                pending_replies.push_back(std::move(reply));
+                if (expected_generation != 0 && expected_generation != channel_generation) {
+                    // Preserve the completed command's ACK/executed marker so a
+                    // redelivery cannot repeat its side effects, but leave the
+                    // cursor/hash unchanged and do not run the retired endpoint's
+                    // remaining commands.
+                    return;
+                }
+            }
         }
         std::lock_guard<std::mutex> lock(mutex);
         for (auto iterator = executed_commands.begin(); iterator != executed_commands.end();) {
@@ -997,12 +1066,52 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                 result.erase(result.begin() + result.size() / 2, result.end());
             }
             auto encoded = result.dump();
-            while (encoded.size() > kMaxReplyBytes && result.size() == 1 &&
-                   result.at(0).value("error_msg", std::string{}).size() > 1) {
-                auto message = result.at(0).at("error_msg").get<std::string>();
-                result.at(0)["error_msg"] =
-                    message.substr(0, std::max<size_t>(1, message.size() / 2)) + "...(truncated)";
+            constexpr const char* kTruncated = "...(truncated)";
+            constexpr std::array<const char*, 4> kTruncatableFields = {"error_msg", "collection", "operation",
+                                                                       "request_id"};
+            while (encoded.size() > kMaxReplyBytes && result.size() == 1) {
+                auto& detail = result.at(0);
+                const char* longest_field = nullptr;
+                size_t longest_size = 0;
+                for (const auto* field : kTruncatableFields) {
+                    if (!detail.contains(field) || !detail.at(field).is_string()) {
+                        continue;
+                    }
+                    const auto size = detail.at(field).get_ref<const std::string&>().size();
+                    if (size > longest_size) {
+                        longest_field = field;
+                        longest_size = size;
+                    }
+                }
+                if (longest_field == nullptr || longest_size == 0) {
+                    break;
+                }
+
+                const auto previous_size = encoded.size();
+                const auto value = detail.at(longest_field).get<std::string>();
+                const auto suffix_size = std::strlen(kTruncated);
+                if (value.size() > suffix_size + 1) {
+                    auto keep = value.size() / 2;
+                    if (keep > suffix_size) {
+                        keep -= suffix_size;
+                    } else {
+                        keep = 0;
+                    }
+                    keep = Utf8SafePrefixLength(value, keep);
+                    detail[longest_field] = value.substr(0, keep) + kTruncated;
+                } else {
+                    detail[longest_field] = "";
+                }
                 encoded = result.dump();
+                if (encoded.size() >= previous_size) {
+                    // Guarantee monotonic progress even for strings whose JSON
+                    // escaping defeats the best-effort prefix truncation.
+                    detail[longest_field] = "";
+                    encoded = result.dump();
+                    if (encoded.size() >= previous_size) {
+                        break;
+                    }
+                }
             }
             if (encoded.size() > kMaxReplyBytes) {
                 throw std::invalid_argument("show_errors response exceeds the 1MB payload limit");
@@ -1183,6 +1292,7 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
     bool join_in_progress{false};
     bool external_stop_requested{false};
     int unsupported_streak{0};
+    uint64_t wait_revision{0};
     // Carries the fractional sampling rate between operations, in kSamplingScale units:
     // each operation adds the rate and the one that pushes it past a whole unit is the one
     // sampled.

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -18,6 +18,7 @@
 #include <condition_variable>
 #include <future>
 #include <iomanip>
+#include <limits>
 #include <milvus/thirdparty/nlohmann/json.hpp>
 #include <sstream>
 #include <thread>
@@ -60,6 +61,108 @@ class ReconnectTelemetryService final : public milvus::proto::milvus::ClientTele
     }
 
     std::atomic<int> heartbeats{0};
+};
+
+class GenerationSwitchTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest*,
+                    milvus::proto::milvus::ClientHeartbeatResponse* response) override {
+        const auto count = ++heartbeats;
+        if (count > 1 && !allow_redelivery_.load()) {
+            return grpc::Status::OK;
+        }
+        auto* reconnect = response->add_commands();
+        reconnect->set_command_id("switch-generation");
+        reconnect->set_command_type("switch-generation");
+        reconnect->set_create_time(1);
+        auto* followup = response->add_commands();
+        followup->set_command_id("followup");
+        followup->set_command_type("followup");
+        followup->set_create_time(2);
+        return grpc::Status::OK;
+    }
+
+    void
+    AllowRedelivery() {
+        allow_redelivery_ = true;
+    }
+
+    std::atomic<int> heartbeats{0};
+
+ private:
+    std::atomic<bool> allow_redelivery_{false};
+};
+
+class UnsupportedTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest*,
+                    milvus::proto::milvus::ClientHeartbeatResponse*) override {
+        ++heartbeats;
+        return {grpc::StatusCode::UNIMPLEMENTED, "telemetry is not supported"};
+    }
+
+    std::atomic<int> heartbeats{0};
+};
+
+class CountingTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    explicit CountingTelemetryService(bool push_max_interval = false) : push_max_interval_(push_max_interval) {
+    }
+
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest*,
+                    milvus::proto::milvus::ClientHeartbeatResponse* response) override {
+        const auto count = ++heartbeats;
+        if (push_max_interval_ && count == 1) {
+            auto* command = response->add_commands();
+            command->set_command_id("max-interval");
+            command->set_command_type("push_config");
+            command->set_payload(R"({"heartbeat_interval_ms":9223372036854775807})");
+            command->set_create_time(1);
+        }
+        return grpc::Status::OK;
+    }
+
+    std::atomic<int> heartbeats{0};
+
+ private:
+    bool push_max_interval_;
+};
+
+class BlockingTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest*,
+                    milvus::proto::milvus::ClientHeartbeatResponse*) override {
+        std::unique_lock<std::mutex> lock(mutex_);
+        heartbeat_entered_ = true;
+        condition_.notify_all();
+        condition_.wait(lock, [this]() { return released_; });
+        return grpc::Status::OK;
+    }
+
+    bool
+    WaitForHeartbeat() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        return condition_.wait_for(lock, std::chrono::seconds(2), [this]() { return heartbeat_entered_; });
+    }
+
+    void
+    Release() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            released_ = true;
+        }
+        condition_.notify_all();
+    }
+
+ private:
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    bool heartbeat_entered_{false};
+    bool released_{false};
 };
 
 class ControlPlaneTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
@@ -290,6 +393,38 @@ TEST(ClientTelemetryTest, RuntimeClientIdDoesNotBecomeStableConfiguration) {
     EXPECT_TRUE(manager.Config().client_id.empty());
 }
 
+TEST(ClientTelemetryTest, MaximumHeartbeatIntervalsAreSafeAndDoNotSpin) {
+    CountingTelemetryService service(true);
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = std::numeric_limits<uint64_t>::max();
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials()),
+                          "", "", "", "", "");
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && service.heartbeats.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(service.heartbeats.load(), 1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    manager.Stop();
+    server->Shutdown();
+
+    EXPECT_EQ(manager.Config().heartbeat_interval_ms, static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+    EXPECT_EQ(service.heartbeats.load(), 1);
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 1U);
+    EXPECT_EQ(replies.front().command_id, "max-interval");
+    EXPECT_TRUE(replies.front().success);
+}
+
 TEST(ClientTelemetryTest, AppliesCommandsAndDeduplicatesIds) {
     milvus::TelemetryConfig config;
     config.enabled = false;
@@ -312,6 +447,30 @@ TEST(ClientTelemetryTest, AppliesCommandsAndDeduplicatesIds) {
     EXPECT_EQ(manager.LastCommandTimestamp(), 2);
     EXPECT_FALSE(manager.ConfigHash().empty());
     EXPECT_EQ(calls, 1);
+}
+
+TEST(ClientTelemetryTest, CustomHandlerRepliesAlwaysUseOriginalCommandId) {
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    milvus::ClientTelemetryManager manager(config);
+    manager.RegisterCommandHandler("wrong", [](const milvus::TelemetryCommand&) {
+        return milvus::TelemetryCommandReply{"different", true, "", ""};
+    });
+    manager.RegisterCommandHandler("empty", [](const milvus::TelemetryCommand&) {
+        return milvus::TelemetryCommandReply{"", true, "", ""};
+    });
+
+    manager.ProcessCommands({
+        {"wrong-id", "wrong", "", 1, false, ""},
+        {"empty-id", "empty", "", 2, false, ""},
+    });
+
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 2U);
+    EXPECT_EQ(replies[0].command_id, "wrong-id");
+    EXPECT_TRUE(replies[0].success);
+    EXPECT_EQ(replies[1].command_id, "empty-id");
+    EXPECT_TRUE(replies[1].success);
 }
 
 TEST(ClientTelemetryTest, RetainsMoreThanOneHundredTwentySnapshotsWithinOneHour) {
@@ -472,6 +631,142 @@ TEST(ClientTelemetryTest, ReusesHeartbeatWorkerWhenReconnectRunsInCommandHandler
 
     EXPECT_GE(service.heartbeats.load(), 2);
     EXPECT_EQ(reconnects.load(), 1);
+}
+
+TEST(ClientTelemetryTest, GenerationSwitchStopsOldBatchAndResumesOnRedelivery) {
+    GenerationSwitchTelemetryService service;
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = 60000;
+    milvus::ClientTelemetryManager manager(config);
+    auto channel = grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials());
+    manager.AttachChannel(channel, "", "", "", "", "");
+    std::atomic<int> switches{0};
+    std::atomic<int> followups{0};
+    manager.RegisterCommandHandler("switch-generation", [&](const milvus::TelemetryCommand&) {
+        ++switches;
+        manager.AttachChannel(channel, "", "", "", "", "");
+        return milvus::TelemetryCommandReply{"wrong-id", true, "", ""};
+    });
+    manager.RegisterCommandHandler("followup", [&](const milvus::TelemetryCommand& command) {
+        ++followups;
+        return milvus::TelemetryCommandReply{command.command_id, true, "", ""};
+    });
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && service.heartbeats.load() < 2; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    ASSERT_GE(service.heartbeats.load(), 2);
+    ASSERT_EQ(switches.load(), 1);
+    EXPECT_EQ(followups.load(), 0);
+    EXPECT_EQ(manager.LastCommandTimestamp(), 0);
+
+    service.AllowRedelivery();
+    manager.Start();
+    for (int retry = 0; retry < 2000 && followups.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    EXPECT_EQ(switches.load(), 1);
+    EXPECT_EQ(followups.load(), 1);
+    EXPECT_EQ(manager.LastCommandTimestamp(), 2);
+    server->Shutdown();
+}
+
+TEST(ClientTelemetryTest, AttachChannelInterruptsUnsupportedBackoff) {
+    UnsupportedTelemetryService unsupported_service;
+    CountingTelemetryService supported_service;
+    grpc::ServerBuilder unsupported_builder;
+    grpc::ServerBuilder supported_builder;
+    int unsupported_port = 0;
+    int supported_port = 0;
+    unsupported_builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &unsupported_port);
+    unsupported_builder.RegisterService(&unsupported_service);
+    supported_builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &supported_port);
+    supported_builder.RegisterService(&supported_service);
+    auto unsupported_server = unsupported_builder.BuildAndStart();
+    auto supported_server = supported_builder.BuildAndStart();
+    ASSERT_NE(unsupported_server, nullptr);
+    ASSERT_NE(supported_server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = 60000;
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(
+        grpc::CreateChannel("127.0.0.1:" + std::to_string(unsupported_port), grpc::InsecureChannelCredentials()), "",
+        "", "", "", "");
+    manager.Start();
+    for (int retry = 0; retry < 2000 && manager.IsSupported(); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_FALSE(manager.IsSupported());
+    ASSERT_EQ(unsupported_service.heartbeats.load(), 1);
+
+    manager.AttachChannel(
+        grpc::CreateChannel("127.0.0.1:" + std::to_string(supported_port), grpc::InsecureChannelCredentials()), "", "",
+        "", "", "");
+    for (int retry = 0; retry < 2000 && supported_service.heartbeats.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    unsupported_server->Shutdown();
+    supported_server->Shutdown();
+
+    EXPECT_EQ(supported_service.heartbeats.load(), 1);
+    EXPECT_TRUE(manager.IsSupported());
+}
+
+TEST(ClientTelemetryTest, AttachChannelDuringHeartbeatImmediatelyProbesReplacement) {
+    BlockingTelemetryService old_service;
+    CountingTelemetryService new_service;
+    grpc::ServerBuilder old_builder;
+    grpc::ServerBuilder new_builder;
+    int old_port = 0;
+    int new_port = 0;
+    old_builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &old_port);
+    old_builder.RegisterService(&old_service);
+    new_builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &new_port);
+    new_builder.RegisterService(&new_service);
+    auto old_server = old_builder.BuildAndStart();
+    auto new_server = new_builder.BuildAndStart();
+    ASSERT_NE(old_server, nullptr);
+    ASSERT_NE(new_server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(
+        grpc::CreateChannel("127.0.0.1:" + std::to_string(old_port), grpc::InsecureChannelCredentials()), "", "", "",
+        "", "");
+    manager.Start();
+    if (!old_service.WaitForHeartbeat()) {
+        old_service.Release();
+        manager.Stop();
+        old_server->Shutdown();
+        new_server->Shutdown();
+        FAIL() << "old heartbeat did not enter the in-flight state";
+    }
+
+    manager.AttachChannel(
+        grpc::CreateChannel("127.0.0.1:" + std::to_string(new_port), grpc::InsecureChannelCredentials()), "", "", "",
+        "", "");
+    old_service.Release();
+    for (int retry = 0; retry < 2000 && new_service.heartbeats.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    old_server->Shutdown();
+    new_server->Shutdown();
+
+    EXPECT_EQ(new_service.heartbeats.load(), 1);
 }
 
 TEST(ClientTelemetryTest, ExternalStopWinsRaceWithHeartbeatSelfRestart) {
@@ -1009,6 +1304,45 @@ TEST(ClientTelemetryTest, PushConfigIsAtomicAndReportsAppliedAndIgnoredKeys) {
     auto payload = nlohmann::json::parse(replies.back().payload);
     EXPECT_EQ(payload["applied"], nlohmann::json({"enabled", "heartbeat_interval_ms", "sampling_rate"}));
     EXPECT_EQ(payload["ignored"], nlohmann::json({"ttl_seconds", "unknown_a", "unknown_b"}));
+}
+
+TEST(ClientTelemetryTest, ShowErrorsBoundsOversizedNonMessageFields) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config);
+    const std::string oversized_collection(1024 * 1024 + 1024, 'c');
+    manager.RecordOperation("Query", oversized_collection, std::chrono::steady_clock::now(), false, "tiny");
+
+    manager.ProcessCommands({{"errors", "show_errors", R"({"max_count":1})", 1, false, ""}});
+
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 1U);
+    ASSERT_TRUE(replies.front().success) << replies.front().error_message;
+    EXPECT_LE(replies.front().payload.size(), 1024U * 1024U);
+    const auto payload = nlohmann::json::parse(replies.front().payload);
+    ASSERT_EQ(payload.size(), 1U);
+    EXPECT_LT(payload.front().at("collection").get<std::string>().size(), oversized_collection.size());
+}
+
+TEST(ClientTelemetryTest, ShowErrorsTruncatesOversizedUtf8FieldsAtCodePointBoundaries) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config);
+    std::string oversized_utf8;
+    oversized_utf8.reserve(1200000);
+    for (size_t index = 0; index < 400000; ++index) {
+        oversized_utf8 += u8"界";
+    }
+    manager.RecordOperation("Query", oversized_utf8, std::chrono::steady_clock::now(), false, oversized_utf8);
+
+    manager.ProcessCommands({{"utf8-errors", "show_errors", R"({"max_count":1})", 1, false, ""}});
+
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 1U);
+    ASSERT_TRUE(replies.front().success) << replies.front().error_message;
+    EXPECT_LE(replies.front().payload.size(), 1024U * 1024U);
+    const auto payload = nlohmann::json::parse(replies.front().payload);
+    ASSERT_EQ(payload.size(), 1U);
+    EXPECT_LT(payload.front().at("collection").get<std::string>().size(), oversized_utf8.size());
+    EXPECT_LT(payload.front().at("error_msg").get<std::string>().size(), oversized_utf8.size());
 }
 
 TEST(ClientTelemetryTest, RejectsWrongCommandPayloadTypes) {


### PR DESCRIPTION
## Summary\n\n- make very large heartbeat intervals safe and cancellable across platforms\n- fence command batches across telemetry transport rebinding and canonicalize ACK IDs\n- wake unsupported backoff on channel replacement and bound show_errors truncation, including UTF-8 payloads\n\nFollow-up hardening for #585.\n\n## Validation\n\n- 854/854 unit tests passed\n- 291/291 mocked integration tests passed\n- final telemetry-focused suite: 33/33 passed\n- clang-format and git diff --check passed\n