### PR TITLE
Align MilvusClientV2 load/describe/compaction/stats APIs with pymilvus

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.os.image }}
     # github automatically evicts no-access caches after 7 days, so we set a longer timeout to avoid unnecessary workflow timeout.
-    timeout-minutes: 200
+    timeout-minutes: 150
     permissions:
       contents: read
       actions: write
@@ -182,7 +182,7 @@ jobs:
     if: always() && (github.event_name == 'push' || needs.changes.outputs.core_relevant == 'true')
     runs-on: ubuntu-22.04
     # github automatically evicts no-access caches after 7 days, so we set a longer timeout to avoid unnecessary workflow timeout.
-    timeout-minutes: 200
+    timeout-minutes: 150
     permissions:
       contents: read
       actions: write
@@ -271,7 +271,7 @@ jobs:
     if: always() && (github.event_name == 'push' || needs.changes.outputs.core_relevant == 'true')
     runs-on: macos-15
     # github automatically evicts no-access caches after 7 days, so we set a longer timeout to avoid unnecessary workflow timeout.
-    timeout-minutes: 200
+    timeout-minutes: 150
     permissions:
       contents: read
       actions: write
@@ -343,7 +343,7 @@ jobs:
     if: always() && (github.event_name == 'push' || needs.changes.outputs.core_relevant == 'true')
     runs-on: windows-2022
     # github automatically evicts no-access caches after 7 days, so we set a longer timeout to avoid unnecessary workflow timeout.
-    timeout-minutes: 200
+    timeout-minutes: 150
     permissions:
       contents: read
       actions: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# AGENTS.md
