### PR TITLE
Match pymilvus search iterator filter and DML/get short-circuits

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -122,7 +122,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.conan2
-          key: linux-${{ matrix.os.key }}-conan-${{ github.base_ref || github.ref_name }}-${{ hashFiles('conanfile.*', 'CMakeLists.txt', 'cmake/**', 'scripts/install_deps.sh') }}
+          # src/** etc. are hashed so the SDK package produced by
+          # build_tutorials.sh (whose recipe revision covers these sources) is
+          # saved under a distinct key whenever the sources change; otherwise
+          # every run would restore the previous snapshot, rebuild the SDK, and
+          # never save the new package (actions/cache skips save on an exact
+          # primary-key hit).
+          key: linux-${{ matrix.os.key }}-conan-${{ github.base_ref || github.ref_name }}-${{ hashFiles('conanfile.*', 'CMakeLists.txt', 'cmake/**', 'scripts/install_deps.sh', 'src/**', 'test/**', 'examples/**', 'thirdparty/**', 'LICENSE', 'README.md', 'DEVELOPMENT.md', 'CHANGELOG.md') }}
           restore-keys: linux-${{ matrix.os.key }}-conan-
       - name: Cache ccache
         uses: actions/cache@v4
@@ -165,7 +171,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PRUNE_PREFIXES: "linux-${{ matrix.os.key }}-ccache- linux-${{ matrix.os.key }}-conan-"
-          KEEP_KEYS: "linux-${{ matrix.os.key }}-ccache-${{ github.sha }} linux-${{ matrix.os.key }}-conan-${{ github.base_ref || github.ref_name }}-${{ hashFiles('conanfile.*', 'CMakeLists.txt', 'cmake/**', 'scripts/install_deps.sh') }}"
+          KEEP_KEYS: "linux-${{ matrix.os.key }}-ccache-${{ github.sha }} linux-${{ matrix.os.key }}-conan-${{ github.base_ref || github.ref_name }}-${{ hashFiles('conanfile.*', 'CMakeLists.txt', 'cmake/**', 'scripts/install_deps.sh', 'src/**', 'test/**', 'examples/**', 'thirdparty/**', 'LICENSE', 'README.md', 'DEVELOPMENT.md', 'CHANGELOG.md') }}"
         run: python3 scripts/prune_caches.py
 
   coverage-ubuntu:

--- a/examples/src/v2/iterator_search.cpp
+++ b/examples/src/v2/iterator_search.cpp
@@ -170,6 +170,86 @@ iterateCollection(milvus::MilvusClientV2Ptr& client, int64_t batch, int64_t limi
     std::cout << "=====================================================" << std::endl;
 }
 
+// Demonstrates the client-side page filter (pymilvus external_filter_func).
+// The callback receives each page of hits fetched by the iterator and prunes rows
+// in place via SingleResult::FilterRows. Here we keep only rows whose user_age is even.
+void
+iterateWithExternalFilter(milvus::MilvusClientV2Ptr& client, int64_t batch, int64_t limit,
+                          const std::string& filter) {
+    std::cout << "=====================================================" << std::endl;
+    std::cout << "Iterate with external filter, batch: " + std::to_string(batch)
+              << " limit: " + std::to_string(limit) << " filter: " + filter << std::endl;
+    milvus::SearchIteratorRequest request;
+    request.SetCollectionName(collection_name);
+    request.SetBatchSize(batch);
+    request.SetLimit(limit);
+    request.SetAnnsField(field_face);
+    request.SetFilter(filter);
+    request.AddOutputField(field_name);
+    request.AddOutputField(field_age);
+    request.AddOutputField("b");  // dynamic field
+    std::vector<float> vector(dimension);
+    for (auto d = 0; d < dimension; ++d) {
+        vector[d] = 1.0f;
+    }
+    request.AddFloatVector(vector);
+
+    // Keep only rows where user_age is even. FilterRows keeps the rows whose
+    // indices are listed, in the order they appear in the list. The age column
+    // is read directly via OutputField() to avoid materializing whole rows.
+    request.SetExternalFilterFunc([](milvus::SingleResult& page) {
+        auto age_field = page.OutputField<milvus::Int8FieldData>(field_age);
+        if (age_field == nullptr) {
+            return milvus::Status{milvus::StatusCode::INVALID_ARGUMENT,
+                                  "user_age output field missing in search result"};
+        }
+        const auto& ages = age_field->Data();
+        std::vector<uint64_t> keep_indices;
+        for (uint64_t i = 0; i < ages.size(); ++i) {
+            if (ages[i] % 2 == 0) {
+                keep_indices.push_back(i);
+            }
+        }
+        return page.FilterRows(keep_indices);
+    });
+
+    milvus::SearchIteratorPtr iterator;
+    auto status = client->SearchIterator(request, iterator);
+    util::CheckStatus("get search iterator with external filter", status);
+
+    std::set<int64_t> ids;
+    int pages = 0;
+    uint64_t total_count = 0;
+    while (true) {
+        milvus::SingleResult batch_results;
+        status = iterator->Next(batch_results);
+        util::CheckStatus("iterator next batch", status);
+        auto batch_count = batch_results.GetRowCount();
+        if (batch_count == 0) {
+            std::cout << "search iteration with external filter finished" << std::endl;
+            break;
+        }
+        pages++;
+        total_count += batch_count;
+
+        milvus::EntityRows rows;
+        status = batch_results.OutputRows(rows);
+        util::CheckStatus("get output rows", status);
+        std::cout << "No." << std::to_string(pages) << " page " << std::to_string(rows.size()) << " rows fetched"
+                  << std::endl;
+        for (const auto& row : rows) {
+            if (row[field_age].get<int64_t>() % 2 != 0) {
+                std::cout << "ERROR: a row with odd user_age " << row[field_age].get<int64_t>()
+                          << " slipped through the external filter" << std::endl;
+            }
+            ids.insert(row[field_id].get<int64_t>());
+        }
+    }
+
+    std::cout << "Total fetched rows (external filter): " << std::to_string(total_count) << std::endl;
+    std::cout << "=====================================================" << std::endl;
+}
+
 }  // namespace
 
 int
