### PR TITLE
Expose DML cost and validate search/hybrid_search params

### DIFF
--- a/src/impl/MilvusClientImpl.cpp
+++ b/src/impl/MilvusClientImpl.cpp
@@ -1041,6 +1041,7 @@ MilvusClientImpl::insert(const std::string& collection_name, const std::string& 
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(response.timestamp());
         results.SetInsertCount(static_cast<uint64_t>(response.insert_cnt()));
+        FillDmlCost(response.status(), results);
 
         // special for dml api: if the api failed, remove the schema cache of this collection
         if (IsRealFailure(response.status())) {
@@ -1115,6 +1116,7 @@ MilvusClientImpl::insert(const std::string& collection_name, const std::string& 
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(response.timestamp());
         results.SetInsertCount(static_cast<uint64_t>(response.insert_cnt()));
+        FillDmlCost(response.status(), results);
 
         // special for dml api: if the api failed, remove the schema cache of this collection
         if (IsRealFailure(response.status())) {
@@ -1212,6 +1214,7 @@ MilvusClientImpl::upsert(const std::string& collection_name, const std::string& 
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(response.timestamp());
         results.SetUpsertCount(static_cast<uint64_t>(response.upsert_cnt()));
+        FillDmlCost(response.status(), results);
 
         // special for dml api: if the api failed, remove the schema cache of this collection
         if (IsRealFailure(response.status())) {
@@ -1285,6 +1288,7 @@ MilvusClientImpl::upsert(const std::string& collection_name, const std::string& 
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(response.timestamp());
         results.SetUpsertCount(static_cast<uint64_t>(response.upsert_cnt()));
+        FillDmlCost(response.status(), results);
 
         // special for dml api: if the api failed, remove the schema cache of this collection
         if (IsRealFailure(response.status())) {
@@ -1325,6 +1329,7 @@ MilvusClientImpl::Delete(const std::string& collection_name, const std::string& 
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(response.timestamp());
         results.SetDeleteCount(static_cast<uint64_t>(response.delete_cnt()));
+        FillDmlCost(response.status(), results);
 
         if (!IsRealFailure(response.status())) {
             // TODO: if the parameters provides db_name in future, we need to set the correct

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -1855,6 +1855,7 @@ MilvusClientV2Impl::insert(const InsertRequest& request, InsertResponse& respons
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(rpc_response.timestamp());
         results.SetInsertCount(static_cast<uint64_t>(rpc_response.insert_cnt()));
+        FillDmlCost(rpc_response.status(), results);
         response.SetResults(std::move(results));
 
         // special for dml api: if the api failed, remove the schema cache of this collection
@@ -1980,6 +1981,7 @@ MilvusClientV2Impl::upsert(const UpsertRequest& request, UpsertResponse& respons
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(rpc_response.timestamp());
         results.SetUpsertCount(static_cast<uint64_t>(rpc_response.upsert_cnt()));
+        FillDmlCost(rpc_response.status(), results);
         response.SetResults(std::move(results));
 
         // special for dml api: if the api failed, remove the schema cache of this collection
@@ -2067,6 +2069,7 @@ MilvusClientV2Impl::Delete(const DeleteRequest& request, DeleteResponse& respons
         results.SetIdArray(std::move(id_array));
         results.SetTimestamp(rpc_response.timestamp());
         results.SetDeleteCount(static_cast<uint64_t>(rpc_response.delete_cnt()));
+        FillDmlCost(rpc_response.status(), results);
         response.SetResults(std::move(results));
 
         if (!IsRealFailure(rpc_response.status())) {
@@ -2244,6 +2247,8 @@ MilvusClientV2Impl::hybridSearch(const HybridSearchRequest& request, HybridSearc
                                  const std::string& cluster_id) {
     const auto endpoint = connection_.CurrentEndpoint();
     const auto database_name = connection_.CurrentDbName(request.DatabaseName());
+    auto validate = [&request]() { return request.Validate(); };
+
     auto pre = [&endpoint, &database_name, &request, &cluster_id](proto::milvus::HybridSearchRequest& rpc_request) {
         return ConvertHybridSearchRequest<HybridSearchRequest>(request, database_name, rpc_request, cluster_id,
                                                                endpoint);
@@ -2272,7 +2277,7 @@ MilvusClientV2Impl::hybridSearch(const HybridSearchRequest& request, HybridSearc
 
     return InvokeWithTelemetry(connection_, "HybridSearch", request.CollectionName(), [&]() {
         return connection_.Invoke<proto::milvus::HybridSearchRequest, proto::milvus::SearchResults>(
-            pre, &MilvusConnection::HybridSearch, post);
+            validate, pre, &MilvusConnection::HybridSearch, post);
     });
 }
 

--- a/src/impl/request/dql/HybridSearchRequest.cpp
+++ b/src/impl/request/dql/HybridSearchRequest.cpp
@@ -185,4 +185,35 @@ HybridSearchRequest::WithStrictGroupSize(bool strict_group_size) {
     return *this;
 }
 
+Status
+HybridSearchRequest::Validate() const {
+    auto status = ValidateLimit(limit_);
+    if (!status.IsOk()) {
+        return status;
+    }
+
+    status = ValidateRoundDecimal(extra_params_);
+    if (!status.IsOk()) {
+        return status;
+    }
+
+    for (const auto& sub_request : sub_requests_) {
+        if (sub_request == nullptr) {
+            return {StatusCode::INVALID_ARGUMENT, "Sub request can not be null!"};
+        }
+        auto status = sub_request->Validate();
+        if (!status.IsOk()) {
+            return status;
+        }
+    }
+    if (function_ == nullptr) {
+        return {StatusCode::INVALID_ARGUMENT, "Rerank function is undefined!"};
+    }
+    if (function_->GetFunctionType() != FunctionType::RERANK) {
+        return {StatusCode::INVALID_ARGUMENT, "Hybrid search only accepts RERANK function!"};
+    }
+
+    return Status::OK();
+}
+
 }  // namespace milvus

--- a/src/impl/request/dql/SearchRequest.cpp
+++ b/src/impl/request/dql/SearchRequest.cpp
@@ -308,6 +308,16 @@ SearchRequest::AddOrderByField(OrderByField order_by_field) {
 
 Status
 SearchRequest::Validate() const {
+    auto status = ValidateLimit(Limit());
+    if (!status.IsOk()) {
+        return status;
+    }
+
+    status = ValidateRoundDecimal(extra_params_);
+    if (!status.IsOk()) {
+        return status;
+    }
+
     if (IDs().GetRowCount() != 0 && (TargetVectors() != nullptr || !EmbeddingLists().empty())) {
         return {StatusCode::INVALID_ARGUMENT, "Only one of IDs or target vectors can be provided"};
     }

--- a/src/impl/types/DmlResults.cpp
+++ b/src/impl/types/DmlResults.cpp
@@ -73,4 +73,14 @@ DmlResults::SetUpsertCount(uint64_t count) {
     upsert_cnt_ = count;
 }
 
+int64_t
+DmlResults::Cost() const {
+    return cost_;
+}
+
+void
+DmlResults::SetCost(int64_t cost) {
+    cost_ = cost;
+}
+
 }  // namespace milvus

--- a/src/impl/types/HybridSearchArguments.cpp
+++ b/src/impl/types/HybridSearchArguments.cpp
@@ -204,6 +204,16 @@ HybridSearchArguments::ExtraParams() const {
 
 Status
 HybridSearchArguments::Validate() const {
+    auto status = ValidateLimit(limit_);
+    if (!status.IsOk()) {
+        return status;
+    }
+
+    status = ValidateRoundDecimal(extra_params_);
+    if (!status.IsOk()) {
+        return status;
+    }
+
     for (auto& it : sub_requests_) {
         if (it == nullptr) {
             return {StatusCode::INVALID_ARGUMENT, "Sub request can not be null!"};

--- a/src/impl/types/SearchRequestBase.cpp
+++ b/src/impl/types/SearchRequestBase.cpp
@@ -259,6 +259,16 @@ SearchRequestBase::SetTimezone(const std::string& timezone) {
 
 Status
 SearchRequestBase::Validate() const {
+    auto status = ValidateLimit(limit_);
+    if (!status.IsOk()) {
+        return status;
+    }
+
+    status = ValidateRoundDecimal(extra_params_);
+    if (!status.IsOk()) {
+        return status;
+    }
+
     if (this->TargetVectors() != nullptr && !embedding_lists_.empty()) {
         return Status{StatusCode::INVALID_ARGUMENT, "Not allow to set both embedding list and target vector"};
     }

--- a/src/impl/utils/DmlUtils.cpp
+++ b/src/impl/utils/DmlUtils.cpp
@@ -23,6 +23,7 @@
 #include "./Constants.h"
 #include "./TypeUtils.h"
 #include "milvus/types/Constants.h"
+#include "milvus/types/DmlResults.h"
 #include "milvus/utils/FP16.h"
 
 namespace {
@@ -1712,6 +1713,19 @@ CheckAndSetRowData(const EntityRows& rows, const CollectionSchema& schema, bool 
     }
 
     return Status::OK();
+}
+
+void
+FillDmlCost(const proto::common::Status& status, DmlResults& results) {
+    const auto& extra_info = status.extra_info();
+    const auto cost_it = extra_info.find("report_value");
+    if (cost_it == extra_info.end()) {
+        return;
+    }
+    try {
+        results.SetCost(std::stoll(cost_it->second));
+    } catch (...) {
+    }
 }
 
 }  // namespace milvus

--- a/src/impl/utils/DmlUtils.h
+++ b/src/impl/utils/DmlUtils.h
@@ -25,6 +25,7 @@
 #include "schema.pb.h"
 
 namespace milvus {
+class DmlResults;
 
 bool
 IsInputField(const FieldSchema& field_schema, bool is_upsert);
@@ -35,6 +36,9 @@ CheckInsertInput(const CollectionDescPtr& collection_desc, const std::vector<Fie
 
 bool
 IsRealFailure(const proto::common::Status& status);
+
+void
+FillDmlCost(const proto::common::Status& status, DmlResults& results);
 
 std::string
 EncodeSparseFloatVector(const SparseFloatVecFieldData::ElementT& sparse);

--- a/src/impl/utils/ExtraParamUtils.h
+++ b/src/impl/utils/ExtraParamUtils.h
@@ -39,6 +39,43 @@ GetExtraInt64(const ExtraParamsMap& params, const std::string& key, int64_t defa
     return default_val;
 }
 
+inline bool
+TryGetExtraInt64(const ExtraParamsMap& params, const std::string& key, int64_t& value) {
+    auto it = params.find(key);
+    if (it == params.end()) {
+        return false;
+    }
+    try {
+        value = std::stoll(it->second);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+inline Status
+ValidateLimit(int64_t limit) {
+    if (limit <= 0) {
+        return {StatusCode::INVALID_ARGUMENT, "limit must be greater than 0"};
+    }
+    return Status::OK();
+}
+
+inline Status
+ValidateRoundDecimal(const ExtraParamsMap& params) {
+    int64_t round_decimal = -1;
+    if (TryGetExtraInt64(params, "round_decimal", round_decimal)) {
+        if (round_decimal <= -2 || round_decimal >= 7) {
+            return {StatusCode::INVALID_ARGUMENT, "round_decimal must be in range (-2, 7)"};
+        }
+        return Status::OK();
+    }
+    if (params.count("round_decimal") != 0) {
+        return {StatusCode::INVALID_ARGUMENT, "round_decimal must be a valid integer"};
+    }
+    return Status::OK();
+}
+
 inline std::string
 DoubleToString(double val) {
     std::ostringstream stream;

--- a/src/include/milvus/request/dql/HybridSearchRequest.h
+++ b/src/include/milvus/request/dql/HybridSearchRequest.h
@@ -217,6 +217,13 @@ class MILVUS_SDK_API HybridSearchRequest : public DQLRequestBase<HybridSearchReq
     HybridSearchRequest&
     WithStrictGroupSize(bool strict_group_size);
 
+    /**
+     * @brief Validate the hybrid search request before sending it to the server.
+     * @return Status::OK when the request is valid, otherwise an INVALID_ARGUMENT error.
+     */
+    Status
+    Validate() const;
+
  private:
     std::vector<SubSearchRequestPtr> sub_requests_;
     FunctionPtr function_;

--- a/src/include/milvus/types/DmlResults.h
+++ b/src/include/milvus/types/DmlResults.h
@@ -95,12 +95,25 @@ class MILVUS_SDK_API DmlResults {
     void
     SetUpsertCount(uint64_t count);
 
+    /**
+     * @brief The operation cost in VCU reported by the server, -1 when unavailable.
+     */
+    int64_t
+    Cost() const;
+
+    /**
+     * @brief Set the operation cost reported by the server.
+     */
+    void
+    SetCost(int64_t cost);
+
  private:
     IDArray id_array_{std::vector<int64_t>{}};
     uint64_t timestamp_{0};
     uint64_t insert_cnt_{0};
     uint64_t delete_cnt_{0};
     uint64_t upsert_cnt_{0};
+    int64_t cost_{-1};
 };
 
 }  // namespace milvus

--- a/test/ut/request/TestDqlRequests.cpp
+++ b/test/ut/request/TestDqlRequests.cpp
@@ -743,3 +743,98 @@ TEST_F(QueryIteratorRequestTest, SetReduceStopForBest) {
     EXPECT_TRUE(req.ReduceStopForBest());
     EXPECT_EQ(&ref, &req);
 }
+
+TEST_F(SearchRequestTest, ValidateRejectsInvalidRoundDecimal) {
+    milvus::SearchRequest req;
+    req.WithLimit(10).WithRoundDecimal(7);
+
+    auto status = req.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(SearchRequestTest, ValidateHandlesNonNumericRoundDecimalWithoutThrowing) {
+    milvus::SearchRequest req;
+    req.WithLimit(10);
+    req.AddExtraParam("round_decimal", "not-a-number");
+
+    auto status = req.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(HybridSearchRequestTest, ValidateRejectsNonPositiveLimit) {
+    milvus::HybridSearchRequest req;
+    req.WithLimit(0);
+
+    auto status = req.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(HybridSearchRequestTest, ValidateRejectsInvalidRoundDecimal) {
+    milvus::HybridSearchRequest req;
+    req.WithLimit(10).WithRoundDecimal(7);
+
+    auto status = req.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(HybridSearchRequestTest, ValidateHandlesNonNumericRoundDecimalWithoutThrowing) {
+    milvus::HybridSearchRequest req;
+    req.WithLimit(10);
+    req.AddExtraParam("round_decimal", "not-a-number");
+
+    auto status = req.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(HybridSearchRequestTest, ValidateAcceptsFullyValidRequest) {
+    milvus::HybridSearchRequest req;
+    auto sub = std::make_shared<milvus::SubSearchRequest>();
+    sub->WithAnnsField("vec").WithLimit(10);
+    sub->AddFloatVector(std::vector<float>{0.1f, 0.2f, 0.3f, 0.4f});
+    req.WithLimit(10).AddSubRequest(sub);
+    req.WithRerank(std::make_shared<milvus::RRFRerank>(60));
+
+    auto status = req.Validate();
+    EXPECT_TRUE(status.IsOk());
+}
+
+TEST_F(HybridSearchRequestTest, ValidateRejectsNullSubRequest) {
+    milvus::HybridSearchRequest req;
+    req.WithLimit(10);
+    req.AddSubRequest(nullptr);
+    req.WithRerank(std::make_shared<milvus::RRFRerank>(60));
+
+    auto status = req.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(HybridSearchRequestTest, ValidateRejectsMissingRerank) {
+    milvus::HybridSearchRequest req;
+    auto sub = std::make_shared<milvus::SubSearchRequest>();
+    sub->WithAnnsField("vec").WithLimit(10);
+    sub->AddFloatVector(std::vector<float>{0.1f, 0.2f, 0.3f, 0.4f});
+    req.WithLimit(10).AddSubRequest(sub);
+
+    auto status = req.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(HybridSearchRequestTest, ValidateRejectsNonRerankFunction) {
+    milvus::HybridSearchRequest req;
+    auto sub = std::make_shared<milvus::SubSearchRequest>();
+    sub->WithAnnsField("vec").WithLimit(10);
+    sub->AddFloatVector(std::vector<float>{0.1f, 0.2f, 0.3f, 0.4f});
+    req.WithLimit(10).AddSubRequest(sub);
+    req.WithRerank(std::make_shared<milvus::Function>("not_rerank", milvus::FunctionType::UNKNOWN));
+
+    auto status = req.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}

--- a/test/ut/types/TestDmlResults.cpp
+++ b/test/ut/types/TestDmlResults.cpp
@@ -50,3 +50,10 @@ TEST_F(DmlResultsTest, UpsertCount) {
     dml_results.SetUpsertCount(75);
     EXPECT_EQ(dml_results.UpsertCount(), 75);
 }
+
+TEST_F(DmlResultsTest, Cost) {
+    milvus::DmlResults dml_results;
+    EXPECT_EQ(dml_results.Cost(), -1);
+    dml_results.SetCost(12345);
+    EXPECT_EQ(dml_results.Cost(), 12345);
+}

--- a/test/ut/types/TestSearchArguments.cpp
+++ b/test/ut/types/TestSearchArguments.cpp
@@ -235,3 +235,56 @@ TEST_F(SearchArgumentsTest, SetRoundDecimal) {
     EXPECT_TRUE(status.IsOk());
     EXPECT_EQ(arguments.RoundDecimal(), 3);
 }
+
+TEST_F(SearchArgumentsTest, ValidateRejectsNonPositiveLimit) {
+    milvus::SearchArguments arguments;
+    arguments.SetLimit(0);
+    arguments.AddFloatVector(std::vector<float>{1.0f, 2.0f});
+
+    auto status = arguments.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(SearchArgumentsTest, ValidateRejectsInvalidRoundDecimal) {
+    milvus::SearchArguments arguments;
+    arguments.SetLimit(10);
+    arguments.SetRoundDecimal(7);
+    arguments.AddFloatVector(std::vector<float>{1.0f, 2.0f});
+
+    auto status = arguments.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(SearchArgumentsTest, ValidateAcceptsBoundaryRoundDecimal) {
+    for (int round_decimal : {-1, 6}) {
+        milvus::SearchArguments arguments;
+        arguments.SetLimit(10);
+        arguments.SetRoundDecimal(round_decimal);
+        arguments.AddFloatVector(std::vector<float>{1.0f, 2.0f});
+        EXPECT_TRUE(arguments.Validate().IsOk());
+    }
+}
+
+TEST_F(SearchArgumentsTest, ValidateRejectsNegativeLowerBoundRoundDecimal) {
+    milvus::SearchArguments arguments;
+    arguments.SetLimit(10);
+    arguments.SetRoundDecimal(-2);
+    arguments.AddFloatVector(std::vector<float>{1.0f, 2.0f});
+
+    auto status = arguments.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(SearchArgumentsTest, ValidateHandlesNonNumericRoundDecimalWithoutThrowing) {
+    milvus::SearchArguments arguments;
+    arguments.SetLimit(10);
+    arguments.AddExtraParam("round_decimal", "not-a-number");
+    arguments.AddFloatVector(std::vector<float>{1.0f, 2.0f});
+
+    auto status = arguments.Validate();
+    EXPECT_FALSE(status.IsOk());
+    EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}

--- a/test/ut/utils/TestDmlUtils.cpp
+++ b/test/ut/utils/TestDmlUtils.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 
 #include "milvus/types/Constants.h"
+#include "milvus/types/DmlResults.h"
 #include "milvus/utils/FP16.h"
 #include "utils/Constants.h"
 #include "utils/DmlUtils.h"
@@ -1470,4 +1471,27 @@ TEST_F(DmlUtilsTest, DenseVectorColumnsRejectRaggedRows) {
         milvus::DataType::BFLOAT16_VECTOR, 2);
     verify(std::make_shared<milvus::Int8VecFieldData>("int8", std::vector<std::vector<int8_t>>{{1}, {2, 3, 4}}),
            milvus::DataType::INT8_VECTOR, 2);
+}
+
+TEST_F(DmlUtilsTest, FillDmlCost) {
+    {
+        milvus::proto::common::Status status;
+        (*status.mutable_extra_info())["report_value"] = "12345";
+        milvus::DmlResults results;
+        milvus::FillDmlCost(status, results);
+        EXPECT_EQ(results.Cost(), 12345);
+    }
+    {
+        milvus::proto::common::Status status;
+        milvus::DmlResults results;
+        milvus::FillDmlCost(status, results);
+        EXPECT_EQ(results.Cost(), -1);
+    }
+    {
+        milvus::proto::common::Status status;
+        (*status.mutable_extra_info())["report_value"] = "not-a-number";
+        milvus::DmlResults results;
+        milvus::FillDmlCost(status, results);
+        EXPECT_EQ(results.Cost(), -1);
+    }
 }


### PR DESCRIPTION
- DmlResults gains a Cost() accessor; insert/upsert/delete now fill it from the server Status extra_info 'report_value', matching SearchResponse and PyMilvus.
- SearchRequestBase/SearchRequest/HybridSearchArguments/HybridSearchRequest Validate() now reject limit <= 0 and round_decimal outside (-2, 7), matching PyMilvus check_pass_param.