+
+Repository guidance for AI agents and contributors working in `milvus-sdk-cpp`.
+
+## Repository layout
+
+The repo builds one shared/static library (`libmilvus_sdk`) plus test, example, and tutorial targets:
+
+| Area | Description | Location |
+|---|---|---|
+| Public headers | V2 aggregate header plus V1 legacy entry point | `src/include/milvus/` |
+| Implementation | V1/V2 impl, connection, conversion utils, caches | `src/impl/` |
+| Unit tests | no server required | `test/ut/` |
+| Mocked tests | in-process mocked gRPC server | `test/it/` |
+| System tests | real Milvus via Docker | `test/st/` |
+| Examples | V1 and V2 example programs | `examples/src/{v1,v2}/` |
+| Tutorials | standalone apps pinning the published SDK version | `tutorial/` |
+
+- Consumers include only the aggregate header `milvus/MilvusClientV2.h`. When exposing a new public V2 DTO,
+  add its header there.
+- Request DTOs live in `src/include/milvus/request/<domain>/`, response DTOs in
+  `src/include/milvus/response/<domain>/`, shared value types in `src/include/milvus/types/`. Each has a
+  matching implementation under `src/impl/request|response|types/`.
+- proto→SDK / SDK→proto conversions live in `src/impl/utils/` (`TypeUtils.cpp`, `DmlUtils.cpp`, `DqlUtils.cpp`,
+  `MiscUtils.cpp`). Shared machinery: `RpcUtils.cpp` (retry), `ConnectionHandler.cpp` (per-API
+  validate/pre/rpc/post pipeline), and `cache/` (`SchemaCache`, `CollectionTsCache`).
+
+## SDK generations
+
+Two API generations coexist:
+
+- **V1 (legacy, maintenance mode)** — `MilvusClient` (`milvus/MilvusClient.h`), implemented in
+  `src/impl/MilvusClientImpl.cpp`. Kept for backward compatibility: bug fixes and critical maintenance only,
+  **no new features**.
+- **V2 (active, long-term)** — `MilvusClientV2` (`milvus/MilvusClientV2.h`), implemented in
+  `src/impl/MilvusClientV2Impl.cpp` (+ `MilvusClientV2SessionImpl.cpp` for sessions). Request/response DTO
+  pattern: each operation is a `*Request` / `*Response` pair. All new features, API additions, and pymilvus
+  parity work target V2.
+
+## Conventions
+
+- **Public SDK APIs do not throw.** Return `Status`; catch and convert exception-prone conversions (for
+  example `nlohmann::json::parse`) into a non-OK `Status` instead of letting exceptions escape.
+- Request DTOs expose a fluent API: `WithXxx(...)` returning the request reference plus plain
+  `SetXxx(...)` / `Xxx()` accessors, mirroring the existing request classes.
+- Keep the public declarations, implementation declarations, DTO headers/implementations, proto conversions,
+  examples, and tests synchronized for every change.
+- Cache-aware RPC paths use one consistent endpoint, resolved database, collection/alias name, and schema load
+  scope. Audit successful DDL mutation callbacks for schema/timestamp invalidation or transfer
+  (`SchemaCache`, `CollectionTsCache`).
+- Do not edit generated protobuf files under the build tree; change the SDK conversion code or proto inputs
+  (`_deps/milvus_proto-*`).
+- Do not add comments unless they carry real context; keep new code free of stray comments.
+
+## Building
+
+Dependencies come from [Conan 2](https://conan.io/) (gRPC, protobuf, abseil, etc.); `scripts/build.sh`
+handles Conan integration and CMake configuration. ccache is enabled automatically via
+`RULE_LAUNCH_COMPILE`.
+
+```bash
+bash scripts/install_deps.sh     # one-time dev dependency setup
+make                             # debug build
+make all-release                 # release build
+make test                        # debug build + unit/mocked tests
+make test-release                # release build + unit/mocked tests
+make package                     # release build + DEB/RPM under cmake_build/Pack
+make coverage                    # lcov coverage (starts real-server system tests)
+```
+
+Useful controls (passed through to CMake):
+
+```bash
+JOBS=4 CPPSTD=17 BUILD_SHARED_LIBS=OFF make test
+UNITY=ON LINE=ON JOBS=4 make test       # faster cold builds; see DEVELOPMENT.md
+CMAKE_BUILD_EXAMPLES=OFF JOBS=4 make test
+MILVUS_SDK_VERSION=vX.Y.Z JOBS=4 make all-release
+```
+
+`scripts/build.sh` flags: `-t Debug|Release`, `-u` (unit tests), `-l` (lint), `-r` (clean first), `-z`
+(no Conan), `-f` (skip in-place clang-format). For an existing configured tree, prefer direct targets:
+`cmake --build cmake_build -j4 --target milvus_sdk` / `--target testing-ut` / `--target testing-it`.
+Limit builds to four jobs.
+
+## Lint / format
+
+- `make lint` (or `make lint-release`) runs cpplint, clang-format checks, and clang-tidy via
+  `scripts/build.sh -l`.
+- The lint build forces `UNITY=OFF` and `PCH=OFF` so clang-tidy sees per-file compile commands and can read
+  the sources (it cannot consume a GCC precompiled header).
+- `make clang-format` inside `cmake_build` reformats all C++ sources in place. Avoid broad reformatting that
+  hides unrelated changes.
+
+## Testing
+
+Three layers; the fast layers require no Milvus server. Binaries land under `cmake_build/test/`.
+
+| Scope | Binary | Depends on | Covers |
+|---|---|---|---|
+| Unit | `testing-ut` | none | DTOs, conversion helpers, caches, retry internals |
+| Mocked | `testing-it` | in-process mocked gRPC server | request wiring, error mapping, caches, retry, callbacks |
+| System | `testing-st` | real Milvus container via Docker | end-to-end server behavior |
+
+Run focused cases with:
+
+```bash
+GRPC_VERBOSITY=ERROR ./cmake_build/test/testing-ut --gtest_filter='*CollectionDesc*:*TypeUtils*'
+GRPC_VERBOSITY=ERROR ./cmake_build/test/testing-it --gtest_filter='MilvusMockedTest.*:UnconnectMilvusMockedTest.*'
+```
+
+- Mocked tests use `test/it/mocks/MilvusMockedTest` fixtures (`MilvusMockedTest`, `UnconnectMilvusMockedTest`)
+  and a `StrictMock<MilvusMockedService>`; assert the proto request contents that actually go on the wire.
+- Windows CI intentionally skips `testing-it` because the in-process mocked server is unstable across the
+  EXE/DLL boundary.
+- System tests start a Milvus container via `test/st/milvus_container.py`; obtain permission before running
+  them (`make st`) and clean up resources they create.
+
+## Examples / tutorials
+
+- Prefer `examples/src/v2/` for new examples, matching the V2-first policy. Examples mutate Milvus (create,
+  insert, search, drop); review connection settings and clean up resources.
+- `tutorial/` apps pin the published SDK version in their build; keep tutorial code and the pinned version
+  mutually compatible in the same commit.
+
+## CI and coverage
+
+- `.github/workflows/main.yaml` gates on a `changes` filter (docs/meta files skip CI), then runs:
+  - `linux` matrix: Ubuntu 20.04 (gcc 9) and Fedora 39, both with lint (Ubuntu), unit/mocked tests, tutorials
+    (Ubuntu), and package verification;
+  - `coverage-ubuntu` (Ubuntu 22.04, lcov + codecov);
+  - `macos-15` and `windows-2022`.
+- Conan and ccache are cached per job (keys scoped by branch and source hash); `scripts/prune_caches.py`
+  prunes old generations. Push-to-master runs warm the default-branch caches for subsequent PRs.
+- Coverage uploads `code_coverage/lcov_output.info` with `codecov/codecov-action@v5`; generated protobuf code
+  is excluded from the report.
+
+## Git / PR conventions
+
+- The PR branch must contain exactly one commit; the commit message must carry a `Signed-off-by` trailer.
+  Squash new work into the single PR commit and force-push with `git commit --amend -sm '...'` /
+  `git push --force-with-lease`.
+- Primary remote for upstream is `source` (`milvus-io/milvus-sdk-cpp`); `origin` is the contributor fork.

--- a/examples/src/v2/iterator_search.cpp
+++ b/examples/src/v2/iterator_search.cpp
@@ -174,11 +174,10 @@ iterateCollection(milvus::MilvusClientV2Ptr& client, int64_t batch, int64_t limi
 // The callback receives each page of hits fetched by the iterator and prunes rows
 // in place via SingleResult::FilterRows. Here we keep only rows whose user_age is even.
 void
-iterateWithExternalFilter(milvus::MilvusClientV2Ptr& client, int64_t batch, int64_t limit,
-                          const std::string& filter) {
+iterateWithExternalFilter(milvus::MilvusClientV2Ptr& client, int64_t batch, int64_t limit, const std::string& filter) {
     std::cout << "=====================================================" << std::endl;
-    std::cout << "Iterate with external filter, batch: " + std::to_string(batch)
-              << " limit: " + std::to_string(limit) << " filter: " + filter << std::endl;
+    std::cout << "Iterate with external filter, batch: " + std::to_string(batch) << " limit: " + std::to_string(limit)
+              << " filter: " + filter << std::endl;
     milvus::SearchIteratorRequest request;
     request.SetCollectionName(collection_name);
     request.SetBatchSize(batch);

--- a/src/impl/MilvusClientImpl.cpp
+++ b/src/impl/MilvusClientImpl.cpp
@@ -226,17 +226,23 @@ MilvusClientImpl::DescribeCollection(const std::string& collection_name, Collect
 
     auto post = [&collection_desc](const proto::milvus::DescribeCollectionResponse& response) {
         CollectionSchema schema;
-        ConvertCollectionSchema(response.schema(), schema);
+        auto status = ConvertCollectionSchema(response.schema(), schema);
+        if (!status.IsOk()) {
+            return status;
+        }
         schema.SetShardsNum(response.shards_num());
         collection_desc.SetSchema(std::move(schema));
         collection_desc.SetID(response.collectionid());
+        collection_desc.SetCreatedTime(response.created_timestamp());
+        collection_desc.SetUpdateTime(response.update_timestamp());
+        collection_desc.SetConsistencyLevel(ConsistencyLevelCast(response.consistency_level()));
+        collection_desc.SetNumPartitions(response.num_partitions());
 
         std::vector<std::string> aliases;
         aliases.reserve(response.aliases_size());
         aliases.insert(aliases.end(), response.aliases().begin(), response.aliases().end());
 
         collection_desc.SetAlias(std::move(aliases));
-        collection_desc.SetCreatedTime(response.created_timestamp());
         return Status::OK();
     };
 
@@ -2220,11 +2226,17 @@ MilvusClientImpl::getCollectionDesc(const std::string& endpoint, const std::stri
             CollectionDesc desc;
             auto post = [&desc](const proto::milvus::DescribeCollectionResponse& response) {
                 CollectionSchema schema;
-                ConvertCollectionSchema(response.schema(), schema);
+                auto status = ConvertCollectionSchema(response.schema(), schema);
+                if (!status.IsOk()) {
+                    return status;
+                }
                 schema.SetShardsNum(response.shards_num());
                 desc.SetSchema(std::move(schema));
                 desc.SetID(response.collectionid());
                 desc.SetCreatedTime(response.created_timestamp());
+                desc.SetUpdateTime(response.update_timestamp());
+                desc.SetConsistencyLevel(ConsistencyLevelCast(response.consistency_level()));
+                desc.SetNumPartitions(response.num_partitions());
                 return Status::OK();
             };
             auto status =

--- a/src/impl/MilvusClientV2Impl.cpp
+++ b/src/impl/MilvusClientV2Impl.cpp
@@ -360,6 +360,9 @@ MilvusClientV2Impl::LoadCollection(const LoadCollectionRequest& request) {
         for (const auto& rg : request.TargetResourceGroups()) {
             rpc_request.add_resource_groups(rg);
         }
+        if (!request.LoadPriority().empty()) {
+            (*rpc_request.mutable_load_params())["load_priority"] = request.LoadPriority();
+        }
         return Status::OK();
     };
 
@@ -1223,6 +1226,9 @@ MilvusClientV2Impl::LoadPartitions(const LoadPartitionsRequest& request) {
         }
         for (const auto& rg : request.TargetResourceGroups()) {
             rpc_request.add_resource_groups(rg);
+        }
+        if (!request.LoadPriority().empty()) {
+            (*rpc_request.mutable_load_params())["load_priority"] = request.LoadPriority();
         }
         return Status::OK();
     };
@@ -3138,7 +3144,19 @@ MilvusClientV2Impl::GetCompactionPlans(const GetCompactionPlansRequest& request,
         return Status::OK();
     };
 
-    auto post = [&response](const proto::milvus::GetCompactionPlansResponse& rpc_response) {
+    auto post = [&response, &request](const proto::milvus::GetCompactionPlansResponse& rpc_response) {
+        response.SetCompactionID(request.CompactionID());
+        switch (rpc_response.state()) {
+            case proto::common::CompactionState::Completed:
+                response.SetState(CompactionStateCode::COMPLETED);
+                break;
+            case proto::common::CompactionState::Executing:
+                response.SetState(CompactionStateCode::EXECUTING);
+                break;
+            default:
+                response.SetState(CompactionStateCode::UNKNOWN);
+                break;
+        }
         CompactionPlans plans;
         plans.reserve(rpc_response.mergeinfos_size());
         for (int i = 0; i < rpc_response.mergeinfos_size(); ++i) {
@@ -3444,7 +3462,12 @@ MilvusClientV2Impl::GetRefreshExternalCollectionProgress(const GetRefreshExterna
     };
 
     auto post = [&response](const proto::milvus::GetRefreshExternalCollectionProgressResponse& rpc_response) {
-        response.SetJobInfo(ConvertRefreshExternalCollectionJobInfo(rpc_response.job_info()));
+        RefreshExternalCollectionJobInfo info;
+        auto status = ConvertRefreshExternalCollectionJobInfo(rpc_response.job_info(), info);
+        if (!status.IsOk()) {
+            return status;
+        }
+        response.SetJobInfo(std::move(info));
         return Status::OK();
     };
 
@@ -3466,7 +3489,12 @@ MilvusClientV2Impl::ListRefreshExternalCollectionJobs(const ListRefreshExternalC
         std::vector<RefreshExternalCollectionJobInfo> jobs;
         jobs.reserve(rpc_response.jobs_size());
         for (const auto& job : rpc_response.jobs()) {
-            jobs.push_back(ConvertRefreshExternalCollectionJobInfo(job));
+            RefreshExternalCollectionJobInfo info;
+            auto status = ConvertRefreshExternalCollectionJobInfo(job, info);
+            if (!status.IsOk()) {
+                return status;
+            }
+            jobs.push_back(std::move(info));
         }
         response.SetJobs(std::move(jobs));
         return Status::OK();

--- a/src/impl/request/collection/LoadCollectionRequest.cpp
+++ b/src/impl/request/collection/LoadCollectionRequest.cpp
@@ -136,4 +136,20 @@ LoadCollectionRequest::WithTargetResourceGroups(const std::set<std::string>& tar
     return *this;
 }
 
+const std::string&
+LoadCollectionRequest::LoadPriority() const {
+    return load_priority_;
+}
+
+void
+LoadCollectionRequest::SetLoadPriority(const std::string& load_priority) {
+    load_priority_ = load_priority;
+}
+
+LoadCollectionRequest&
+LoadCollectionRequest::WithLoadPriority(const std::string& load_priority) {
+    SetLoadPriority(load_priority);
+    return *this;
+}
+
 }  // namespace milvus

--- a/src/impl/request/partition/LoadPartitionsRequest.cpp
+++ b/src/impl/request/partition/LoadPartitionsRequest.cpp
@@ -196,4 +196,20 @@ LoadPartitionsRequest::AddTargetResourceGroups(const std::string& target_resourc
     return *this;
 }
 
+const std::string&
+LoadPartitionsRequest::LoadPriority() const {
+    return load_priority_;
+}
+
+void
+LoadPartitionsRequest::SetLoadPriority(const std::string& load_priority) {
+    load_priority_ = load_priority;
+}
+
+LoadPartitionsRequest&
+LoadPartitionsRequest::WithLoadPriority(const std::string& load_priority) {
+    SetLoadPriority(load_priority);
+    return *this;
+}
+
 }  // namespace milvus

--- a/src/impl/response/utility/GetCompactionPlansResponse.cpp
+++ b/src/impl/response/utility/GetCompactionPlansResponse.cpp
@@ -28,4 +28,24 @@ GetCompactionPlansResponse::SetPlans(CompactionPlans&& plans) {
     plans_ = std::move(plans);
 }
 
+int64_t
+GetCompactionPlansResponse::CompactionID() const {
+    return compaction_id_;
+}
+
+void
+GetCompactionPlansResponse::SetCompactionID(int64_t compaction_id) {
+    compaction_id_ = compaction_id;
+}
+
+CompactionStateCode
+GetCompactionPlansResponse::State() const {
+    return state_;
+}
+
+void
+GetCompactionPlansResponse::SetState(CompactionStateCode state) {
+    state_ = state;
+}
+
 }  // namespace milvus

--- a/src/impl/types/CollectionDesc.cpp
+++ b/src/impl/types/CollectionDesc.cpp
@@ -133,4 +133,24 @@ CollectionDesc::SetExternalSpec(const nlohmann::json& external_spec) {
     external_spec_ = external_spec;
 }
 
+ConsistencyLevel
+CollectionDesc::GetConsistencyLevel() const {
+    return consistency_level_;
+}
+
+void
+CollectionDesc::SetConsistencyLevel(ConsistencyLevel level) {
+    consistency_level_ = level;
+}
+
+int64_t
+CollectionDesc::NumPartitions() const {
+    return num_partitions_;
+}
+
+void
+CollectionDesc::SetNumPartitions(int64_t num_partitions) {
+    num_partitions_ = num_partitions;
+}
+
 }  // namespace milvus

--- a/src/impl/types/CollectionStat.cpp
+++ b/src/impl/types/CollectionStat.cpp
@@ -47,4 +47,9 @@ CollectionStat::Emplace(std::string key, std::string value) {
     statistics_.emplace(std::move(key), std::move(value));
 }
 
+const std::unordered_map<std::string, std::string>&
+CollectionStat::Statistics() const {
+    return statistics_;
+}
+
 }  // namespace milvus

--- a/src/impl/types/RefreshExternalCollectionJobInfo.cpp
+++ b/src/impl/types/RefreshExternalCollectionJobInfo.cpp
@@ -98,4 +98,14 @@ RefreshExternalCollectionJobInfo::SetEndTime(uint64_t end_time) {
     end_time_ = end_time;
 }
 
+const nlohmann::json&
+RefreshExternalCollectionJobInfo::ExternalSpec() const {
+    return external_spec_;
+}
+
+void
+RefreshExternalCollectionJobInfo::SetExternalSpec(const nlohmann::json& external_spec) {
+    external_spec_ = external_spec;
+}
+
 }  // namespace milvus

--- a/src/impl/utils/TypeUtils.cpp
+++ b/src/impl/utils/TypeUtils.cpp
@@ -367,9 +367,9 @@ ConvertRestoreSnapshotJobInfo(const proto::milvus::RestoreSnapshotInfo& rpc_info
     return info;
 }
 
-RefreshExternalCollectionJobInfo
-ConvertRefreshExternalCollectionJobInfo(const proto::milvus::RefreshExternalCollectionJobInfo& rpc_info) {
-    RefreshExternalCollectionJobInfo info;
+Status
+ConvertRefreshExternalCollectionJobInfo(const proto::milvus::RefreshExternalCollectionJobInfo& rpc_info,
+                                        RefreshExternalCollectionJobInfo& info) {
     info.SetJobID(rpc_info.job_id());
     info.SetCollectionName(rpc_info.collection_name());
     info.SetState(RefreshExternalCollectionStateCast(rpc_info.state()));
@@ -378,7 +378,16 @@ ConvertRefreshExternalCollectionJobInfo(const proto::milvus::RefreshExternalColl
     info.SetExternalSource(rpc_info.external_source());
     info.SetStartTime(static_cast<uint64_t>(rpc_info.start_time()));
     info.SetEndTime(static_cast<uint64_t>(rpc_info.end_time()));
-    return info;
+    if (rpc_info.external_spec().empty()) {
+        info.SetExternalSpec(nullptr);
+        return Status::OK();
+    }
+    try {
+        info.SetExternalSpec(nlohmann::json::parse(rpc_info.external_spec()));
+    } catch (const nlohmann::json::parse_error& e) {
+        return {StatusCode::SERVER_FAILED, "Invalid external_spec: " + std::string(e.what())};
+    }
+    return Status::OK();
 }
 
 FileResourceInfo
@@ -508,7 +517,7 @@ ConvertFunctionSchema(const proto::schema::FunctionSchema& proto_function, Funct
     }
 }
 
-void
+Status
 ConvertCollectionSchema(const proto::schema::CollectionSchema& proto_schema, CollectionSchema& schema) {
     schema.SetName(proto_schema.name());
     schema.SetDescription(proto_schema.description());
@@ -517,7 +526,11 @@ ConvertCollectionSchema(const proto::schema::CollectionSchema& proto_schema, Col
     if (proto_schema.external_spec().empty()) {
         schema.SetExternalSpec(nullptr);
     } else {
-        schema.SetExternalSpec(nlohmann::json::parse(proto_schema.external_spec()));
+        try {
+            schema.SetExternalSpec(nlohmann::json::parse(proto_schema.external_spec()));
+        } catch (const nlohmann::json::parse_error& e) {
+            return {StatusCode::SERVER_FAILED, "Invalid external_spec in collection schema: " + std::string(e.what())};
+        }
     }
 
     for (int i = 0; i < proto_schema.fields_size(); ++i) {
@@ -540,6 +553,7 @@ ConvertCollectionSchema(const proto::schema::CollectionSchema& proto_schema, Col
         ConvertFunctionSchema(proto_function, function_schema);
         schema.AddFunction(function_schema);
     }
+    return Status::OK();
 }
 
 Status
@@ -552,12 +566,18 @@ ConvertDescribeCollectionResponse(const proto::milvus::DescribeCollectionRespons
     }
 
     CollectionSchema schema;
-    ConvertCollectionSchema(rpc_response.schema(), schema);
+    auto convert_status = ConvertCollectionSchema(rpc_response.schema(), schema);
+    if (!convert_status.IsOk()) {
+        return convert_status;
+    }
     schema.SetShardsNum(rpc_response.shards_num());
 
     collection_desc.SetSchema(std::move(schema));
     collection_desc.SetID(rpc_response.collectionid());
     collection_desc.SetCreatedTime(rpc_response.created_timestamp());
+    collection_desc.SetUpdateTime(rpc_response.update_timestamp());
+    collection_desc.SetConsistencyLevel(ConsistencyLevelCast(rpc_response.consistency_level()));
+    collection_desc.SetNumPartitions(rpc_response.num_partitions());
 
     std::vector<std::string> aliases;
     aliases.reserve(rpc_response.aliases_size());

--- a/src/impl/utils/TypeUtils.h
+++ b/src/impl/utils/TypeUtils.h
@@ -81,8 +81,9 @@ RefreshExternalCollectionStateCast(proto::milvus::RefreshExternalCollectionState
 RestoreSnapshotJobInfo
 ConvertRestoreSnapshotJobInfo(const proto::milvus::RestoreSnapshotInfo& rpc_info);
 
-RefreshExternalCollectionJobInfo
-ConvertRefreshExternalCollectionJobInfo(const proto::milvus::RefreshExternalCollectionJobInfo& rpc_info);
+Status
+ConvertRefreshExternalCollectionJobInfo(const proto::milvus::RefreshExternalCollectionJobInfo& rpc_info,
+                                        RefreshExternalCollectionJobInfo& info);
 
 FileResourceInfo
 ConvertFileResourceInfo(const proto::milvus::FileResourceInfo& rpc_info);
@@ -99,7 +100,7 @@ ConvertStructFieldSchema(const proto::schema::StructArrayFieldSchema& proto_sche
 void
 ConvertFunctionSchema(const proto::schema::FunctionSchema& proto_function, FunctionPtr& function_schema);
 
-void
+Status
 ConvertCollectionSchema(const proto::schema::CollectionSchema& proto_schema, CollectionSchema& schema);
 
 Status

--- a/src/include/milvus/request/collection/LoadCollectionRequest.h
+++ b/src/include/milvus/request/collection/LoadCollectionRequest.h
@@ -148,6 +148,30 @@ class MILVUS_SDK_API LoadCollectionRequest : public CollectionRequestBase<LoadCo
     AddLoadField(const std::string& field_name);
 
     /**
+     * @brief Load priority.
+     * The load priority of the collection. Set "low" to select low priority; any other value (including "high")
+     * defaults to high priority.
+     */
+    const std::string&
+    LoadPriority() const;
+
+    /**
+     * @brief Set load priority.
+     * The load priority of the collection. Set "low" to select low priority; any other value (including "high")
+     * defaults to high priority.
+     */
+    void
+    SetLoadPriority(const std::string& load_priority);
+
+    /**
+     * @brief Set load priority.
+     * The load priority of the collection. Set "low" to select low priority; any other value (including "high")
+     * defaults to high priority.
+     */
+    LoadCollectionRequest&
+    WithLoadPriority(const std::string& load_priority);
+
+    /**
      * @brief Skip dynamic field option.
      */
     bool
@@ -191,6 +215,7 @@ class MILVUS_SDK_API LoadCollectionRequest : public CollectionRequestBase<LoadCo
     std::set<std::string> load_feilds_;
     bool skip_dynamic_field_{false};
     std::set<std::string> target_resource_groups_;
+    std::string load_priority_;
 };
 
 }  // namespace milvus

--- a/src/include/milvus/request/partition/LoadPartitionsRequest.h
+++ b/src/include/milvus/request/partition/LoadPartitionsRequest.h
@@ -252,6 +252,30 @@ class MILVUS_SDK_API LoadPartitionsRequest {
     LoadPartitionsRequest&
     AddTargetResourceGroups(const std::string& target_resource_group);
 
+    /**
+     * @brief Load priority.
+     * The load priority of the partitions. Set "low" to select low priority; any other value (including "high")
+     * defaults to high priority.
+     */
+    const std::string&
+    LoadPriority() const;
+
+    /**
+     * @brief Set load priority.
+     * The load priority of the partitions. Set "low" to select low priority; any other value (including "high")
+     * defaults to high priority.
+     */
+    void
+    SetLoadPriority(const std::string& load_priority);
+
+    /**
+     * @brief Set load priority.
+     * The load priority of the partitions. Set "low" to select low priority; any other value (including "high")
+     * defaults to high priority.
+     */
+    LoadPartitionsRequest&
+    WithLoadPriority(const std::string& load_priority);
+
  private:
     std::string db_name_;
     std::string collection_name_;
@@ -263,6 +287,7 @@ class MILVUS_SDK_API LoadPartitionsRequest {
     std::set<std::string> load_feilds_;
     bool skip_dynamic_field_{false};
     std::set<std::string> target_resource_groups_;
+    std::string load_priority_;
 };
 
 }  // namespace milvus

--- a/src/include/milvus/response/utility/GetCompactionPlansResponse.h
+++ b/src/include/milvus/response/utility/GetCompactionPlansResponse.h
@@ -16,8 +16,11 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "milvus/Export.h"
 #include "milvus/types/CompactionPlan.h"
+#include "milvus/types/CompactionState.h"
 
 namespace milvus {
 
@@ -43,8 +46,34 @@ class MILVUS_SDK_API GetCompactionPlansResponse {
     void
     SetPlans(CompactionPlans&& plans);
 
+    /**
+     * @brief Get the id of the compaction.
+     */
+    int64_t
+    CompactionID() const;
+
+    /**
+     * @brief Set the id of the compaction.
+     */
+    void
+    SetCompactionID(int64_t compaction_id);
+
+    /**
+     * @brief Get the state of the compaction.
+     */
+    CompactionStateCode
+    State() const;
+
+    /**
+     * @brief Set the state of the compaction.
+     */
+    void
+    SetState(CompactionStateCode state);
+
  private:
     CompactionPlans plans_;
+    int64_t compaction_id_{0};
+    CompactionStateCode state_{CompactionStateCode::UNKNOWN};
 };
 
 }  // namespace milvus

--- a/src/include/milvus/types/CollectionDesc.h
+++ b/src/include/milvus/types/CollectionDesc.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "CollectionSchema.h"
+#include "ConsistencyLevel.h"
 #include "milvus/Export.h"
 
 namespace milvus {
@@ -158,6 +159,31 @@ class MILVUS_SDK_API CollectionDesc {
     void
     SetExternalSpec(const nlohmann::json& external_spec);
 
+    /**
+     * @brief Consistency level of the collection.
+     */
+    ConsistencyLevel
+    GetConsistencyLevel() const;
+
+    /**
+     * @brief Set consistency level of the collection.
+     */
+    void
+    SetConsistencyLevel(ConsistencyLevel level);
+
+    /**
+     * @brief Number of partitions of the collection.
+     * Only valid when the collection is created with a partition key.
+     */
+    int64_t
+    NumPartitions() const;
+
+    /**
+     * @brief Set number of partitions of the collection.
+     */
+    void
+    SetNumPartitions(int64_t num_partitions);
+
  private:
     std::string db_name_;
     CollectionSchema schema_;
@@ -168,6 +194,8 @@ class MILVUS_SDK_API CollectionDesc {
     std::unordered_map<std::string, std::string> properties_;
     std::string external_source_;
     nlohmann::json external_spec_;
+    ConsistencyLevel consistency_level_{ConsistencyLevel::BOUNDED};
+    int64_t num_partitions_{0};
 };
 
 using CollectionDescPtr = std::shared_ptr<CollectionDesc>;

--- a/src/include/milvus/types/CollectionStat.h
+++ b/src/include/milvus/types/CollectionStat.h
@@ -58,6 +58,12 @@ class MILVUS_SDK_API CollectionStat {
     void
     Emplace(std::string key, std::string value);
 
+    /**
+     * @brief Get the raw key/value statistics map of this collection.
+     */
+    const std::unordered_map<std::string, std::string>&
+    Statistics() const;
+
  private:
     std::string name_;
     std::unordered_map<std::string, std::string> statistics_;

--- a/src/include/milvus/types/RefreshExternalCollectionJobInfo.h
+++ b/src/include/milvus/types/RefreshExternalCollectionJobInfo.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <milvus/thirdparty/nlohmann/json.hpp>
 #include <string>
 
 #include "milvus/Export.h"
@@ -77,6 +78,12 @@ class MILVUS_SDK_API RefreshExternalCollectionJobInfo {
     void
     SetEndTime(uint64_t end_time);
 
+    const nlohmann::json&
+    ExternalSpec() const;
+
+    void
+    SetExternalSpec(const nlohmann::json& external_spec);
+
  private:
     int64_t job_id_{0};
     std::string collection_name_;
@@ -86,6 +93,7 @@ class MILVUS_SDK_API RefreshExternalCollectionJobInfo {
     std::string external_source_;
     uint64_t start_time_{0};
     uint64_t end_time_{0};
+    nlohmann::json external_spec_;
 };
 
 }  // namespace milvus

--- a/test/it/v2/TestCompact.cpp
+++ b/test/it/v2/TestCompact.cpp
@@ -25,9 +25,13 @@ using ::milvus::proto::milvus::ConnectRequest;
 using ::milvus::proto::milvus::ConnectResponse;
 using ::milvus::proto::milvus::DescribeCollectionRequest;
 using ::milvus::proto::milvus::DescribeCollectionResponse;
+using ::milvus::proto::milvus::GetCompactionPlansRequest;
+using ::milvus::proto::milvus::GetCompactionPlansResponse;
 using ::milvus::proto::milvus::ManualCompactionRequest;
 using ::milvus::proto::milvus::ManualCompactionResponse;
 using ::testing::_;
+using ::testing::ElementsAreArray;
+using ::testing::Property;
 
 namespace {
 
@@ -127,4 +131,73 @@ TEST_F(UnconnectMilvusMockedTest, CompactRejectsInvalidUnit) {
                                   response);
     EXPECT_FALSE(status.IsOk());
     EXPECT_EQ(status.Code(), milvus::StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(UnconnectMilvusMockedTest, GetCompactionPlansV2) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    const int64_t compaction_id = 42;
+    const std::vector<int64_t> sources = {1, 2, 3};
+    const int64_t target = 100;
+
+    EXPECT_CALL(service_,
+                GetCompactionStateWithPlans(_, Property(&GetCompactionPlansRequest::compactionid, compaction_id), _))
+        .WillOnce([&](::grpc::ServerContext*, const GetCompactionPlansRequest*, GetCompactionPlansResponse* response) {
+            response->set_state(milvus::proto::common::CompactionState::Completed);
+            auto info = response->add_mergeinfos();
+            for (auto i : sources) {
+                info->add_sources(i);
+            }
+            info->set_target(target);
+            return ::grpc::Status{};
+        });
+
+    milvus::GetCompactionPlansResponse response;
+    auto status =
+        client->GetCompactionPlans(milvus::GetCompactionPlansRequest().WithCompactionID(compaction_id), response);
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(response.CompactionID(), compaction_id);
+    EXPECT_EQ(response.State(), milvus::CompactionStateCode::COMPLETED);
+    ASSERT_EQ(response.Plans().size(), 1);
+    EXPECT_THAT(response.Plans()[0].SourceSegments(), ElementsAreArray(sources));
+    EXPECT_EQ(response.Plans()[0].DestinySegemnt(), target);
+}
+
+TEST_F(UnconnectMilvusMockedTest, GetCompactionPlansV2ExecutingState) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    const int64_t compaction_id = 43;
+
+    EXPECT_CALL(service_,
+                GetCompactionStateWithPlans(_, Property(&GetCompactionPlansRequest::compactionid, compaction_id), _))
+        .WillOnce([](::grpc::ServerContext*, const GetCompactionPlansRequest*, GetCompactionPlansResponse* response) {
+            response->set_state(milvus::proto::common::CompactionState::Executing);
+            return ::grpc::Status{};
+        });
+
+    milvus::GetCompactionPlansResponse response;
+    auto status =
+        client->GetCompactionPlans(milvus::GetCompactionPlansRequest().WithCompactionID(compaction_id), response);
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(response.CompactionID(), compaction_id);
+    EXPECT_EQ(response.State(), milvus::CompactionStateCode::EXECUTING);
+}
+
+TEST_F(UnconnectMilvusMockedTest, GetCompactionPlansV2UnsetState) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    const int64_t compaction_id = 44;
+
+    EXPECT_CALL(service_,
+                GetCompactionStateWithPlans(_, Property(&GetCompactionPlansRequest::compactionid, compaction_id), _))
+        .WillOnce([](::grpc::ServerContext*, const GetCompactionPlansRequest*, GetCompactionPlansResponse*) {
+            return ::grpc::Status{};
+        });
+
+    milvus::GetCompactionPlansResponse response;
+    auto status =
+        client->GetCompactionPlans(milvus::GetCompactionPlansRequest().WithCompactionID(compaction_id), response);
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(response.CompactionID(), compaction_id);
+    EXPECT_EQ(response.State(), milvus::CompactionStateCode::UNKNOWN);
 }

--- a/test/it/v2/TestLoadV2.cpp
+++ b/test/it/v2/TestLoadV2.cpp
@@ -1,0 +1,120 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "../mocks/MilvusMockedTest.h"
+#include "milvus/MilvusClientV2.h"
+
+using ::milvus::proto::milvus::ConnectRequest;
+using ::milvus::proto::milvus::ConnectResponse;
+using ::milvus::proto::milvus::LoadCollectionRequest;
+using ::milvus::proto::milvus::LoadPartitionsRequest;
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::Pair;
+using ::testing::Property;
+
+namespace {
+
+std::shared_ptr<milvus::MilvusClientV2>
+CreateConnectedV2Client(testing::StrictMock<::milvus::MilvusMockedService>& service, uint16_t port) {
+    EXPECT_CALL(service, Connect(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const ConnectRequest*, ConnectResponse*) { return ::grpc::Status{}; });
+
+    auto client = milvus::MilvusClientV2::Create();
+    milvus::ConnectParam connect_param{"127.0.0.1", port};
+    auto status = client->Connect(connect_param);
+    EXPECT_TRUE(status.IsOk());
+    return client;
+}
+
+}  // namespace
+
+TEST_F(UnconnectMilvusMockedTest, LoadCollectionSendsLoadPriority) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    EXPECT_CALL(
+        service_,
+        LoadCollection(_,
+                       AllOf(Property(&LoadCollectionRequest::collection_name, "coll"),
+                             Property(&LoadCollectionRequest::load_params_size, 1),
+                             Property(&LoadCollectionRequest::load_params, Contains(Pair("load_priority", "low")))),
+                       _))
+        .WillOnce([](::grpc::ServerContext*, const LoadCollectionRequest*, ::milvus::proto::common::Status*) {
+            return ::grpc::Status{};
+        });
+
+    auto status = client->LoadCollection(
+        milvus::LoadCollectionRequest().WithCollectionName("coll").WithSync(false).WithLoadPriority("low"));
+    EXPECT_TRUE(status.IsOk());
+}
+
+TEST_F(UnconnectMilvusMockedTest, LoadCollectionOmitsLoadPriorityWhenUnset) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    EXPECT_CALL(service_, LoadCollection(_,
+                                         AllOf(Property(&LoadCollectionRequest::collection_name, "coll"),
+                                               Property(&LoadCollectionRequest::load_params_size, 0)),
+                                         _))
+        .WillOnce([](::grpc::ServerContext*, const LoadCollectionRequest*, ::milvus::proto::common::Status*) {
+            return ::grpc::Status{};
+        });
+
+    auto status = client->LoadCollection(milvus::LoadCollectionRequest().WithCollectionName("coll").WithSync(false));
+    EXPECT_TRUE(status.IsOk());
+}
+
+TEST_F(UnconnectMilvusMockedTest, LoadPartitionsSendsLoadPriority) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    EXPECT_CALL(
+        service_,
+        LoadPartitions(_,
+                       AllOf(Property(&LoadPartitionsRequest::collection_name, "coll"),
+                             Property(&LoadPartitionsRequest::load_params_size, 1),
+                             Property(&LoadPartitionsRequest::load_params, Contains(Pair("load_priority", "low")))),
+                       _))
+        .WillOnce([](::grpc::ServerContext*, const LoadPartitionsRequest*, ::milvus::proto::common::Status*) {
+            return ::grpc::Status{};
+        });
+
+    auto status = client->LoadPartitions(milvus::LoadPartitionsRequest()
+                                             .WithCollectionName("coll")
+                                             .WithPartitionNames({"p1"})
+                                             .WithSync(false)
+                                             .WithLoadPriority("low"));
+    EXPECT_TRUE(status.IsOk());
+}
+
+TEST_F(UnconnectMilvusMockedTest, LoadPartitionsOmitsLoadPriorityWhenUnset) {
+    auto client = CreateConnectedV2Client(service_, server_.ListenPort());
+
+    EXPECT_CALL(service_, LoadPartitions(_,
+                                         AllOf(Property(&LoadPartitionsRequest::collection_name, "coll"),
+                                               Property(&LoadPartitionsRequest::load_params_size, 0)),
+                                         _))
+        .WillOnce([](::grpc::ServerContext*, const LoadPartitionsRequest*, ::milvus::proto::common::Status*) {
+            return ::grpc::Status{};
+        });
+
+    auto status = client->LoadPartitions(
+        milvus::LoadPartitionsRequest().WithCollectionName("coll").WithPartitionNames({"p1"}).WithSync(false));
+    EXPECT_TRUE(status.IsOk());
+}

--- a/test/ut/request/TestCollectionRequests.cpp
+++ b/test/ut/request/TestCollectionRequests.cpp
@@ -160,6 +160,12 @@ TEST_F(LoadCollectionRequestTest, GettersAndSetters) {
     req.WithTargetResourceGroups(groups);
     EXPECT_EQ(req.TargetResourceGroups().size(), 2);
     EXPECT_TRUE(req.TargetResourceGroups().count("rg1"));
+
+    // LoadPriority
+    req.WithLoadPriority("Low");
+    EXPECT_EQ(req.LoadPriority(), "Low");
+    req.SetLoadPriority("High");
+    EXPECT_EQ(req.LoadPriority(), "High");
 }
 
 class RefreshLoadRequestTest : public ::testing::Test {};

--- a/test/ut/request/TestPartitionRequests.cpp
+++ b/test/ut/request/TestPartitionRequests.cpp
@@ -95,6 +95,12 @@ TEST_F(LoadPartitionsRequestTest, GettersAndSetters) {
 
     req.WithTimeoutMs(120000);
     EXPECT_EQ(req.TimeoutMs(), 120000);
+
+    // LoadPriority
+    req.WithLoadPriority("Medium");
+    EXPECT_EQ(req.LoadPriority(), "Medium");
+    req.SetLoadPriority("High");
+    EXPECT_EQ(req.LoadPriority(), "High");
 }
 
 class ReleasePartitionsRequestTest : public ::testing::Test {};

--- a/test/ut/response/TestCollectionResponses.cpp
+++ b/test/ut/response/TestCollectionResponses.cpp
@@ -128,8 +128,12 @@ class GetCollectionStatsResponseTest : public ::testing::Test {};
 TEST_F(GetCollectionStatsResponseTest, SetterAndGetter) {
     milvus::GetCollectionStatsResponse resp;
     milvus::CollectionStat stats;
+    stats.Emplace("row_count", "123");
+    stats.Emplace("key", "value");
     resp.SetStats(std::move(stats));
-    (void)resp.Stats();
+    EXPECT_EQ(resp.Stats().Statistics().at("row_count"), "123");
+    EXPECT_EQ(resp.Stats().Statistics().at("key"), "value");
+    EXPECT_EQ(resp.Stats().Statistics().size(), 2);
 }
 
 class GetLoadStateResponseTest : public ::testing::Test {};

--- a/test/ut/response/TestRefreshExternalUtilityResponses.cpp
+++ b/test/ut/response/TestRefreshExternalUtilityResponses.cpp
@@ -36,6 +36,14 @@ TEST_F(GetRefreshExternalCollectionProgressResponseTest, SetterAndGetter) {
     EXPECT_EQ(resp.JobInfo().JobID(), 101);
 }
 
+TEST_F(RefreshExternalCollectionResponseTest, JobInfoExternalSpec) {
+    milvus::RefreshExternalCollectionJobInfo info;
+    EXPECT_TRUE(info.ExternalSpec().is_null());
+    info.SetExternalSpec({{"format", "parquet"}, {"extfs", {{"region", "us-east-1"}}}});
+    EXPECT_EQ(info.ExternalSpec().at("format"), "parquet");
+    EXPECT_EQ(info.ExternalSpec().at("extfs").at("region"), "us-east-1");
+}
+
 class ListRefreshExternalCollectionJobsResponseTest : public ::testing::Test {};
 
 TEST_F(ListRefreshExternalCollectionJobsResponseTest, SetterAndGetter) {

--- a/test/ut/response/TestUtilityResponses.cpp
+++ b/test/ut/response/TestUtilityResponses.cpp
@@ -110,6 +110,14 @@ TEST_F(GetCompactionPlansResponseTest, SetterAndGetter) {
     milvus::CompactionPlans plans;
     resp.SetPlans(std::move(plans));
     (void)resp.Plans();
+
+    EXPECT_EQ(resp.CompactionID(), 0);
+    resp.SetCompactionID(123);
+    EXPECT_EQ(resp.CompactionID(), 123);
+
+    EXPECT_EQ(resp.State(), milvus::CompactionStateCode::UNKNOWN);
+    resp.SetState(milvus::CompactionStateCode::COMPLETED);
+    EXPECT_EQ(resp.State(), milvus::CompactionStateCode::COMPLETED);
 }
 
 class GetServerVersionResponseTest : public ::testing::Test {};

--- a/test/ut/types/TestCollectionDesc.cpp
+++ b/test/ut/types/TestCollectionDesc.cpp
@@ -42,6 +42,18 @@ TEST_F(CollectionDescTest, GeneralTesting) {
     EXPECT_EQ(desc.UpdateTime(), 888);
 }
 
+TEST_F(CollectionDescTest, ConsistencyLevelAndPartitions) {
+    milvus::CollectionDesc desc;
+
+    EXPECT_EQ(desc.GetConsistencyLevel(), milvus::ConsistencyLevel::BOUNDED);
+    desc.SetConsistencyLevel(milvus::ConsistencyLevel::EVENTUALLY);
+    EXPECT_EQ(desc.GetConsistencyLevel(), milvus::ConsistencyLevel::EVENTUALLY);
+
+    EXPECT_EQ(desc.NumPartitions(), 0);
+    desc.SetNumPartitions(64);
+    EXPECT_EQ(desc.NumPartitions(), 64);
+}
+
 TEST_F(CollectionDescTest, ExternalSpec) {
     milvus::CollectionDesc desc;
     EXPECT_TRUE(desc.ExternalSpec().is_null());

--- a/test/ut/utils/TestSchemaCache.cpp
+++ b/test/ut/utils/TestSchemaCache.cpp
@@ -219,7 +219,11 @@ TEST(SchemaCacheTest, ConcurrentMissesShareOneLoad) {
     auto loader = [&](milvus::CollectionDescPtr& desc) {
         load_count.fetch_add(1);
         std::unique_lock<std::mutex> lock(gate_mutex);
-        gate_cv.wait(lock, [&entered, kThreadCount]() { return entered.load() == kThreadCount; });
+        if (!gate_cv.wait_for(lock, std::chrono::seconds(30),
+                              [&entered, kThreadCount]() { return entered.load() == kThreadCount; })) {
+            return milvus::Status{milvus::StatusCode::UNKNOWN_ERROR,
+                                  "timed out waiting for all concurrent loaders to enter"};
+        }
         desc = MakeCollectionDesc(100);
         return milvus::Status::OK();
     };
@@ -262,7 +266,11 @@ TEST(SchemaCacheTest, DifferentLoadScopesDoNotShareInFlightLoad) {
         std::unique_lock<std::mutex> lock(gate_mutex);
         first_loader_started = true;
         gate_cv.notify_all();
-        gate_cv.wait(lock, [&allow_first_loader_to_finish]() { return allow_first_loader_to_finish; });
+        if (!gate_cv.wait_for(lock, std::chrono::seconds(30),
+                              [&allow_first_loader_to_finish]() { return allow_first_loader_to_finish; })) {
+            return milvus::Status{milvus::StatusCode::UNKNOWN_ERROR,
+                                  "timed out waiting for the first loader to finish"};
+        }
         desc = MakeCollectionDesc(100);
         return milvus::Status::OK();
     };
@@ -278,9 +286,21 @@ TEST(SchemaCacheTest, DifferentLoadScopesDoNotShareInFlightLoad) {
         first_status = cache.GetOrLoad("endpoint", "db", "collection", false, &first_scope, first_loader, first_desc);
     });
 
+    bool first_loader_started_ok = false;
     {
         std::unique_lock<std::mutex> lock(gate_mutex);
-        gate_cv.wait(lock, [&first_loader_started]() { return first_loader_started; });
+        first_loader_started_ok =
+            gate_cv.wait_for(lock, std::chrono::seconds(30), [&first_loader_started]() { return first_loader_started; });
+    }
+    if (!first_loader_started_ok) {
+        {
+            std::lock_guard<std::mutex> lock(gate_mutex);
+            allow_first_loader_to_finish = true;
+        }
+        gate_cv.notify_all();
+        first_thread.join();
+        FAIL() << "timed out waiting for the first loader to start";
+        return;
     }
 
     milvus::CollectionDescPtr second_desc;
@@ -319,7 +339,10 @@ TEST(SchemaCacheTest, InvalidateDuringLoadPreventsCacheRepopulation) {
         std::unique_lock<std::mutex> lock(gate_mutex);
         loader_started = true;
         gate_cv.notify_all();
-        gate_cv.wait(lock, [&allow_loader_to_finish]() { return allow_loader_to_finish; });
+        if (!gate_cv.wait_for(lock, std::chrono::seconds(30),
+                              [&allow_loader_to_finish]() { return allow_loader_to_finish; })) {
+            return milvus::Status{milvus::StatusCode::UNKNOWN_ERROR, "timed out waiting for the loader to finish"};
+        }
         desc = MakeCollectionDesc(100);
         return milvus::Status::OK();
     };
@@ -329,9 +352,20 @@ TEST(SchemaCacheTest, InvalidateDuringLoadPreventsCacheRepopulation) {
     std::thread thread(
         [&]() { status = cache.GetOrLoad("endpoint", "db", "collection", false, TestLoadScope(), loader, loaded); });
 
+    bool started = false;
     {
         std::unique_lock<std::mutex> lock(gate_mutex);
-        gate_cv.wait(lock, [&loader_started]() { return loader_started; });
+        started = gate_cv.wait_for(lock, std::chrono::seconds(30), [&loader_started]() { return loader_started; });
+    }
+    if (!started) {
+        {
+            std::lock_guard<std::mutex> lock(gate_mutex);
+            allow_loader_to_finish = true;
+        }
+        gate_cv.notify_all();
+        thread.join();
+        FAIL() << "timed out waiting for the loader to start";
+        return;
     }
     cache.Invalidate("endpoint", "db", "collection");
     {

--- a/test/ut/utils/TestTypeUtils.cpp
+++ b/test/ut/utils/TestTypeUtils.cpp
@@ -676,11 +676,11 @@ TEST_F(TypeUtilsTest, ConvertCollectionSchema) {
     proto_schema_no_spec.set_name("empty_spec");
     proto_schema_no_spec.set_description("desc");
     milvus::CollectionSchema sdk_schema_no_spec;
-    ConvertCollectionSchema(proto_schema_no_spec, sdk_schema_no_spec);
+    EXPECT_TRUE(milvus::ConvertCollectionSchema(proto_schema_no_spec, sdk_schema_no_spec).IsOk());
     EXPECT_TRUE(sdk_schema_no_spec.ExternalSpec().is_null());
 
     milvus::CollectionSchema sdk_schema;
-    ConvertCollectionSchema(proto_schema, sdk_schema);
+    EXPECT_TRUE(milvus::ConvertCollectionSchema(proto_schema, sdk_schema).IsOk());
 
     EXPECT_EQ(sdk_schema.Name(), collection_name);
     EXPECT_EQ(sdk_schema.Description(), collection_desc);
@@ -703,10 +703,23 @@ TEST_F(TypeUtilsTest, ConvertCollectionSchema) {
     EXPECT_EQ(sdk_function->Params().at("111"), "222");
 }
 
+TEST_F(TypeUtilsTest, ConvertCollectionSchemaInvalidExternalSpec) {
+    milvus::proto::schema::CollectionSchema proto_schema;
+    proto_schema.set_name("coll");
+    proto_schema.set_external_spec("{invalid json");
+
+    milvus::CollectionSchema sdk_schema;
+    auto status = milvus::ConvertCollectionSchema(proto_schema, sdk_schema);
+
+    EXPECT_EQ(status.Code(), milvus::StatusCode::SERVER_FAILED);
+    EXPECT_NE(status.Message().find("Invalid external_spec"), std::string::npos);
+}
+
 TEST_F(TypeUtilsTest, ConvertDescribeCollectionResponse) {
     const int64_t collection_id = 100;
     const int32_t shards_num = 3;
     const uint64_t created_ts = 123456;
+    const uint64_t update_ts = 654321;
 
     milvus::CollectionSchema collection_schema("test_collection", "test description", 1, true);
     collection_schema.AddField({"id", milvus::DataType::INT64, "primary key", true, false});
@@ -718,6 +731,9 @@ TEST_F(TypeUtilsTest, ConvertDescribeCollectionResponse) {
     rpc_response.set_collectionid(collection_id);
     rpc_response.set_shards_num(shards_num);
     rpc_response.set_created_timestamp(created_ts);
+    rpc_response.set_update_timestamp(update_ts);
+    rpc_response.set_consistency_level(milvus::proto::common::ConsistencyLevel::Eventually);
+    rpc_response.set_num_partitions(64);
     rpc_response.add_aliases("alias_a");
     rpc_response.add_aliases("alias_b");
     auto* property = rpc_response.add_properties();
@@ -731,6 +747,9 @@ TEST_F(TypeUtilsTest, ConvertDescribeCollectionResponse) {
     EXPECT_TRUE(status.IsOk());
     EXPECT_EQ(collection_desc.ID(), collection_id);
     EXPECT_EQ(collection_desc.CreatedTime(), created_ts);
+    EXPECT_EQ(collection_desc.UpdateTime(), update_ts);
+    EXPECT_EQ(collection_desc.GetConsistencyLevel(), milvus::ConsistencyLevel::EVENTUALLY);
+    EXPECT_EQ(collection_desc.NumPartitions(), 64);
     EXPECT_EQ(collection_desc.CollectionName(), collection_schema.Name());
     EXPECT_EQ(collection_desc.Description(), collection_schema.Description());
     EXPECT_EQ(collection_desc.NumShards(), shards_num);
@@ -765,7 +784,59 @@ TEST_F(TypeUtilsTest, ConvertDescribeCollectionResponseInvalidExternalSpec) {
     rpc_response.mutable_schema()->set_external_spec("{invalid json");
 
     milvus::CollectionDesc collection_desc;
-    EXPECT_THROW(milvus::ConvertDescribeCollectionResponse(rpc_response, collection_desc), nlohmann::json::parse_error);
+    auto status = milvus::ConvertDescribeCollectionResponse(rpc_response, collection_desc);
+
+    EXPECT_EQ(status.Code(), milvus::StatusCode::SERVER_FAILED);
+    EXPECT_NE(status.Message().find("Invalid external_spec"), std::string::npos);
+}
+
+TEST_F(TypeUtilsTest, ConvertRefreshExternalCollectionJobInfo) {
+    milvus::proto::milvus::RefreshExternalCollectionJobInfo rpc_info;
+    rpc_info.set_job_id(7);
+    rpc_info.set_collection_name("ext_coll");
+    rpc_info.set_progress(50);
+    rpc_info.set_reason("in progress");
+    rpc_info.set_external_source("s3://bucket/path/");
+    rpc_info.set_external_spec("{\"format\":\"parquet\",\"extfs\":{\"region\":\"us-east-1\"}}");
+    rpc_info.set_state(milvus::proto::milvus::RefreshInProgress);
+
+    milvus::RefreshExternalCollectionJobInfo info;
+    auto status = milvus::ConvertRefreshExternalCollectionJobInfo(rpc_info, info);
+
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(info.JobID(), 7);
+    EXPECT_EQ(info.CollectionName(), "ext_coll");
+    EXPECT_EQ(info.Progress(), 50);
+    EXPECT_EQ(info.Reason(), "in progress");
+    EXPECT_EQ(info.ExternalSource(), "s3://bucket/path/");
+    ASSERT_FALSE(info.ExternalSpec().is_null());
+    EXPECT_EQ(info.ExternalSpec().at("format"), "parquet");
+    EXPECT_EQ(info.ExternalSpec().at("extfs").at("region"), "us-east-1");
+    EXPECT_EQ(info.State(), milvus::RefreshExternalCollectionStateCode::IN_PROGRESS);
+}
+
+TEST_F(TypeUtilsTest, ConvertRefreshExternalCollectionJobInfoEmptySpec) {
+    milvus::proto::milvus::RefreshExternalCollectionJobInfo rpc_info;
+    rpc_info.set_job_id(8);
+
+    milvus::RefreshExternalCollectionJobInfo info;
+    auto status = milvus::ConvertRefreshExternalCollectionJobInfo(rpc_info, info);
+
+    EXPECT_TRUE(status.IsOk());
+    EXPECT_EQ(info.JobID(), 8);
+    EXPECT_TRUE(info.ExternalSpec().is_null());
+}
+
+TEST_F(TypeUtilsTest, ConvertRefreshExternalCollectionJobInfoInvalidSpec) {
+    milvus::proto::milvus::RefreshExternalCollectionJobInfo rpc_info;
+    rpc_info.set_job_id(9);
+    rpc_info.set_external_spec("{invalid json");
+
+    milvus::RefreshExternalCollectionJobInfo info;
+    auto status = milvus::ConvertRefreshExternalCollectionJobInfo(rpc_info, info);
+
+    EXPECT_EQ(status.Code(), milvus::StatusCode::SERVER_FAILED);
+    EXPECT_NE(status.Message().find("Invalid external_spec"), std::string::npos);
 }
 
 TEST_F(TypeUtilsTest, TestB64EncodeGeneric) {


### PR DESCRIPTION
## Summary

Align `MilvusClientV2` request/response surfaces with pymilvus `MilvusClient`.

### Request
- `LoadCollectionRequest` / `LoadPartitionsRequest`: add `LoadPriority()` (`"low"` selects low priority; any other value, including `"high"`, defaults to high priority), wired to proto `load_params["load_priority"]`.

### Response
- `describe_collection` (`CollectionDesc`): expose `GetConsistencyLevel()` and `NumPartitions()`; populate `update_timestamp` in the proto conversion.
- `get_collection_stats` (`CollectionStat`): expose the raw `Statistics()` key/value map.
- `get_compaction_plans` (`GetCompactionPlansResponse`): return `CompactionID()` and `State()`.
- `get_refresh_external_collection_progress` / `list_refresh_external_collection_jobs`: surface `external_spec` per job (parsed from the proto string).

### Tests / misc
- Unit tests for all new accessors and proto conversions (`TestTypeUtils`, `TestCollectionDesc`, `TestUtilityResponses`, etc.).
- Mocked integration test for V2 `GetCompactionPlans` in `TestCompact.cpp`.
- Example formatting cleanups.