@@ -198,6 +278,9 @@ main(int argc, char* argv[]) {
         iterateCollection(client, 1000, 2500, std::string(field_age) + " > 30");
         // batch 1000, limit 100000, filter "user_age in [30, 40, 50]"
         iterateCollection(client, 1000, 100000, std::string(field_age) + " in [30, 40, 50]");
+
+        // batch 3000, limit 100000, client-side page filter keeps even user_age rows only
+        iterateWithExternalFilter(client, 3000, 100000, "");
     };
 
     iterationFunc(milvus::MetricType::L2);

--- a/scripts/build_tutorials.sh
+++ b/scripts/build_tutorials.sh
@@ -19,17 +19,26 @@ if ! conan remote list | grep -q "^${REMOTE_NAME}:"; then
     conan remote add "${REMOTE_NAME}" "${REMOTE_URL}" --allowed-packages "milvus-sdk-cpp/*"
 fi
 
-echo "Creating milvus-sdk-cpp/${SDK_VERSION}@${SDK_USER}/${SDK_CHANNEL} from the current checkout"
-conan create "${ROOT_DIR}" \
+echo "Exporting milvus-sdk-cpp/${SDK_VERSION}@${SDK_USER}/${SDK_CHANNEL} from the current checkout"
+conan export "${ROOT_DIR}" \
     --version="${SDK_VERSION}" \
     --user="${SDK_USER}" \
-    --channel="${SDK_CHANNEL}" \
+    --channel="${SDK_CHANNEL}"
+
+# Build the SDK package only when the current checkout is not already cached.
+# conan create always forces a rebuild; export + install --build=missing reuses
+# the cached package whenever the recipe revision is unchanged.
+SDK_REF="milvus-sdk-cpp/${SDK_VERSION}@${SDK_USER}/${SDK_CHANNEL}"
+SDK_BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "${SDK_BUILD_DIR}"' EXIT
+conan install --requires="${SDK_REF}" \
+    --build=missing \
     -s build_type=Release \
     -s compiler.cppstd=14 \
     -s:b build_type=Release \
     -s:b compiler.cppstd=17 \
     -c tools.build:jobs="${JOBS}" \
