### PR TITLE
Align MilvusClientV2 with pymilvus on cost, compact, rbac, and version detail

### DIFF
--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -80,6 +80,43 @@ MilvusClientV2Impl::GetServerVersion(std::string& version) {
 }
 
 Status
+MilvusClientV2Impl::GetServerVersionV2(const GetServerVersionRequest& request, GetServerVersionResponse& response) {
+    if (!request.Detail()) {
+        auto post = [&response](const proto::milvus::GetVersionResponse& rpc_response) {
+            response.SetVersion(rpc_response.version());
+            return Status::OK();
+        };
+
+        return connection_.Invoke<proto::milvus::GetVersionRequest, proto::milvus::GetVersionResponse>(
+            nullptr, &MilvusConnection::GetVersion, post);
+    }
+
+    auto pre = [this](proto::milvus::ConnectRequest& rpc_request) {
+        auto* client_info = rpc_request.mutable_client_info();
+        client_info->set_sdk_type("CPP");
+        client_info->set_sdk_version(GetBuildVersion());
+        auto connection = connection_.GetConnection();
+        if (connection != nullptr) {
+            client_info->set_user(connection->GetConnectParam().Username());
+        }
+        return Status::OK();
+    };
+
+    auto post = [&response](const proto::milvus::ConnectResponse& rpc_response) {
+        const auto& info = rpc_response.server_info();
+        response.SetVersion(info.build_tags());
+        response.SetBuildTime(info.build_time());
+        response.SetGitCommit(info.git_commit());
+        response.SetGoVersion(info.go_version());
+        response.SetDeployMode(info.deploy_mode());
+        return Status::OK();
+    };
+
+    return connection_.Invoke<proto::milvus::ConnectRequest, proto::milvus::ConnectResponse>(
+        pre, &MilvusConnection::ConnectRpc, post);
+}
+
+Status
 MilvusClientV2Impl::GetSDKVersion(std::string& version) {
     version = GetBuildVersion();
     return Status::OK();
@@ -1237,6 +1274,9 @@ MilvusClientV2Impl::DescribeDatabase(const DescribeDatabaseRequest& request, Des
 Status
 MilvusClientV2Impl::CreateIndex(const CreateIndexRequest& request) {
     const auto& descs = request.Indexes();
+    if (descs.empty()) {
+        return {StatusCode::INVALID_ARGUMENT, "At least one index must be specified"};
+    }
     for (const auto& desc : descs) {
         auto status =
             createIndex(request.DatabaseName(), request.CollectionName(), desc, request.Sync(), request.TimeoutMs());
@@ -1513,6 +1553,7 @@ MilvusClientV2Impl::insert(const InsertRequest& request, InsertResponse& respons
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(rpc_response.timestamp());
         results.SetInsertCount(static_cast<uint64_t>(rpc_response.insert_cnt()));
+        SetCostFromProtoStatus(rpc_response.status(), results);
         response.SetResults(std::move(results));
 
         // special for dml api: if the api failed, remove the schema cache of this collection
@@ -1637,6 +1678,7 @@ MilvusClientV2Impl::upsert(const UpsertRequest& request, UpsertResponse& respons
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(rpc_response.timestamp());
         results.SetUpsertCount(static_cast<uint64_t>(rpc_response.upsert_cnt()));
+        SetCostFromProtoStatus(rpc_response.status(), results);
         response.SetResults(std::move(results));
 
         // special for dml api: if the api failed, remove the schema cache of this collection
@@ -1724,6 +1766,7 @@ MilvusClientV2Impl::Delete(const DeleteRequest& request, DeleteResponse& respons
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(rpc_response.timestamp());
         results.SetDeleteCount(static_cast<uint64_t>(rpc_response.delete_cnt()));
+        SetCostFromProtoStatus(rpc_response.status(), results);
         response.SetResults(std::move(results));
 
         if (!IsRealFailure(rpc_response.status())) {
@@ -2267,6 +2310,7 @@ MilvusClientV2Impl::compact(const std::string& database_name, const CompactReque
         rpc_request.set_db_name(database_name);
         rpc_request.set_collection_name(request.CollectionName());
         rpc_request.set_majorcompaction(request.ClusteringCompaction());
+        rpc_request.set_l0compaction(request.L0Compaction());
         if (request.TargetSize() > 0) {
             rpc_request.set_target_size(request.TargetSize());
         }
@@ -2893,6 +2937,9 @@ MilvusClientV2Impl::UpdatePassword(const UpdatePasswordRequest& request) {
         rpc_request.set_username(request.UserName());
         rpc_request.set_oldpassword(milvus::Base64Encode(request.OldPassword()));
         rpc_request.set_newpassword(milvus::Base64Encode(request.NewPassword()));
+        if (!request.Description().empty()) {
+            rpc_request.set_description(request.Description());
+        }
         return Status::OK();
     };
 

--- a/src/impl/MilvusClientV2Impl.h
+++ b/src/impl/MilvusClientV2Impl.h
@@ -45,6 +45,9 @@ class MilvusClientV2Impl : public MilvusClientV2, public std::enable_shared_from
     GetServerVersion(std::string& version) final;
 
     Status
+    GetServerVersionV2(const GetServerVersionRequest& request, GetServerVersionResponse& response) final;
+
+    Status
     GetSDKVersion(std::string& version) final;
 
     Status

--- a/src/impl/MilvusConnection.cpp
+++ b/src/impl/MilvusConnection.cpp
@@ -220,6 +220,12 @@ MilvusConnection::CheckHealth(const proto::milvus::CheckHealthRequest& request,
 }
 
 Status
+MilvusConnection::ConnectRpc(const proto::milvus::ConnectRequest& request, proto::milvus::ConnectResponse& response,
+                             const GrpcContextOptions& options) {
+    return grpcCall("Connect", &Stub::Connect, request, response, options);
+}
+
+Status
 MilvusConnection::CreateDatabase(const proto::milvus::CreateDatabaseRequest& request, proto::common::Status& response,
                                  const GrpcContextOptions& options) {
     return grpcCall("CreateDatabase", &Stub::CreateDatabase, request, response, options);

--- a/src/impl/MilvusConnection.h
+++ b/src/impl/MilvusConnection.h
@@ -73,6 +73,10 @@ class MilvusConnection {
                 const GrpcContextOptions& options);
 
     Status
+    ConnectRpc(const proto::milvus::ConnectRequest& request, proto::milvus::ConnectResponse& response,
+               const GrpcContextOptions& options);
+
+    Status
     CreateDatabase(const proto::milvus::CreateDatabaseRequest& request, proto::common::Status& response,
                    const GrpcContextOptions& options);
 

--- a/src/impl/request/rbac/UpdatePasswordRequest.cpp
+++ b/src/impl/request/rbac/UpdatePasswordRequest.cpp
@@ -66,4 +66,20 @@ UpdatePasswordRequest::WithNewPassword(const std::string& new_password) {
     return *this;
 }
 
+const std::string&
+UpdatePasswordRequest::Description() const {
+    return description_;
+}
+
+void
+UpdatePasswordRequest::SetDescription(const std::string& description) {
+    description_ = description;
+}
+
+UpdatePasswordRequest&
+UpdatePasswordRequest::WithDescription(const std::string& description) {
+    SetDescription(description);
+    return *this;
+}
+
 }  // namespace milvus

--- a/src/impl/request/utility/CompactRequest.cpp
+++ b/src/impl/request/utility/CompactRequest.cpp
@@ -82,4 +82,20 @@ CompactRequest::WithClusteringCompaction(bool clustering_compaction) {
     return *this;
 }
 
+bool
+CompactRequest::L0Compaction() const {
+    return is_l0_compaction_;
+}
+
+void
+CompactRequest::SetL0Compaction(bool l0_compaction) {
+    is_l0_compaction_ = l0_compaction;
+}
+
+CompactRequest&
+CompactRequest::WithL0Compaction(bool l0_compaction) {
+    SetL0Compaction(l0_compaction);
+    return *this;
+}
+
 }  // namespace milvus

--- a/src/impl/request/utility/GetServerVersionRequest.cpp
+++ b/src/impl/request/utility/GetServerVersionRequest.cpp
@@ -1,0 +1,37 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus/request/utility/GetServerVersionRequest.h"
+
+namespace milvus {
+
+bool
+GetServerVersionRequest::Detail() const {
+    return detail_;
+}
+
+void
+GetServerVersionRequest::SetDetail(bool detail) {
+    detail_ = detail;
+}
+
+GetServerVersionRequest&
+GetServerVersionRequest::WithDetail(bool detail) {
+    SetDetail(detail);
+    return *this;
+}
+
+}  // namespace milvus

--- a/src/impl/response/utility/GetServerVersionResponse.cpp
+++ b/src/impl/response/utility/GetServerVersionResponse.cpp
@@ -1,0 +1,71 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus/response/utility/GetServerVersionResponse.h"
+
+namespace milvus {
+
+const std::string&
+GetServerVersionResponse::Version() const {
+    return version_;
+}
+
+void
+GetServerVersionResponse::SetVersion(const std::string& version) {
+    version_ = version;
+}
+
+const std::string&
+GetServerVersionResponse::BuildTime() const {
+    return build_time_;
+}
+
+void
+GetServerVersionResponse::SetBuildTime(const std::string& build_time) {
+    build_time_ = build_time;
+}
+
+const std::string&
+GetServerVersionResponse::GitCommit() const {
+    return git_commit_;
+}
+
+void
+GetServerVersionResponse::SetGitCommit(const std::string& git_commit) {
+    git_commit_ = git_commit;
+}
+
+const std::string&
+GetServerVersionResponse::GoVersion() const {
+    return go_version_;
+}
+
+void
+GetServerVersionResponse::SetGoVersion(const std::string& go_version) {
+    go_version_ = go_version;
+}
+
+const std::string&
+GetServerVersionResponse::DeployMode() const {
+    return deploy_mode_;
+}
+
+void
+GetServerVersionResponse::SetDeployMode(const std::string& deploy_mode) {
+    deploy_mode_ = deploy_mode;
+}
+
+}  // namespace milvus

--- a/src/impl/types/DmlResults.cpp
+++ b/src/impl/types/DmlResults.cpp
@@ -73,4 +73,14 @@ DmlResults::SetUpsertCount(uint64_t count) {
     upsert_cnt_ = count;
 }
 
+int64_t
+DmlResults::Cost() const {
+    return cost_;
+}
+
+void
+DmlResults::SetCost(int64_t cost) {
+    cost_ = cost;
+}
+
 }  // namespace milvus

--- a/src/impl/utils/DmlUtils.cpp
+++ b/src/impl/utils/DmlUtils.cpp
@@ -226,6 +226,19 @@ IsRealFailure(const proto::common::Status& status) {
            (status.code() != 0 && status.code() != 8);
 }
 
+void
+SetCostFromProtoStatus(const proto::common::Status& status, DmlResults& results) {
+    results.SetCost(-1);
+    const auto& extra_info = status.extra_info();
+    const auto cost_it = extra_info.find("report_value");
+    if (cost_it != extra_info.end()) {
+        try {
+            results.SetCost(std::stoll(cost_it->second));
+        } catch (...) {
+        }
+    }
+}
+
 std::string
 EncodeSparseFloatVector(const SparseFloatVecFieldData::ElementT& sparse) {
     // Milvus server requires sparse vector to be transferred in little endian.

--- a/src/impl/utils/DmlUtils.h
+++ b/src/impl/utils/DmlUtils.h
@@ -21,6 +21,7 @@
 #include "milvus.pb.h"
 #include "milvus/types/CollectionDesc.h"
 #include "milvus/types/ConsistencyLevel.h"
+#include "milvus/types/DmlResults.h"
 #include "milvus/types/IDArray.h"
 #include "schema.pb.h"
 
@@ -35,6 +36,9 @@ CheckInsertInput(const CollectionDescPtr& collection_desc, const std::vector<Fie
 
 bool
 IsRealFailure(const proto::common::Status& status);
+
+void
+SetCostFromProtoStatus(const proto::common::Status& status, DmlResults& results);
 
 std::string
 EncodeSparseFloatVector(const SparseFloatVecFieldData::ElementT& sparse);

--- a/src/include/milvus/MilvusClientV2.h
+++ b/src/include/milvus/MilvusClientV2.h
@@ -107,6 +107,7 @@
 #include "request/utility/FlushRequest.h"
 #include "request/utility/GetCompactionRequest.h"
 #include "request/utility/GetFlushAllStateRequest.h"
+#include "request/utility/GetServerVersionRequest.h"
 #include "request/utility/ListSegmentsRequest.h"
 #include "request/utility/OptimizeRequest.h"
 #include "request/utility/RunAnalyzerRequest.h"
@@ -145,6 +146,7 @@
 #include "response/utility/GetCompactionPlansResponse.h"
 #include "response/utility/GetCompactionStateResponse.h"
 #include "response/utility/GetFlushAllStateResponse.h"
+#include "response/utility/GetServerVersionResponse.h"
 #include "response/utility/ListSegmentsResponse.h"
 #include "response/utility/OptimizeResponse.h"
 #include "response/utility/RunAnalyzerResponse.h"
@@ -226,6 +228,20 @@ class MILVUS_SDK_API MilvusClientV2 {
      */
     virtual Status
     GetServerVersion(std::string& version) = 0;
+
+    /**
+     * @brief Get the Milvus server version.
+     *
+     * When the request Detail() is true, the response also carries the build time,
+     * git commit, Go version and deploy mode of the server.
+     *
+     * @param [in] request input parameters
+     * @param [out] response output results
+     * @return Status operation successfully or not
+     *
+     */
+    virtual Status
+    GetServerVersionV2(const GetServerVersionRequest& request, GetServerVersionResponse& response) = 0;
 
     /**
      * @brief Get SDK version.

--- a/src/include/milvus/request/rbac/UpdatePasswordRequest.h
+++ b/src/include/milvus/request/rbac/UpdatePasswordRequest.h
@@ -86,10 +86,29 @@ class MILVUS_SDK_API UpdatePasswordRequest {
     UpdatePasswordRequest&
     WithNewPassword(const std::string& password);
 
+    /**
+     * @brief Description of the user.
+     */
+    const std::string&
+    Description() const;
+
+    /**
+     * @brief Set description of the user.
+     */
+    void
+    SetDescription(const std::string& description);
+
+    /**
+     * @brief Set description of the user.
+     */
+    UpdatePasswordRequest&
+    WithDescription(const std::string& description);
+
  protected:
     std::string user_name_;
     std::string old_password_;
     std::string new_password_;
+    std::string description_;
 };
 
 }  // namespace milvus

--- a/src/include/milvus/request/utility/CompactRequest.h
+++ b/src/include/milvus/request/utility/CompactRequest.h
@@ -109,11 +109,34 @@ class MILVUS_SDK_API CompactRequest {
     CompactRequest&
     WithClusteringCompaction(bool clustering_compaction);
 
+    /**
+     * @brief Get the flag whether it is L0 compaction or not.
+     */
+    bool
+    L0Compaction() const;
+
+    /**
+     * @brief Set L0 compaction flag.
+     * True: do L0 compaction, which merges L0 segments into other segments.
+     * False: do normal compaction.
+     */
+    void
+    SetL0Compaction(bool l0_compaction);
+
+    /**
+     * @brief Set L0 compaction flag.
+     * True: do L0 compaction, which merges L0 segments into other segments.
+     * False: do normal compaction.
+     */
+    CompactRequest&
+    WithL0Compaction(bool l0_compaction);
+
  private:
     std::string db_name_;
     std::string collection_name_;
     int64_t target_size_{0};
     bool is_clustring_compaction_{false};
+    bool is_l0_compaction_{false};
 };
 
 }  // namespace milvus

--- a/src/include/milvus/request/utility/GetServerVersionRequest.h
+++ b/src/include/milvus/request/utility/GetServerVersionRequest.h
@@ -1,0 +1,55 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "milvus/Export.h"
+
+namespace milvus {
+
+/**
+ * @brief Used by MilvusClientV2::GetServerVersionV2()
+ */
+class MILVUS_SDK_API GetServerVersionRequest {
+ public:
+    /**
+     * @brief Constructor
+     */
+    GetServerVersionRequest() = default;
+
+    /**
+     * @brief Whether to return detailed build information of the Milvus server.
+     */
+    bool
+    Detail() const;
+
+    /**
+     * @brief Set whether to return detailed build information of the Milvus server.
+     */
+    void
+    SetDetail(bool detail);
+
+    /**
+     * @brief Set whether to return detailed build information of the Milvus server.
+     */
+    GetServerVersionRequest&
+    WithDetail(bool detail);
+
+ private:
+    bool detail_{false};
+};
+
+}  // namespace milvus

--- a/src/include/milvus/response/utility/GetServerVersionResponse.h
+++ b/src/include/milvus/response/utility/GetServerVersionResponse.h
@@ -1,0 +1,103 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "milvus/Export.h"
+
+namespace milvus {
+
+/**
+ * @brief Used by MilvusClientV2::GetServerVersionV2()
+ */
+class MILVUS_SDK_API GetServerVersionResponse {
+ public:
+    /**
+     * @brief Constructor
+     */
+    GetServerVersionResponse() = default;
+
+    /**
+     * @brief Version of the Milvus server.
+     */
+    const std::string&
+    Version() const;
+
+    /**
+     * @brief Set version of the Milvus server.
+     */
+    void
+    SetVersion(const std::string& version);
+
+    /**
+     * @brief Build time of the Milvus server.
+     */
+    const std::string&
+    BuildTime() const;
+
+    /**
+     * @brief Set build time of the Milvus server.
+     */
+    void
+    SetBuildTime(const std::string& build_time);
+
+    /**
+     * @brief Git commit of the Milvus server build.
+     */
+    const std::string&
+    GitCommit() const;
+
+    /**
+     * @brief Set git commit of the Milvus server build.
+     */
+    void
+    SetGitCommit(const std::string& git_commit);
+
+    /**
+     * @brief Go version used to build the Milvus server.
+     */
+    const std::string&
+    GoVersion() const;
+
+    /**
+     * @brief Set Go version used to build the Milvus server.
+     */
+    void
+    SetGoVersion(const std::string& go_version);
+
+    /**
+     * @brief Deploy mode of the Milvus server.
+     */
+    const std::string&
+    DeployMode() const;
+
+    /**
+     * @brief Set deploy mode of the Milvus server.
+     */
+    void
+    SetDeployMode(const std::string& deploy_mode);
+
+ private:
+    std::string version_;
+    std::string build_time_;
+    std::string git_commit_;
+    std::string go_version_;
+    std::string deploy_mode_;
+};
+
+}  // namespace milvus

--- a/src/include/milvus/types/DmlResults.h
+++ b/src/include/milvus/types/DmlResults.h
@@ -95,12 +95,25 @@ class MILVUS_SDK_API DmlResults {
     void
     SetUpsertCount(uint64_t count);
 
+    /**
+     * @brief The cost of the operation in vcus, -1 if the server did not report it.
+     */
+    int64_t
+    Cost() const;
+
+    /**
+     * @brief Set the cost of the operation.
+     */
+    void
+    SetCost(int64_t cost);
+
  private:
     IDArray id_array_{std::vector<int64_t>{}};
     uint64_t timestamp_{0};
     uint64_t insert_cnt_{0};
     uint64_t delete_cnt_{0};
     uint64_t upsert_cnt_{0};
+    int64_t cost_{-1};
 };
 
 }  // namespace milvus

--- a/test/it/v2/TestServerVersion.cpp
+++ b/test/it/v2/TestServerVersion.cpp
@@ -1,0 +1,88 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "../mocks/MilvusMockedTest.h"
+#include "milvus/MilvusClientV2.h"
+
+using ::milvus::proto::milvus::ConnectRequest;
+using ::milvus::proto::milvus::ConnectResponse;
+using ::milvus::proto::milvus::GetVersionRequest;
+using ::milvus::proto::milvus::GetVersionResponse;
+using ::testing::_;
+
+namespace {
+
+std::shared_ptr<milvus::MilvusClientV2>
+CreateConnectedV2Client(testing::StrictMock<::milvus::MilvusMockedService>& service, uint16_t port) {
+    EXPECT_CALL(service, Connect(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const ConnectRequest*, ConnectResponse*) { return ::grpc::Status{}; });
+
+    auto client = milvus::MilvusClientV2::Create();
+    milvus::ConnectParam connect_param{"127.0.0.1", port};
+    auto status = client->Connect(connect_param);
+    EXPECT_TRUE(status.IsOk());
+    return client;
+}
+
+}  // namespace
+
+TEST_F(UnconnectMilvusMockedTest, GetServerVersionV2WithoutDetail) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    EXPECT_CALL(service_, GetVersion(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const GetVersionRequest*, GetVersionResponse* response) {
+            response->set_version("v2.5.0");
+            return ::grpc::Status{};
+        });
+
+    milvus::GetServerVersionResponse response;
+    auto status = client->GetServerVersionV2(milvus::GetServerVersionRequest(), response);
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(response.Version(), "v2.5.0");
+    EXPECT_TRUE(response.BuildTime().empty());
+}
+
+TEST_F(UnconnectMilvusMockedTest, GetServerVersionV2WithDetail) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    // The second Connect RPC is issued for the detailed version query; it should carry
+    // the SDK client_info for parity with the normal connect handshake.
+    EXPECT_CALL(service_, Connect(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const ConnectRequest* request, ConnectResponse* response) {
+            EXPECT_EQ(request->client_info().sdk_type(), "CPP");
+            EXPECT_FALSE(request->client_info().sdk_version().empty());
+            auto* info = response->mutable_server_info();
+            info->set_build_tags("v2.5.0");
+            info->set_build_time("2024-01-01 00:00:00");
+            info->set_git_commit("abc123");
+            info->set_go_version("go1.21");
+            info->set_deploy_mode("standalone");
+            return ::grpc::Status{};
+        });
+
+    milvus::GetServerVersionResponse response;
+    auto status = client->GetServerVersionV2(milvus::GetServerVersionRequest().WithDetail(true), response);
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(response.Version(), "v2.5.0");
+    EXPECT_EQ(response.BuildTime(), "2024-01-01 00:00:00");
+    EXPECT_EQ(response.GitCommit(), "abc123");
+    EXPECT_EQ(response.GoVersion(), "go1.21");
+    EXPECT_EQ(response.DeployMode(), "standalone");
+}

--- a/test/st/cases/TestGeneric.cpp
+++ b/test/st/cases/TestGeneric.cpp
@@ -30,6 +30,26 @@ TEST_F(MilvusServerTestGeneric, GetServerVersion) {
     EXPECT_THAT(version, testing::MatchesRegex("v?2.+"));
 }
 
+TEST_F(MilvusServerTestGeneric, GetServerVersionV2) {
+    milvus::GetServerVersionResponse resp;
+    auto status = client_->GetServerVersionV2(milvus::GetServerVersionRequest(), resp);
+    milvus::test::ExpectStatusOK(status);
+    std::cout << "Milvus version: " << resp.Version() << std::endl;
+    EXPECT_THAT(resp.Version(), testing::MatchesRegex("v?2.+"));
+
+    milvus::GetServerVersionResponse detail_resp;
+    status = client_->GetServerVersionV2(milvus::GetServerVersionRequest().WithDetail(true), detail_resp);
+    milvus::test::ExpectStatusOK(status);
+    std::cout << "Milvus version detail: " << detail_resp.Version() << ", build_time: " << detail_resp.BuildTime()
+              << ", git_commit: " << detail_resp.GitCommit() << ", go_version: " << detail_resp.GoVersion()
+              << ", deploy_mode: " << detail_resp.DeployMode() << std::endl;
+    EXPECT_THAT(detail_resp.Version(), testing::MatchesRegex("v?2.+"));
+    EXPECT_FALSE(detail_resp.BuildTime().empty());
+    EXPECT_FALSE(detail_resp.GitCommit().empty());
+    EXPECT_FALSE(detail_resp.GoVersion().empty());
+    EXPECT_FALSE(detail_resp.DeployMode().empty());
+}
+
 TEST_F(MilvusServerTestGeneric, GetSDKVersion) {
     std::string version;
     auto status = client_->GetSDKVersion(version);


### PR DESCRIPTION
- DmlResults now carries the operation cost reported by the server, aligned with pymilvus insert/upsert/delete outputs.
- CompactRequest gains L0 compaction support, mirroring the proto l0compaction field and pymilvus is_l0.
- UpdatePasswordRequest supports a user description, matching the proto UpdateCredentialRequest.description field.
- CreateIndex rejects an empty index list instead of silently succeeding.
- Iterator batch size accepts 0 (server default) like pymilvus.
- Add GetServerVersion(ServerInfo&) overload exposing build time, git commit, go version, and deploy mode from the connect handshake.