### PR TITLE
Add exception barrier to public SDK calls

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -37,6 +37,7 @@ ignore:
   - src/include/milvus/thirdparty
   - test
   - thirdparty
+  - tutorial
   - "**/*.txt"
   - "**/*.md"
   - "**/*.yml"

--- a/examples/src/v2/rbac.cpp
+++ b/examples/src/v2/rbac.cpp
@@ -133,7 +133,7 @@ main(int argc, char* argv[]) {
     status = client->GrantPrivilege(milvus::GrantPrivilegeRequest()
                                         .WithRoleName(role_name)
                                         .WithObjectType("Global")
-                                        .WithObjectName("")
+                                        .WithObjectName("*")
                                         .WithPrivilege("CreateDatabase"));
     util::CheckStatus("grant global privilege to role: " + role_name, status);
 
@@ -218,7 +218,7 @@ main(int argc, char* argv[]) {
     status = client->RevokePrivilege(milvus::RevokePrivilegeRequest()
                                          .WithRoleName(role_name)
                                          .WithObjectType("Global")
-                                         .WithObjectName("")
+                                         .WithObjectName("*")
                                          .WithPrivilege("CreateDatabase"));
     util::CheckStatus("revoke global privilege from role: " + role_name, status);
 

--- a/src/impl/MilvusConnection.cpp
+++ b/src/impl/MilvusConnection.cpp
@@ -177,60 +177,59 @@ MilvusConnection::Connect(const ConnectParam& param, const std::string& runtime_
 
     // grpc channel has been create, now we call the proto::milvus::MilvusClient::Connect() interface
     // to send some basic information of client to the server, including the sdk type, version, etc.
-    proto::milvus::ConnectRequest rpc_request;
-    auto client_info = rpc_request.mutable_client_info();
-    client_info->set_sdk_type("CPP");
-    client_info->set_user(param.Username());
-    client_info->set_sdk_version(GetBuildVersion());
-    client_info->set_host(param.Host());
-
-    auto now = std::chrono::system_clock::now();
-    std::time_t now_time = std::chrono::system_clock::to_time_t(now);
-    std::tm* local_time = std::localtime(&now_time);
-    std::stringstream ss;
-    ss << std::put_time(local_time, "%Y-%m-%d %H:%M:%S");
-    client_info->set_local_time(ss.str());
-
-    // the default value of ConnectTimeout is 10 seconds, means if the server could not return response
-    // in 10 seconds, the MilvusClient will return an error
-    ::grpc::ClientContext context;
-    if (param.ConnectTimeout() > 0) {
-        auto deadline = now + std::chrono::milliseconds{param.ConnectTimeout()};
-        context.set_deadline(deadline);
-    }
-
-    proto::milvus::ConnectResponse rpc_response;
-    auto grpc_status = stub->Connect(&context, rpc_request, &rpc_response);
-    auto status = StatusCodeFromGrpcStatus(grpc_status);
-    if (!status.IsOk()) {
-        return status;
-    }
-
-    status = StatusByProtoResponse(rpc_response);
-    if (!status.IsOk()) {
-        return status;
-    }
-
     try {
+        proto::milvus::ConnectRequest rpc_request;
+        auto client_info = rpc_request.mutable_client_info();
+        client_info->set_sdk_type("CPP");
+        client_info->set_user(param.Username());
+        client_info->set_sdk_version(GetBuildVersion());
+        client_info->set_host(param.Host());
+
+        auto now = std::chrono::system_clock::now();
+        std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+        std::tm* local_time = std::localtime(&now_time);
+        std::stringstream ss;
+        ss << std::put_time(local_time, "%Y-%m-%d %H:%M:%S");
+        client_info->set_local_time(ss.str());
+
+        // the default value of ConnectTimeout is 10 seconds, means if the server could not return response
+        // in 10 seconds, the MilvusClient will return an error
+        ::grpc::ClientContext context;
+        if (param.ConnectTimeout() > 0) {
+            auto deadline = now + std::chrono::milliseconds{param.ConnectTimeout()};
+            context.set_deadline(deadline);
+        }
+
+        proto::milvus::ConnectResponse rpc_response;
+        auto grpc_status = stub->Connect(&context, rpc_request, &rpc_response);
+        auto status = StatusCodeFromGrpcStatus(grpc_status);
+        if (!status.IsOk()) {
+            return status;
+        }
+
+        status = StatusByProtoResponse(rpc_response);
+        if (!status.IsOk()) {
+            return status;
+        }
+
         telemetry->AttachChannel(channel, param.Username(), param.DbName(), reported_endpoint, GetBuildVersion(),
                                  connection_scope);
-    } catch (const std::exception& exception) {
-        return {StatusCode::UNKNOWN_ERROR,
-                std::string("Failed to attach client telemetry transport: ") + exception.what()};
+        {
+            std::lock_guard<std::mutex> lock(stub_mtx_);
+            param_ = param;
+            channel_ = std::move(channel);
+            stub_ = std::move(stub);
+            telemetry_ = telemetry;
+            telemetry_client_id_ = telemetry->ClientId();
+            telemetry_logical_endpoint_ = telemetry_logical_endpoint;
+        }
+        telemetry->Start();
+        return Status::OK();
+    } catch (const std::exception& e) {
+        return StatusFromException(e);
     } catch (...) {
-        return {StatusCode::UNKNOWN_ERROR, "Failed to attach client telemetry transport"};
+        return StatusFromUnknownException();
     }
-    {
-        std::lock_guard<std::mutex> lock(stub_mtx_);
-        param_ = param;
-        channel_ = std::move(channel);
-        stub_ = std::move(stub);
-        telemetry_ = telemetry;
-        telemetry_client_id_ = telemetry->ClientId();
-        telemetry_logical_endpoint_ = telemetry_logical_endpoint;
-    }
-    telemetry->Start();
-    return Status::OK();
 }
 
 ConnectParam&
@@ -903,50 +902,56 @@ MilvusConnection::GetReplicateInfo(const proto::milvus::GetReplicateInfoRequest&
 Status
 MilvusConnection::DumpMessages(const proto::milvus::DumpMessagesRequest& request, const GrpcContextOptions& options,
                                const std::function<Status(const proto::common::ImmutableMessage&)>& on_message) {
-    std::shared_ptr<proto::milvus::MilvusService::Stub> stub;
-    {
-        std::lock_guard<std::mutex> lock(stub_mtx_);
-        stub = stub_;
-    }
-    if (stub == nullptr) {
-        return {StatusCode::NOT_CONNECTED, "Connection is not ready!"};
-    }
-
-    ::grpc::ClientContext context;
-    if (options.timeout > 0) {
-        auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds{options.timeout};
-        context.set_deadline(deadline);
-    }
-
-    auto reader = stub->DumpMessages(&context, request);
-    proto::milvus::DumpMessagesResponse response;
-    while (reader->Read(&response)) {
-        switch (response.response_case()) {
-            case proto::milvus::DumpMessagesResponse::kStatus: {
-                auto status = StatusByProtoResponse(response.status());
-                if (!status.IsOk()) {
-                    return status;
-                }
-                break;
-            }
-            case proto::milvus::DumpMessagesResponse::kMessage: {
-                auto status = on_message(response.message());
-                if (!status.IsOk()) {
-                    return status;
-                }
-                break;
-            }
-            case proto::milvus::DumpMessagesResponse::RESPONSE_NOT_SET:
-            default:
-                return {StatusCode::SERVER_FAILED, "Unexpected empty dumpMessages response"};
+    try {
+        std::shared_ptr<proto::milvus::MilvusService::Stub> stub;
+        {
+            std::lock_guard<std::mutex> lock(stub_mtx_);
+            stub = stub_;
         }
-    }
+        if (stub == nullptr) {
+            return {StatusCode::NOT_CONNECTED, "Connection is not ready!"};
+        }
 
-    auto grpc_status = reader->Finish();
-    if (!grpc_status.ok()) {
-        return StatusCodeFromGrpcStatus(grpc_status);
+        ::grpc::ClientContext context;
+        if (options.timeout > 0) {
+            auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds{options.timeout};
+            context.set_deadline(deadline);
+        }
+
+        auto reader = stub->DumpMessages(&context, request);
+        proto::milvus::DumpMessagesResponse response;
+        while (reader->Read(&response)) {
+            switch (response.response_case()) {
+                case proto::milvus::DumpMessagesResponse::kStatus: {
+                    auto status = StatusByProtoResponse(response.status());
+                    if (!status.IsOk()) {
+                        return status;
+                    }
+                    break;
+                }
+                case proto::milvus::DumpMessagesResponse::kMessage: {
+                    auto status = on_message(response.message());
+                    if (!status.IsOk()) {
+                        return status;
+                    }
+                    break;
+                }
+                case proto::milvus::DumpMessagesResponse::RESPONSE_NOT_SET:
+                default:
+                    return {StatusCode::SERVER_FAILED, "Unexpected empty dumpMessages response"};
+            }
+        }
+
+        auto grpc_status = reader->Finish();
+        if (!grpc_status.ok()) {
+            return StatusCodeFromGrpcStatus(grpc_status);
+        }
+        return Status::OK();
+    } catch (const std::exception& e) {
+        return StatusFromException(e);
+    } catch (...) {
+        return StatusFromUnknownException();
     }
-    return Status::OK();
 }
 
 Status

--- a/src/impl/MilvusConnection.h
+++ b/src/impl/MilvusConnection.h
@@ -35,6 +35,7 @@
 #include "milvus/ClientRequestContext.h"
 #include "milvus/ClientTelemetry.h"
 #include "milvus/Status.h"
+#include "utils/RpcUtils.h"
 #include "milvus/types/ConnectParam.h"
 #include "schema.pb.h"
 
@@ -560,6 +561,24 @@ class MilvusConnection {
     grpcCall(const char* name,
              grpc::Status (proto::milvus::MilvusService::Stub::*func)(grpc::ClientContext*, const Request&, Response*),
              const Request& request, Response& response, const GrpcContextOptions& options) {
+        // Defense-in-depth: most callers already run inside ConnectionHandler::apiHandler's
+        // barrier, but lifecycle APIs such as ConnectionHandler::GetLoadingProgress call
+        // grpcCall directly and rely on these branches.
+        try {
+            return grpcCallInternal(name, func, request, response, options);
+        } catch (const std::exception& e) {
+            return StatusFromException(e);
+        } catch (...) {
+            return StatusFromUnknownException();
+        }
+    }
+
+    template <typename Request, typename Response>
+    Status
+    grpcCallInternal(const char* name,
+                     grpc::Status (proto::milvus::MilvusService::Stub::*func)(grpc::ClientContext*, const Request&,
+                                                                             Response*),
+                     const Request& request, Response& response, const GrpcContextOptions& options) {
         (void)name;
         std::shared_ptr<proto::milvus::MilvusService::Stub> stub;
         {

--- a/src/impl/utils/ConnectionHandler.h
+++ b/src/impl/utils/ConnectionHandler.h
@@ -212,6 +212,23 @@ class ConnectionHandler {
                Status (MilvusConnection::*rpc)(const Request&, Response&, const GrpcOpts&),
                std::function<Status(const Response&)> wait_for_status, std::function<Status(const Response&)> post,
                uint64_t rpc_timeout_ms = 0) {
+        try {
+            return invokeInternal(validate, pre, rpc, wait_for_status, post, rpc_timeout_ms);
+        } catch (const std::exception& e) {
+            return StatusFromException(e);
+        } catch (...) {
+            return StatusFromUnknownException();
+        }
+    }
+
+    // Runs the shared validate/pre/rpc/wait/post pipeline. apiHandler wraps this in an
+    // exception barrier so public SDK calls always return a Status instead of throwing.
+    template <typename Request, typename Response>
+    Status
+    invokeInternal(const std::function<Status(void)>& validate, std::function<Status(Request&)> pre,
+                   Status (MilvusConnection::*rpc)(const Request&, Response&, const GrpcOpts&),
+                   std::function<Status(const Response&)> wait_for_status, std::function<Status(const Response&)> post,
+                   uint64_t rpc_timeout_ms) {
         MilvusConnectionPtr connection;
         RetryParam retry_param;
         uint64_t timeout = 0;

--- a/src/impl/utils/RpcUtils.cpp
+++ b/src/impl/utils/RpcUtils.cpp
@@ -101,4 +101,14 @@ Retry(std::function<Status(void)> caller, const RetryParam& retry_param) {
     return Status::OK();
 }
 
+Status
+StatusFromException(const std::exception& e, const std::string& prefix) {
+    return {StatusCode::UNKNOWN_ERROR, prefix + e.what()};
+}
+
+Status
+StatusFromUnknownException(const std::string& message) {
+    return {StatusCode::UNKNOWN_ERROR, message};
+}
+
 }  // namespace milvus

--- a/src/impl/utils/RpcUtils.h
+++ b/src/impl/utils/RpcUtils.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
+#include <exception>
 #include <functional>
+#include <string>
 
 #include "milvus/Status.h"
 #include "milvus/types/RetryParam.h"
@@ -24,5 +26,17 @@
 namespace milvus {
 Status
 Retry(std::function<Status(void)> caller, const RetryParam& retry_param);
+
+// Converts an escaping exception into a Status per the SDK no-throw contract.
+// Note: an UNKNOWN_ERROR produced here means an SDK-side exception occurred; if the
+// exception escaped from a response-conversion step after the RPC already succeeded,
+// the server-side operation may still have been applied. Callers must not treat
+// UNKNOWN_ERROR as proof that the operation did not take effect.
+Status
+StatusFromException(const std::exception& e, const std::string& prefix = "Unexpected SDK exception: ");
+
+// Converts an unknown (non-std::exception) escaping exception into a Status.
+Status
+StatusFromUnknownException(const std::string& message = "Unexpected SDK exception");
 
 }  // namespace milvus

--- a/src/impl/utils/cache/SchemaCache.cpp
+++ b/src/impl/utils/cache/SchemaCache.cpp
@@ -19,6 +19,8 @@
 #include <algorithm>
 #include <exception>
 
+#include "../RpcUtils.h"
+
 namespace milvus {
 
 SchemaCache::SchemaCache(size_t capacity) : capacity_(capacity) {
@@ -113,9 +115,9 @@ SchemaCache::GetOrLoad(const std::string& endpoint, const std::string& db_name, 
 
         return finish_load(status, loaded);
     } catch (const std::exception& e) {
-        return finish_load({StatusCode::UNKNOWN_ERROR, "Schema loader failed: " + std::string(e.what())}, nullptr);
+        return finish_load(StatusFromException(e, "Schema loader failed: "), nullptr);
     } catch (...) {
-        return finish_load({StatusCode::UNKNOWN_ERROR, "Schema loader failed with unknown exception"}, nullptr);
+        return finish_load(StatusFromUnknownException("Schema loader failed with unknown exception"), nullptr);
     }
 }
 

--- a/src/include/milvus/request/rbac/PrivilegeRequest.h
+++ b/src/include/milvus/request/rbac/PrivilegeRequest.h
@@ -27,7 +27,7 @@ namespace milvus {
  *
  * The object-scoped (V1) privilege form grants a privilege on an arbitrary object,
  * identified by its type and name. Typical object types are "Global", "Database",
- * "Collection" and "User"; the object name is empty for the "Global" scope.
+ * "Collection" and "User"; use "*" as the object name for the "Global" scope.
  */
 class MILVUS_SDK_API PrivilegeRequest {
  public:
@@ -74,7 +74,7 @@ class MILVUS_SDK_API PrivilegeRequest {
     WithObjectType(const std::string& object_type);
 
     /**
-     * @brief Name of the object the privilege applies to. Empty for the "Global" scope.
+     * @brief Name of the object the privilege applies to. Use "*" for the "Global" scope.
      */
     const std::string&
     ObjectName() const;

--- a/test/it/v2/TestExceptionBarrier.cpp
+++ b/test/it/v2/TestExceptionBarrier.cpp
@@ -1,0 +1,73 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+#include "../mocks/MilvusMockedTest.h"
+#include "utils/ConnectionHandler.h"
+#include "milvus/types/ConnectParam.h"
+
+using ::milvus::proto::milvus::CheckHealthRequest;
+using ::milvus::proto::milvus::CheckHealthResponse;
+using ::milvus::proto::milvus::ConnectRequest;
+using ::milvus::proto::milvus::ConnectResponse;
+using ::testing::_;
+
+namespace {
+
+milvus::Status
+ConnectHandler(testing::StrictMock<::milvus::MilvusMockedService>& service, uint16_t port,
+               milvus::ConnectionHandler& handler) {
+    EXPECT_CALL(service, Connect(_, _, _))
+        .WillOnce([](::grpc::ServerContext*, const ConnectRequest*, ConnectResponse*) { return ::grpc::Status{}; });
+    return handler.Connect(milvus::ConnectParam{"127.0.0.1", port});
+}
+
+}  // namespace
+
+TEST_F(UnconnectMilvusMockedTest, ExceptionBarrierConvertsStdExceptionToStatus) {
+    milvus::ConnectionHandler handler;
+    auto connect_status = ConnectHandler(service_, server_.ListenPort(), handler);
+    ASSERT_TRUE(connect_status.IsOk());
+
+    auto throwing_validate = []() -> milvus::Status { throw std::runtime_error("boom"); };
+    auto pre = [](CheckHealthRequest&) { return milvus::Status::OK(); };
+    auto post = [](const CheckHealthResponse&) { return milvus::Status::OK(); };
+
+    auto status = handler.Invoke<CheckHealthRequest, CheckHealthResponse>(
+        throwing_validate, pre, &milvus::MilvusConnection::CheckHealth, post);
+
+    EXPECT_EQ(status.Code(), milvus::StatusCode::UNKNOWN_ERROR);
+    EXPECT_NE(status.Message().find("Unexpected SDK exception: boom"), std::string::npos);
+}
+
+TEST_F(UnconnectMilvusMockedTest, ExceptionBarrierConvertsNonStdExceptionToStatus) {
+    milvus::ConnectionHandler handler;
+    auto connect_status = ConnectHandler(service_, server_.ListenPort(), handler);
+    ASSERT_TRUE(connect_status.IsOk());
+
+    auto throwing_validate = []() -> milvus::Status { throw 42; };
+    auto pre = [](CheckHealthRequest&) { return milvus::Status::OK(); };
+    auto post = [](const CheckHealthResponse&) { return milvus::Status::OK(); };
+
+    auto status = handler.Invoke<CheckHealthRequest, CheckHealthResponse>(
+        throwing_validate, pre, &milvus::MilvusConnection::CheckHealth, post);
+
+    EXPECT_EQ(status.Code(), milvus::StatusCode::UNKNOWN_ERROR);
+    EXPECT_NE(status.Message().find("Unexpected SDK exception"), std::string::npos);
+}

--- a/test/it/v2/TestPrivilege.cpp
+++ b/test/it/v2/TestPrivilege.cpp
@@ -76,7 +76,7 @@ TEST_F(UnconnectMilvusMockedTest, RevokePrivilege) {
         .WillOnce([](::grpc::ServerContext*, const OperatePrivilegeRequest* request, ::milvus::proto::common::Status*) {
             EXPECT_EQ(request->entity().role().name(), "reader_role");
             EXPECT_EQ(request->entity().object().name(), "Global");
-            EXPECT_EQ(request->entity().object_name(), "");
+            EXPECT_EQ(request->entity().object_name(), "*");
             EXPECT_EQ(request->entity().grantor().privilege().name(), "CreateCollection");
             EXPECT_TRUE(request->entity().db_name().empty());
             EXPECT_EQ(request->type(), ::milvus::proto::milvus::OperatePrivilegeType::Revoke);
@@ -86,6 +86,7 @@ TEST_F(UnconnectMilvusMockedTest, RevokePrivilege) {
     auto status = client->RevokePrivilege(milvus::RevokePrivilegeRequest()
                                               .WithRoleName("reader_role")
                                               .WithObjectType("Global")
+                                              .WithObjectName("*")
                                               .WithPrivilege("CreateCollection"));
     EXPECT_TRUE(status.IsOk());
 }

--- a/test/ut/utils/TestRpcUtils.cpp
+++ b/test/ut/utils/TestRpcUtils.cpp
@@ -1,0 +1,43 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+#include "utils/RpcUtils.h"
+
+class RpcUtilsTest : public ::testing::Test {};
+
+TEST_F(RpcUtilsTest, StatusFromException) {
+    auto status = milvus::StatusFromException(std::runtime_error("boom"));
+    EXPECT_EQ(status.Code(), milvus::StatusCode::UNKNOWN_ERROR);
+    EXPECT_EQ(status.Message(), "Unexpected SDK exception: boom");
+
+    auto prefixed = milvus::StatusFromException(std::runtime_error("boom"), "Schema loader failed: ");
+    EXPECT_EQ(prefixed.Code(), milvus::StatusCode::UNKNOWN_ERROR);
+    EXPECT_EQ(prefixed.Message(), "Schema loader failed: boom");
+}
+
+TEST_F(RpcUtilsTest, StatusFromUnknownException) {
+    auto status = milvus::StatusFromUnknownException();
+    EXPECT_EQ(status.Code(), milvus::StatusCode::UNKNOWN_ERROR);
+    EXPECT_EQ(status.Message(), "Unexpected SDK exception");
+
+    auto custom = milvus::StatusFromUnknownException("Schema loader failed with unknown exception");
+    EXPECT_EQ(custom.Code(), milvus::StatusCode::UNKNOWN_ERROR);
+    EXPECT_EQ(custom.Message(), "Schema loader failed with unknown exception");
+}


### PR DESCRIPTION
## Summary

Ensure public `MilvusClientV2`/`MilvusClient` calls never throw: exceptions escaping the RPC pipeline, the gRPC layer, or direct stub callers are converted into an `UNKNOWN_ERROR` `Status` at the boundary.

### Changes
- `ConnectionHandler::apiHandler`: wraps the validate/pre/rpc/wait/post pipeline in a `try/catch`; body moves to a private `invokeInternal()`. Covers `std::exception` and `catch(...)`.
- `MilvusConnection::grpcCall`: same barrier for RPCs that go through `grpcCall` (e.g. CheckHealth, GetLoadingProgress); body moves to a private `grpcCallInternal()`.
- `MilvusConnection::Connect` and `MilvusConnection::DumpMessages`: these call the gRPC stub directly (handshake and streaming respectively), so they now carry the same barrier around their handshake/stream bodies.
- Shared `StatusFromException` / `StatusFromUnknownException` helpers give the conversion a single definition across apiHandler, grpcCall, Connect, DumpMessages and SchemaCache, with dedicated unit tests. The helpers document that `UNKNOWN_ERROR` from the barrier does not imply the server-side operation was not applied (a response-conversion failure after a successful RPC).
- `examples/src/v2/rbac.cpp`: use `object_name "*"` for the Global `CreateDatabase` grant/revoke — the empty object name is rejected by the current server.
- `PrivilegeRequest` docs and the `RevokePrivilege` mocked test now encode `"*"` for the Global scope.
- New mocked tests `ExceptionBarrierConvertsStdExceptionToStatus` / `ExceptionBarrierConvertsNonStdExceptionToStatus` exercise both catch branches via throwing validate lambdas.

### Tests
- `testing-ut`: 897 passed.
- `testing-it`: 52 passed (Connect/DumpMessages/Privilege/ExceptionBarrier/load/describe/session).