-    --build=missing
+    --output-folder="${SDK_BUILD_DIR}"
 
 export MILVUS_SDK_VERSION="${SDK_VERSION}"
 export MILVUS_SDK_USER="${SDK_USER}"

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -1772,6 +1772,24 @@ Status
 MilvusClientV2Impl::insert(const InsertRequest& request, InsertResponse& response, bool allow_retry) {
     const auto endpoint = connection_.CurrentEndpoint();
     const auto database_name = connection_.CurrentDbName(request.DatabaseName());
+
+    // Short-circuit empty data like pymilvus: no rows to insert, do not issue the RPC.
+    // Check the row count rather than container emptiness so a request whose
+    // columns hold zero rows (FieldData::Count() == 0) is still short-circuited.
+    const auto& columns = request.ColumnsData();
+    uint64_t column_count = 0;
+    if (!columns.empty() && columns.front() != nullptr) {
+        column_count = columns.front()->Count();
+    }
+    if (column_count == 0 && request.RowsData().empty()) {
+        if (request.CollectionName().empty()) {
+            return {StatusCode::INVALID_ARGUMENT, "Collection name cannot be empty!"};
+        }
+        DmlResults results;
+        response.SetResults(std::move(results));
+        return Status::OK();
+    }
+
     CollectionDescPtr collection_desc;
     std::vector<proto::schema::FieldData> rpc_fields;
     auto validate = [this, &endpoint, &database_name, &request, &collection_desc, &rpc_fields]() {
@@ -1892,6 +1910,25 @@ Status
 MilvusClientV2Impl::upsert(const UpsertRequest& request, UpsertResponse& response, bool allow_retry) {
     const auto endpoint = connection_.CurrentEndpoint();
     const auto database_name = connection_.CurrentDbName(request.DatabaseName());
+
+    // Short-circuit empty data like pymilvus: no rows to upsert, do not issue the RPC.
+    // Keep partial-update field operations flowing to the server for validation even
+    // when the request carries no rows (field_ops is a C++-specific input). The row
+    // count, not container emptiness, drives the short-circuit (see insert()).
+    const auto& upsert_columns = request.ColumnsData();
+    uint64_t upsert_column_count = 0;
+    if (!upsert_columns.empty() && upsert_columns.front() != nullptr) {
+        upsert_column_count = upsert_columns.front()->Count();
+    }
+    if (upsert_column_count == 0 && request.RowsData().empty() && request.FieldOps().empty()) {
+        if (request.CollectionName().empty()) {
+            return {StatusCode::INVALID_ARGUMENT, "Collection name cannot be empty!"};
+        }
+        DmlResults results;
+        response.SetResults(std::move(results));
+        return Status::OK();
+    }
+
     std::vector<proto::schema::FieldData> rpc_fields;
     CollectionDescPtr collection_desc;
     auto validate = [this, &endpoint, &database_name, &request, &collection_desc, &rpc_fields]() {
@@ -2354,6 +2391,16 @@ MilvusClientV2Impl::get(const GetRequest& request, GetResponse& response, const 
 Status
 MilvusClientV2Impl::getWithoutTelemetry(const GetRequest& request, GetResponse& response,
                                         const std::string& cluster_id) {
+    // Short-circuit empty ids like pymilvus: no rows to fetch, do not issue the RPC.
+    if (request.IDs().GetRowCount() == 0) {
+        if (request.CollectionName().empty()) {
+            return {StatusCode::INVALID_ARGUMENT, "Collection name cannot be empty!"};
+        }
+        response.SetResults(QueryResults{});
+        response.SetSessionTs(0);
+        return Status::OK();
+    }
+
     const auto endpoint = connection_.CurrentEndpoint();
     const auto database_name = connection_.CurrentDbName(request.DatabaseName());
     CollectionDescPtr collection_desc;

--- a/src/impl/types/IteratorArguments.cpp
+++ b/src/impl/types/IteratorArguments.cpp
@@ -59,6 +59,16 @@ IteratorArguments::SetPkSchema(const FieldSchema& schema) {
     return Status::OK();
 }
 
+const std::function<Status(SingleResult&)>&
+IteratorArguments::ExternalFilterFunc() const {
+    return external_filter_func_;
+}
+
+void
+IteratorArguments::SetExternalFilterFunc(const std::function<Status(SingleResult&)>& func) {
+    external_filter_func_ = func;
+}
+
 /////////////////////////////////////////////////////////////////////////////////////
 // QueryIteratorArguments
 bool

--- a/src/impl/types/SearchIteratorImpl.cpp
+++ b/src/impl/types/SearchIteratorImpl.cpp
@@ -58,24 +58,63 @@ SearchIteratorImpl<T>::Next(SingleResult& results) {
         output_count = std::min(output_count, left_count);
     }
 
-    if (SearchIteratorImpl::CachedCount(cache_) < output_count) {
-        // if cache is not sufficient, try to fill the result by probing with constant width
-        // until finish filling or exceeding max trial time: 10
-        auto status = trySearchFill(output_count);
+    // Apply the client-side page filter (pymilvus external_filter_func) if set.
+    // A filtered-out page does not grow the cache, so keep filling and fetching
+    // until a non-empty page is produced or the server has no more results.
+    const bool has_filter = static_cast<bool>(args_.ExternalFilterFunc());
+    while (true) {
+        if (SearchIteratorImpl::CachedCount(cache_) < output_count) {
+            // if cache is not sufficient, try to fill the result by probing with constant width
+            // until finish filling or exceeding max trial time: 10
+            auto status = trySearchFill(output_count);
+            if (!status.IsOk()) {
+                return status;
+            }
+        }
+
+        // return batch from the cache if cache is big enough
+        results.Clear();
+        auto status = SearchIteratorImpl::FetchPageFromCache(cache_, args_.OutputFields(), output_count, results);
         if (!status.IsOk()) {
             return status;
         }
+
+        if (results.GetRowCount() == 0) {
+            // no more rows from the server
+            break;
+        }
+
+        // keep width_ derived from the unfiltered page: the external filter below usually
+        // prunes rows below BatchSize, so the old post-loop width update would never fire
+        // and width_ (which drives radius expansion) would stay frozen at the init value.
+        if (results.GetRowCount() == args_.BatchSize()) {
+            updateWidth(results);
+        }
+
+        if (!has_filter) {
+            break;
+        }
+
+        status = args_.ExternalFilterFunc()(results);
+        if (!status.IsOk()) {
+            return status;
+        }
+        if (results.GetRowCount() > 0) {
+            break;
+        }
+
+        // the whole page was filtered out; pull more rows from the server
+        if (SearchIteratorImpl::CachedCount(cache_) < output_count) {
+            auto fill_status = trySearchFill(output_count);
+            if (!fill_status.IsOk()) {
+                return fill_status;
+            }
+        }
+        if (SearchIteratorImpl::CachedCount(cache_) == 0) {
+            break;
+        }
     }
 
-    // return batch from the cache if cache is big enough
-    auto status = SearchIteratorImpl::FetchPageFromCache(cache_, args_.OutputFields(), output_count, results);
-    if (!status.IsOk()) {
-        return status;
-    }
-
-    if (results.GetRowCount() == args_.BatchSize()) {
-        updateWidth(results);
-    }
     returned_count_ += results.GetRowCount();
     return Status::OK();
 }

--- a/src/impl/types/SearchIteratorV2Impl.cpp
+++ b/src/impl/types/SearchIteratorV2Impl.cpp
@@ -67,6 +67,19 @@ SearchIteratorV2Impl<T>::Next(SingleResult& results) {
             break;
         }
 
+        // Apply the client-side page filter (pymilvus external_filter_func) if set.
+        // A filtered-out page does not grow the cache, so keep pulling until the
+        // target length is reached or the server has no more results.
+        if (args_.ExternalFilterFunc()) {
+            status = args_.ExternalFilterFunc()(*single_result);
+            if (!status.IsOk()) {
+                return status;
+            }
+            if (single_result->GetRowCount() == 0) {
+                continue;
+            }
+        }
+
         cache_.emplace_back(std::move(single_result));
         auto cache_count = SearchIteratorImpl<T>::CachedCount(cache_);
         if (cache_count >= static_cast<uint64_t>(target_len)) {

--- a/src/impl/types/SearchResults.cpp
+++ b/src/impl/types/SearchResults.cpp
@@ -17,6 +17,7 @@
 #include "milvus/types/SearchResults.h"
 
 #include <stdexcept>
+#include <utility>
 
 #include "../utils/Constants.h"
 #include "../utils/DqlUtils.h"
@@ -165,6 +166,47 @@ SingleResult&
 SingleResult::WithHighlightResults(std::vector<HighlightResults>&& highlight_results) {
     highlight_results_ = std::move(highlight_results);
     return *this;
+}
+
+Status
+SingleResult::FilterRows(const std::vector<uint64_t>& keep_indices) {
+    if (keep_indices.empty()) {
+        output_fields_.clear();
+        output_names_.clear();
+        highlight_results_.clear();
+        return Status::OK();
+    }
+
+    std::vector<FieldDataPtr> filtered_fields;
+    filtered_fields.reserve(output_fields_.size());
+    for (const auto& field : output_fields_) {
+        if (field == nullptr) {
+            filtered_fields.emplace_back(nullptr);
+            continue;
+        }
+
+        FieldDataPtr target;
+        auto status = CopyFieldDataByIndices(field, keep_indices, target);
+        if (!status.IsOk()) {
+            return status;
+        }
+        filtered_fields.emplace_back(std::move(target));
+    }
+    output_fields_ = std::move(filtered_fields);
+
+    if (!highlight_results_.empty()) {
+        std::vector<HighlightResults> filtered_highlights;
+        filtered_highlights.reserve(keep_indices.size());
+        for (uint64_t idx : keep_indices) {
+            if (idx >= highlight_results_.size()) {
+                return {StatusCode::INVALID_ARGUMENT, "Highlight row index is out of bound"};
+            }
+            filtered_highlights.emplace_back(highlight_results_[idx]);
+        }
+        highlight_results_ = std::move(filtered_highlights);
+    }
+
+    return Status::OK();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/impl/utils/DqlUtils.cpp
+++ b/src/impl/utils/DqlUtils.cpp
@@ -2178,6 +2178,133 @@ CopyFieldDataRange(const FieldDataPtr& src, uint64_t from, uint64_t to, FieldDat
     return Status::OK();
 }
 
+template <typename T>
+Status
+CopyFieldDataIndices(const FieldDataPtr& src, const std::vector<uint64_t>& indices, FieldDataPtr& target) {
+    auto src_ptr = std::static_pointer_cast<T>(src);
+    const auto& src_data = src_ptr->Data();
+
+    std::vector<typename T::ElementT> target_data{};
+    target_data.reserve(indices.size());
+    const auto& src_valid_data = src_ptr->ValidData();
+    std::vector<bool> target_valid_data;
+    if (!src_valid_data.empty()) {
+        target_valid_data.reserve(indices.size());
+    }
+    for (uint64_t idx : indices) {
+        if (idx >= src->Count()) {
+            return {StatusCode::INVALID_ARGUMENT, "row index out of bound"};
+        }
+        target_data.push_back(src_data.at(idx));
+        if (!src_valid_data.empty()) {
+            target_valid_data.push_back(!src_ptr->IsNull(idx));
+        }
+    }
+    target = std::make_shared<T>(src->Name(), std::move(target_data), std::move(target_valid_data));
+    return Status::OK();
+}
+
+Status
+CopyFieldDataByIndices(const FieldDataPtr& src, const std::vector<uint64_t>& indices, FieldDataPtr& target) {
+    if (src == nullptr) {
+        return {StatusCode::INVALID_ARGUMENT, "Source field data is null pointer"};
+    }
+
+    switch (src->Type()) {
+        case DataType::BOOL: {
+            return CopyFieldDataIndices<BoolFieldData>(src, indices, target);
+        }
+        case DataType::INT8: {
+            return CopyFieldDataIndices<Int8FieldData>(src, indices, target);
+        }
+        case DataType::INT16: {
+            return CopyFieldDataIndices<Int16FieldData>(src, indices, target);
+        }
+        case DataType::INT32: {
+            return CopyFieldDataIndices<Int32FieldData>(src, indices, target);
+        }
+        case DataType::INT64: {
+            return CopyFieldDataIndices<Int64FieldData>(src, indices, target);
+        }
+        case DataType::FLOAT: {
+            return CopyFieldDataIndices<FloatFieldData>(src, indices, target);
+        }
+        case DataType::DOUBLE: {
+            return CopyFieldDataIndices<DoubleFieldData>(src, indices, target);
+        }
+        case DataType::VARCHAR:
+        case DataType::GEOMETRY:
+        case DataType::TEXT:
+        case DataType::TIMESTAMPTZ: {
+            return CopyFieldDataIndices<VarCharFieldData>(src, indices, target);
+        }
+        case DataType::JSON: {
+            return CopyFieldDataIndices<JSONFieldData>(src, indices, target);
+        }
+        case DataType::ARRAY: {
+            switch (src->ElementType()) {
+                case DataType::BOOL: {
+                    return CopyFieldDataIndices<ArrayBoolFieldData>(src, indices, target);
+                }
+                case DataType::INT8: {
+                    return CopyFieldDataIndices<ArrayInt8FieldData>(src, indices, target);
+                }
+                case DataType::INT16: {
+                    return CopyFieldDataIndices<ArrayInt16FieldData>(src, indices, target);
+                }
+                case DataType::INT32: {
+                    return CopyFieldDataIndices<ArrayInt32FieldData>(src, indices, target);
+                }
+                case DataType::INT64: {
+                    return CopyFieldDataIndices<ArrayInt64FieldData>(src, indices, target);
+                }
+                case DataType::FLOAT: {
+                    return CopyFieldDataIndices<ArrayFloatFieldData>(src, indices, target);
+                }
+                case DataType::DOUBLE: {
+                    return CopyFieldDataIndices<ArrayDoubleFieldData>(src, indices, target);
+                }
+                case DataType::VARCHAR:
+                case DataType::GEOMETRY:
+                case DataType::TEXT:
+                case DataType::TIMESTAMPTZ: {
+                    return CopyFieldDataIndices<ArrayVarCharFieldData>(src, indices, target);
+                }
+                case DataType::STRUCT: {
+                    return CopyFieldDataIndices<StructFieldData>(src, indices, target);
+                }
+                default: {
+                    std::string msg = "Unsupported element type: " + std::to_string(src->ElementType());
+                    return {StatusCode::NOT_SUPPORTED, msg};
+                }
+            }
+        }
+        case DataType::BINARY_VECTOR: {
+            return CopyFieldDataIndices<BinaryVecFieldData>(src, indices, target);
+        }
+        case DataType::FLOAT_VECTOR: {
+            return CopyFieldDataIndices<FloatVecFieldData>(src, indices, target);
+        }
+        case DataType::FLOAT16_VECTOR: {
+            return CopyFieldDataIndices<Float16VecFieldData>(src, indices, target);
+        }
+        case DataType::BFLOAT16_VECTOR: {
+            return CopyFieldDataIndices<BFloat16VecFieldData>(src, indices, target);
+        }
+        case DataType::SPARSE_FLOAT_VECTOR: {
+            return CopyFieldDataIndices<SparseFloatVecFieldData>(src, indices, target);
+        }
+        case DataType::INT8_VECTOR: {
+            return CopyFieldDataIndices<Int8VecFieldData>(src, indices, target);
+        }
+        default: {
+            return {StatusCode::NOT_SUPPORTED, "Unsupported field type: " + std::to_string(src->Type())};
+        }
+    }
+
+    return Status::OK();
+}
+
 Status
 CopyFieldData(const FieldDataPtr& src, uint64_t from, uint64_t to, FieldDataPtr& target) {
     if (src == nullptr) {

--- a/src/impl/utils/DqlUtils.h
+++ b/src/impl/utils/DqlUtils.h
@@ -111,6 +111,14 @@ ConvertHybridSearchRequest(const T& request, const std::string& current_db,
 Status
 CopyFieldData(const FieldDataPtr& src, uint64_t from, uint64_t to, FieldDataPtr& target);
 
+/**
+ * @brief Copy the rows at the given indices into a new FieldData in one pass.
+ * The kept rows keep the order they appear in `indices`. Reserved ahead of time,
+ * so it avoids the per-row allocation of CopyFieldData + AppendFieldData loops.
+ */
+Status
+CopyFieldDataByIndices(const FieldDataPtr& src, const std::vector<uint64_t>& indices, FieldDataPtr& target);
+
 Status
 CopyFieldsData(const std::vector<FieldDataPtr>& src, uint64_t from, uint64_t to, std::vector<FieldDataPtr>& target);
 

--- a/src/include/milvus/types/IteratorArguments.h
+++ b/src/include/milvus/types/IteratorArguments.h
@@ -16,12 +16,16 @@
 
 #pragma once
 
+#include <functional>
+
 #include "FieldSchema.h"
 #include "QueryArguments.h"
 #include "SearchArguments.h"
 #include "milvus/Export.h"
 
 namespace milvus {
+
+struct SingleResult;
 
 /**
  * @brief Base class arguments for MilvusClient::QueryIterator() and SearchIterator().
@@ -71,10 +75,29 @@ class MILVUS_SDK_API IteratorArguments {
     Status
     SetPkSchema(const FieldSchema& schema);
 
+    /**
+     * @brief Get the client-side page filter callback.
+     * The callback receives each page of hits fetched by the search iterator and
+     * returns Status::OK after filtering the page in place (e.g. via
+     * SingleResult::FilterRows). Returning a non-OK status aborts iteration.
+     * Only SearchIterator supports this callback.
+     */
+    const std::function<Status(SingleResult&)>&
+    ExternalFilterFunc() const;
+
+    /**
+     * @brief Set a client-side page filter for the search iterator.
+     * Matches pymilvus `external_filter_func`: the callback filters each page of
+     * search hits before they are returned. This is a no-op for query iterators.
+     */
+    void
+    SetExternalFilterFunc(const std::function<Status(SingleResult&)>& func);
+
  private:
     int64_t batch_size_{1000};
     int64_t collection_id_{0};
     FieldSchema pk_schema_;
+    std::function<Status(SingleResult&)> external_filter_func_;
 };
 
 /**

--- a/src/include/milvus/types/SearchResults.h
+++ b/src/include/milvus/types/SearchResults.h
@@ -147,6 +147,16 @@ struct MILVUS_SDK_API SingleResult {
     SingleResult&
     WithHighlightResults(std::vector<HighlightResults>&& highlight_results);
 
+    /**
+     * @brief Keep only the rows whose indices are in `keep_indices`, dropping the rest.
+     * This is used by the client-side page filter of the search iterator to prune
+     * hits fetched from the server. The order of the kept rows follows `keep_indices`.
+     * @return Status::OK on success, otherwise an error status (INVALID_ARGUMENT
+     * or NOT_SUPPORTED, as propagated from the underlying field copy).
+     */
+    Status
+    FilterRows(const std::vector<uint64_t>& keep_indices);
+
  private:
     void
     verify() const;

--- a/test/it/v1/TestSearchIterator.cpp
+++ b/test/it/v1/TestSearchIterator.cpp
@@ -302,3 +302,168 @@ TEST_F(MilvusMockedTest, SearchIteratorV2PinsProbeTimestampForSessionConsistency
 
     milvus::CollectionTsCache::GetInstance().Invalidate(endpoint, "default", collection_name);
 }
+
+// Verifies the client-side page filter (pymilvus external_filter_func) is applied
+// on each fetched page: a fully-filtered page is dropped, and only the kept rows
+// from partially-filtered pages are accumulated across pages up to the target length.
+// `use_v1` forces the V1 fallback (empty token) so SearchIteratorImpl::Next runs the
+// filter loop instead of SearchIteratorV2.
+void
+DoSearchIteratorWithExternalFilter(testing::StrictMock<milvus::MilvusMockedService>& service,
+                                   milvus::MilvusClientPtr& client, bool use_v1) {
+    const std::string collection_name = "Foo";
+    milvus::CollectionSchema collection_schema(collection_name);
+    milvus::BuildCollectionSchema(collection_schema);
+    const int row_count = 10000;
+
+    std::vector<milvus::FieldDataPtr> fields_data;
+    milvus::BuildFieldsData(collection_schema, fields_data, row_count);
+
+    std::vector<std::string> field_names;
+    for (const auto& field : collection_schema.Fields()) {
+        field_names.push_back(field.Name());
+    }
+
+    EXPECT_CALL(service,
+                DescribeCollection(_, Property(&DescribeCollectionRequest::collection_name, collection_name), _))
+        .WillOnce([&](::grpc::ServerContext*, const DescribeCollectionRequest*, DescribeCollectionResponse* response) {
+            response->set_collectionid(100);
+            response->set_shards_num(2);
+            response->set_created_timestamp(1111);
+            auto proto_schema = response->mutable_schema();
+            milvus::ConvertCollectionSchema(collection_schema, *proto_schema);
+            return ::grpc::Status{};
+        });
+
+    const uint64_t batch_size = 100;
+    uint64_t current_poz = 0;
+    bool probe_compability = true;
+    EXPECT_CALL(service, Search(_, _, _))
+        .WillRepeatedly([&](::grpc::ServerContext*, const SearchRequest* request, SearchResults* response) {
+            auto token = use_v1 ? "" : "dummy";
+            response->mutable_results()->mutable_search_iterator_v2_results()->set_token(token);
+            if (probe_compability) {
+                probe_compability = false;
+                if (!use_v1) {
+                    response->set_session_ts(123456);
+                }
+                return ::grpc::Status{};
+            }
+
+            response->mutable_status()->set_code(milvus::proto::common::ErrorCode::Success);
+            auto* results = response->mutable_results();
+            auto topk = batch_size;
+            if (current_poz >= static_cast<uint64_t>(row_count)) {
+                topk = 0;
+            } else if (current_poz + batch_size > static_cast<uint64_t>(row_count)) {
+                topk = row_count - current_poz;
+            }
+            if (topk == 0) {
+                results->set_top_k(0);
+                results->set_num_queries(1);
+                results->set_primary_field_name(milvus::T_PK_NAME);
+                results->mutable_topks()->Add(0);
+                results->mutable_search_iterator_v2_results()->set_token(token);
+                return ::grpc::Status{};
+            }
+            auto page_poz = current_poz;
+            current_poz += topk;
+            results->set_top_k(topk);
+            results->set_num_queries(1);
+            results->set_primary_field_name(milvus::T_PK_NAME);
+            auto* mutable_fields = results->mutable_fields_data();
+            for (const auto& field_data : fields_data) {
+                // the primary key is returned via result_data.ids(), not in fields_data
+                if (field_data->Name() == milvus::T_PK_NAME) {
+                    continue;
+                }
+                milvus::FieldDataPtr page_data;
+                auto cstatus = milvus::CopyFieldData(field_data, page_poz, page_poz + topk, page_data);
+                EXPECT_TRUE(cstatus.IsOk());
+                milvus::FieldDataSchema bridge(page_data, nullptr);
+                milvus::proto::schema::FieldData data;
+                cstatus = milvus::CreateProtoFieldData(bridge, data);
+                EXPECT_TRUE(cstatus.IsOk());
+                mutable_fields->Add(std::move(data));
+            }
+            milvus::Int64FieldDataPtr pk_ptr = std::static_pointer_cast<milvus::Int64FieldData>(fields_data.at(0));
+            for (uint64_t i = 0; i < static_cast<uint64_t>(topk); i++) {
+                results->mutable_ids()->mutable_int_id()->add_data(pk_ptr->Value(page_poz + i));
+            }
+            results->mutable_topks()->Add(topk);
+            for (auto i = 0; i < topk; i++) {
+                results->mutable_scores()->Add(static_cast<float>(page_poz) + 100.0 - 0.01f * static_cast<float>(i));
+            }
+            return ::grpc::Status{};
+        });
+
+    milvus::SearchIteratorArguments arguments{};
+    arguments.SetBatchSize(batch_size);
+    arguments.SetLimit(row_count);
+    arguments.SetCollectionName(collection_name);
+    arguments.SetFilter("id >= 0");
+    arguments.SetConsistencyLevel(milvus::ConsistencyLevel::STRONG);
+    arguments.SetMetricType(milvus::MetricType::COSINE);
+    for (const auto& name : field_names) {
+        arguments.AddOutputField(name);
+    }
+    std::vector<float> vector(milvus::T_DIMENSION, 1.0f);
+    auto status = arguments.AddFloat16Vector("f16_vector", vector);
+    EXPECT_TRUE(status.IsOk());
+
+    // keep even primary keys in the first half of the pk range. Pages beyond the
+    // first half are entirely filtered out (exercising the fully-filtered continue),
+    // while pages in the first half are partially filtered (even rows kept).
+    arguments.SetExternalFilterFunc([row_count](milvus::SingleResult& page) {
+        std::vector<uint64_t> keep_indices;
+        auto ids = page.Ids();
+        EXPECT_TRUE(ids.IsIntegerID());
+        for (uint64_t i = 0; i < page.GetRowCount(); i++) {
+            auto pk = ids.IntIDArray().at(i);
+            if (pk % 2 == 0 && pk < row_count / 2) {
+                keep_indices.push_back(i);
+            }
+        }
+        return page.FilterRows(keep_indices);
+    });
+
+    milvus::SearchIteratorPtr iterator;
+    status = client->SearchIterator(arguments, iterator);
+    EXPECT_TRUE(status.IsOk());
+
+    uint64_t returned_count = 0;
+    while (true) {
+        milvus::SingleResult batch_results;
+        status = iterator->Next(batch_results);
+        EXPECT_TRUE(status.IsOk());
+        auto batch_count = batch_results.GetRowCount();
+        if (batch_count == 0) {
+            break;
+        }
+        returned_count += batch_count;
+
+        auto ids = batch_results.Ids();
+        for (uint64_t i = 0; i < static_cast<uint64_t>(batch_count); i++) {
+            auto pk = ids.IntIDArray().at(i);
+            EXPECT_EQ(pk % 2, 0) << "odd row leaked through the external filter";
+            EXPECT_LT(pk, row_count / 2) << "row beyond the kept range leaked through the external filter";
+        }
+    }
+    EXPECT_EQ(returned_count, static_cast<uint64_t>(row_count) / 4);
+}
+
+TEST_F(MilvusMockedTest, SearchIteratorV2AppliesExternalFilterPerPage) {
+    milvus::ConnectParam connect_param{"127.0.0.1", server_.ListenPort()};
+    auto status = client_->Connect(connect_param);
+    EXPECT_TRUE(status.IsOk());
+
+    DoSearchIteratorWithExternalFilter(service_, client_, false);
+}
+
+TEST_F(MilvusMockedTest, SearchIteratorV1AppliesExternalFilterPerPage) {
+    milvus::ConnectParam connect_param{"127.0.0.1", server_.ListenPort()};
+    auto status = client_->Connect(connect_param);
+    EXPECT_TRUE(status.IsOk());
+
+    DoSearchIteratorWithExternalFilter(service_, client_, true);
+}

--- a/test/it/v2/TestUpsert.cpp
+++ b/test/it/v2/TestUpsert.cpp
@@ -670,3 +670,32 @@ TEST_F(UnconnectMilvusMockedTest, BuildFieldsDataStringBacked) {
     ASSERT_EQ(arr_text->Data().size(), 4u);
     EXPECT_EQ(arr_text->Value(0).size(), 2u);
 }
+
+TEST_F(UnconnectMilvusMockedTest, InsertEmptyDataShortCircuitsNoRpc) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    milvus::InsertResponse response;
+    auto status = client->Insert(milvus::InsertRequest().WithCollectionName("empty_coll"), response);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+    EXPECT_EQ(response.Results().InsertCount(), 0);
+    EXPECT_EQ(response.Results().IdArray().GetRowCount(), 0);
+}
+
+TEST_F(UnconnectMilvusMockedTest, UpsertEmptyDataShortCircuitsNoRpc) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    milvus::UpsertResponse response;
+    auto status = client->Upsert(milvus::UpsertRequest().WithCollectionName("empty_coll"), response);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+    EXPECT_EQ(response.Results().UpsertCount(), 0);
+    EXPECT_EQ(response.Results().IdArray().GetRowCount(), 0);
+}
+
+TEST_F(UnconnectMilvusMockedTest, GetEmptyIdsShortCircuitsNoRpc) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    milvus::GetResponse response;
+    auto status = client->Get(milvus::GetRequest().WithCollectionName("empty_coll"), response);
+    EXPECT_TRUE(status.IsOk()) << status.Message();
+    EXPECT_EQ(response.Results().GetRowCount(), 0);
+}

--- a/test/ut/types/TestIteratorArguments.cpp
+++ b/test/ut/types/TestIteratorArguments.cpp
@@ -81,3 +81,19 @@ TEST_F(SearchIteratorArgumentsTest, SetCollectionID) {
     EXPECT_TRUE(status.IsOk());
     EXPECT_EQ(args.CollectionID(), 999);
 }
+
+TEST_F(SearchIteratorArgumentsTest, ExternalFilterFunc) {
+    milvus::SearchIteratorArguments args;
+    EXPECT_FALSE(args.ExternalFilterFunc());
+
+    bool invoked = false;
+    milvus::SingleResult page;
+    args.SetExternalFilterFunc([&invoked](milvus::SingleResult&) {
+        invoked = true;
+        return milvus::Status::OK();
+    });
+    ASSERT_TRUE(args.ExternalFilterFunc());
+    auto status = args.ExternalFilterFunc()(page);
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_TRUE(invoked);
+}

--- a/test/ut/types/TestSearchResults.cpp
+++ b/test/ut/types/TestSearchResults.cpp
@@ -39,6 +39,38 @@ TEST_F(SearchResultsTest, TestSingleResult) {
     EXPECT_EQ(result.OutputFieldNames().size(), output_names.size());
 }
 
+TEST_F(SearchResultsTest, FilterRowsKeepsSelectedRows) {
+    std::vector<milvus::FieldDataPtr> fields{
+        std::make_shared<milvus::Int64FieldData>("pk", std::vector<int64_t>{1, 2, 3, 4, 5}),
+        std::make_shared<milvus::FloatFieldData>("score", std::vector<float>{0.1f, 0.2f, 0.3f, 0.4f, 0.5f}),
+        std::make_shared<milvus::VarCharFieldData>("tag", std::vector<std::string>{"a", "b", "c", "d", "e"})};
+    std::set<std::string> output_names;
+    output_names.insert("tag");
+    milvus::SingleResult result{"pk", "score", std::move(fields), output_names};
+
+    auto status = result.FilterRows({3, 0, 2});
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(result.GetRowCount(), 3);
+    EXPECT_EQ(result.Ids().IntIDArray(), (std::vector<int64_t>{4, 1, 3}));
+    EXPECT_EQ(result.Scores(), (std::vector<float>{0.4f, 0.1f, 0.3f}));
+    auto tag = result.OutputField<milvus::VarCharFieldData>("tag");
+    ASSERT_NE(tag, nullptr);
+    EXPECT_EQ(tag->Data(), (std::vector<std::string>{"d", "a", "c"}));
+}
+
+TEST_F(SearchResultsTest, FilterRowsEmptyClears) {
+    std::vector<milvus::FieldDataPtr> fields{
+        std::make_shared<milvus::Int64FieldData>("pk", std::vector<int64_t>{1, 2, 3}),
+        std::make_shared<milvus::FloatFieldData>("score", std::vector<float>{0.1f, 0.2f, 0.3f})};
+    std::set<std::string> output_names;
+    milvus::SingleResult result{"pk", "score", std::move(fields), output_names};
+
+    auto status = result.FilterRows({});
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(result.GetRowCount(), 0);
+    EXPECT_TRUE(result.OutputFields().empty());
+}
+
 TEST_F(SearchResultsTest, GeneralTesting) {
     std::vector<milvus::FieldDataPtr> fields{};
     std::set<std::string> output_names;


### PR DESCRIPTION
- Add external_filter_func to iterator arguments; SearchIteratorV2 applies it per fetched page via SingleResult::FilterRows, matching pymilvus page filter.
- Short-circuit insert/upsert with empty data and get with empty ids (no RPC), returning empty results like pymilvus.