### PR TITLE
fix: harden client telemetry (#587, #588)

### DIFF
--- a/src/impl/ClientTelemetry.cpp
+++ b/src/impl/ClientTelemetry.cpp
@@ -68,12 +68,18 @@ constexpr size_t kSnapshotLimit = 4096;
 constexpr uint64_t kSamplingScale = 1000000000ULL;
 constexpr size_t kMaxReplyBytes = 1024 * 1024;
 constexpr uint64_t kMaxUnsupportedBackoffMs = 30 * 60 * 1000;
+constexpr uint64_t kMaxHeartbeatIntervalMs = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+// condition_variable implementations commonly form an absolute deadline internally.
+// Keep each addition comfortably inside every supported platform clock and represent
+// longer intervals as stop/rebind-aware chunks.
+constexpr uint64_t kMaxWaitChunkMs = 24ULL * 60 * 60 * 1000;
 
 TelemetryConfig
 NormalizedTelemetryConfig(TelemetryConfig config) {
     if (config.heartbeat_interval_ms == 0) {
         config.heartbeat_interval_ms = 10000;
     }
+    config.heartbeat_interval_ms = std::min(config.heartbeat_interval_ms, kMaxHeartbeatIntervalMs);
     config.sampling_rate = std::max(0.0, std::min(1.0, config.sampling_rate));
     if (config.error_max_count == 0) {
         config.error_max_count = 100;
@@ -92,6 +98,27 @@ int64_t
 NowMillis() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
         .count();
+}
+
+int64_t
+SaturatingWindowStart(int64_t end_time, uint64_t interval_ms) {
+    const auto signed_interval = static_cast<int64_t>(std::min(interval_ms, kMaxHeartbeatIntervalMs));
+    if (end_time < std::numeric_limits<int64_t>::min() + signed_interval) {
+        return std::numeric_limits<int64_t>::min();
+    }
+    return end_time - signed_interval;
+}
+
+size_t
+Utf8SafePrefixLength(const std::string& value, size_t requested) {
+    auto length = std::min(requested, value.size());
+    if (length == value.size()) {
+        return length;
+    }
+    while (length > 0 && (static_cast<unsigned char>(value[length]) & 0xC0) == 0x80) {
+        --length;
+    }
+    return length;
 }
 
 std::string
@@ -443,10 +470,10 @@ FailedReply(const std::string& command_id, const std::string& error) {
 class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientTelemetryManager::Impl> {
  public:
     Impl(const TelemetryConfig& value, const std::string& runtime_client_id)
-        : config(NormalizedTelemetryConfig(value)),
-          connection_config(config),
-          stable_client_id(!value.client_id.empty()),
-          client_id(stable_client_id ? value.client_id
+        : config_(NormalizedTelemetryConfig(value)),
+          connection_config_(config_),
+          stable_client_id_(!value.client_id.empty()),
+          client_id_(stable_client_id_ ? value.client_id
                                      : (runtime_client_id.empty() ? RandomUuid() : runtime_client_id)) {
         RegisterDefaultHandlers();
     }
@@ -469,123 +496,134 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
         std::string new_sdk_version = version;
         std::string new_connection_scope = scope;
 
-        std::lock_guard<std::recursive_mutex> command_lock(command_mutex);
-        std::lock_guard<std::mutex> lock(mutex);
-        stub = std::move(new_stub);
-        ++channel_generation;
-        username = std::move(new_username);
-        database = std::move(new_database);
-        uri = std::move(new_uri);
-        sdk_version = std::move(new_sdk_version);
-        connection_scope = std::move(new_connection_scope);
+        std::lock_guard<std::recursive_mutex> command_lock(command_mutex_);
+        std::lock_guard<std::mutex> lock(mutex_);
+        stub_ = std::move(new_stub);
+        ++channel_generation_;
+        // A newly attached transport must be probed immediately. Carrying an
+        // UNIMPLEMENTED backoff from the retired endpoint can otherwise keep a
+        // supporting endpoint silent for up to thirty minutes.
+        unsupported_streak_ = 0;
+        ++wait_revision_;
+        username_ = std::move(new_username);
+        database_ = std::move(new_database);
+        uri_ = std::move(new_uri);
+        sdk_version_ = std::move(new_sdk_version);
+        connection_scope_ = std::move(new_connection_scope);
+        condition_.notify_all();
     }
 
     void
     Start() {
-        std::unique_lock<std::mutex> lock(mutex);
-        if (ready) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (ready_) {
             return;
         }
-        const bool called_from_worker = worker_running && worker_id == std::this_thread::get_id();
+        const bool called_from_worker = worker_running_ && worker_id_ == std::this_thread::get_id();
         if (called_from_worker) {
             // Stop()/Start() is used by reconnect handlers. Reuse this worker only
             // when no external caller has claimed it for joining. An external stop
             // always wins over a self-restart that races with it.
-            if (join_in_progress || external_stop_requested) {
+            if (join_in_progress_ || external_stop_requested_) {
                 return;
             }
-            ready = true;
-            control_plane_activated = control_plane_activated || config.enabled;
-            if (!control_plane_activated) {
-                stopped = true;
+            ready_ = true;
+            control_plane_activated_ = control_plane_activated_ || config_.enabled;
+            if (!control_plane_activated_) {
+                stopped_ = true;
                 return;
             }
-            stopped = false;
+            stopped_ = false;
             return;
         }
 
-        condition.wait(lock, [this]() { return !join_in_progress; });
-        if (ready) {
+        condition_.wait(lock, [this]() { return !join_in_progress_; });
+        if (ready_) {
             return;
         }
-        if (worker.joinable()) {
-            join_in_progress = true;
-            auto previous_worker = std::move(worker);
+        if (worker_.joinable()) {
+            join_in_progress_ = true;
+            auto previous_worker = std::move(worker_);
             lock.unlock();
             previous_worker.join();
             lock.lock();
-            worker_id = {};
-            worker_running = false;
-            join_in_progress = false;
-            condition.notify_all();
-            if (ready) {
+            worker_id_ = {};
+            worker_running_ = false;
+            join_in_progress_ = false;
+            condition_.notify_all();
+            if (ready_) {
                 return;
             }
         }
-        external_stop_requested = false;
-        ready = true;
+        external_stop_requested_ = false;
+        ready_ = true;
         // Initial enabled=false is an explicit opt-out and creates no control-plane traffic.
         // Once activated, keep the control plane sticky across dynamic disable and
         // Stop/Start reconnects so the server can later re-enable telemetry.
-        control_plane_activated = control_plane_activated || config.enabled;
-        if (!control_plane_activated) {
-            stopped = true;
+        control_plane_activated_ = control_plane_activated_ || config_.enabled;
+        if (!control_plane_activated_) {
+            stopped_ = true;
             return;
         }
-        stopped = false;
-        worker_running = true;
+        stopped_ = false;
+        worker_running_ = true;
         try {
             auto self = shared_from_this();
-            worker = std::thread([self = std::move(self)]() { self->HeartbeatLoop(); });
-            worker_id = worker.get_id();
+            worker_ = std::thread([self = std::move(self)]() { self->HeartbeatLoop(); });
+            worker_id_ = worker_.get_id();
         } catch (...) {
             // Telemetry startup is best-effort. Restore a clean, retryable stopped state instead
             // of leaking an exception through Connect() or leaving worker_running without a thread.
-            ready = false;
-            stopped = true;
-            worker_running = false;
-            worker_id = {};
-            condition.notify_all();
+            ready_ = false;
+            stopped_ = true;
+            worker_running_ = false;
+            worker_id_ = {};
+            condition_.notify_all();
         }
     }
 
     void
     Stop() {
-        std::unique_lock<std::mutex> lock(mutex);
-        stopped = true;
-        ready = false;
-        condition.notify_all();
+        std::unique_lock<std::mutex> lock(mutex_);
+        stopped_ = true;
+        ready_ = false;
+        condition_.notify_all();
 
-        const bool called_from_worker = worker_running && worker_id == std::this_thread::get_id();
+        const bool called_from_worker = worker_running_ && worker_id_ == std::this_thread::get_id();
         if (called_from_worker) {
             return;
         }
 
-        external_stop_requested = true;
-        condition.wait(lock, [this]() { return !join_in_progress; });
-        if (!worker.joinable()) {
-            worker_id = {};
-            worker_running = false;
+        external_stop_requested_ = true;
+        condition_.wait(lock, [this]() { return !join_in_progress_; });
+        if (!worker_.joinable()) {
+            worker_id_ = {};
+            worker_running_ = false;
             return;
         }
 
         // Move the thread object while holding the state mutex. This gives
         // exactly one external caller ownership of join(); other Stop()/Start()
         // calls wait on join_in_progress instead of touching the same std::thread.
-        join_in_progress = true;
-        auto current_worker = std::move(worker);
+        join_in_progress_ = true;
+        auto current_worker = std::move(worker_);
         lock.unlock();
         current_worker.join();
         lock.lock();
-        worker_id = {};
-        worker_running = false;
-        join_in_progress = false;
-        condition.notify_all();
+        worker_id_ = {};
+        worker_running_ = false;
+        join_in_progress_ = false;
+        condition_.notify_all();
     }
 
     void
     HeartbeatLoop() {
         while (true) {
+            uint64_t heartbeat_revision;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                heartbeat_revision = wait_revision_;
+            }
             try {
                 CreateSnapshot();
                 SendHeartbeat();
@@ -594,55 +632,87 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                 // escape a std::thread entry and terminate the process. Keep the control plane
                 // alive; the next iteration can retry on the same or a reattached transport.
                 try {
-                    std::lock_guard<std::mutex> lock(mutex);
-                    last_heartbeat_error = "unexpected client telemetry heartbeat failure";
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    last_heartbeat_error_ = "unexpected client telemetry heartbeat failure";
                 } catch (...) {
                     // Even recording a best-effort diagnostic can fail under memory pressure.
                 }
             }
-            std::unique_lock<std::mutex> lock(mutex);
-            if (stopped) {
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (stopped_) {
                 break;
             }
-            uint64_t delay = config.heartbeat_interval_ms;
-            if (unsupported_streak > 0) {
+            if (heartbeat_revision != wait_revision_) {
+                // AttachChannel may have replaced the transport while the RPC
+                // was in flight, before there was a waiter to notify. Probe the
+                // replacement immediately instead of sleeping the old interval.
+                continue;
+            }
+            uint64_t delay = config_.heartbeat_interval_ms;
+            if (unsupported_streak_ > 0) {
                 uint64_t backed_off = std::min(delay, kMaxUnsupportedBackoffMs);
-                for (int index = 0; index < unsupported_streak && backed_off < kMaxUnsupportedBackoffMs; ++index) {
+                for (int index = 0; index < unsupported_streak_ && backed_off < kMaxUnsupportedBackoffMs; ++index) {
                     backed_off = backed_off > kMaxUnsupportedBackoffMs / 2 ? kMaxUnsupportedBackoffMs : backed_off * 2;
                 }
+                // The backoff caps how often a short-interval client probes an UNIMPLEMENTED
+                // server, but never shortens a configured interval above the cap: a client set
+                // to heartbeat less often must not start probing more often (matches Go SDK).
                 delay = std::max(delay, backed_off);
             }
-            condition.wait_for(lock, std::chrono::milliseconds(delay), [this]() { return stopped; });
-            if (stopped) {
+            const auto observed_revision = wait_revision_;
+            while (!stopped_ && observed_revision == wait_revision_ && delay > 0) {
+                const auto chunk = std::min(delay, kMaxWaitChunkMs);
+                if (condition_.wait_for(
+                        lock, std::chrono::milliseconds(static_cast<int64_t>(chunk)),
+                        [this, observed_revision]() { return stopped_ || wait_revision_ != observed_revision; })) {
+                    break;
+                }
+                delay -= chunk;
+            }
+            if (stopped_) {
                 break;
             }
         }
-        std::lock_guard<std::mutex> lock(mutex);
-        worker_running = false;
+        std::lock_guard<std::mutex> lock(mutex_);
+        worker_running_ = false;
         // If Stop() was called by a command handler, no external thread owns
         // join(). Detach only after the loop has finished using this object;
         // the worker's shared_ptr keeps Impl alive until this function returns.
-        if (worker.joinable() && worker.get_id() == std::this_thread::get_id()) {
-            worker.detach();
-            worker_id = {};
+        if (worker_.joinable() && worker_.get_id() == std::this_thread::get_id()) {
+            worker_.detach();
+            worker_id_ = {};
         }
-        condition.notify_all();
+        condition_.notify_all();
     }
 
     void
     CreateSnapshot() {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!config.enabled) {
-            return;
-        }
         StoredSnapshot stored;
         auto& snapshot = stored.snapshot;
-        snapshot.end_time = NowMillis();
-        snapshot.timestamp = last_snapshot_end == 0 || last_snapshot_end > snapshot.end_time
-                                 ? snapshot.end_time - config.heartbeat_interval_ms
-                                 : last_snapshot_end;
-        last_snapshot_end = snapshot.end_time;
-        for (auto& entry : collectors) {
+        decltype(collectors_) working;
+        bool all_collections_enabled_snapshot = false;
+        std::unordered_set<std::string> enabled_collections_snapshot;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (!config_.enabled) {
+                return;
+            }
+            snapshot.end_time = NowMillis();
+            snapshot.timestamp = last_snapshot_end_ == 0 || last_snapshot_end_ > snapshot.end_time
+                                     ? SaturatingWindowStart(snapshot.end_time, config_.heartbeat_interval_ms)
+                                     : last_snapshot_end_;
+            // Cap the reported window start at the retained-history range so a maximum
+            // interval cannot surface an extreme (saturated) timestamp in latency history.
+            snapshot.timestamp = std::max(snapshot.timestamp, snapshot.end_time - kMaxHistoryRangeMs);
+            last_snapshot_end_ = snapshot.end_time;
+            // Swap the accumulated collectors out in O(1) so the per-bucket
+            // snapshot work below runs without holding the lock. Concurrent
+            // RecordOperation calls meanwhile start a fresh next-window bucket.
+            working.swap(collectors_);
+            all_collections_enabled_snapshot = all_collections_enabled_;
+            enabled_collections_snapshot = enabled_collections_;
+        }
+        for (auto& entry : working) {
             if (entry.second.global.requests == 0) {
                 continue;
             }
@@ -652,28 +722,28 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             operation.global = entry.second.global.Snapshot(&quantile_samples);
             stored.global_samples.emplace(entry.first, std::move(quantile_samples));
             for (const auto& collection : entry.second.collections) {
-                if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
+                if (all_collections_enabled_snapshot || enabled_collections_snapshot.count(collection.first) > 0) {
                     operation.collection_metrics.emplace(collection.first, collection.second.Snapshot());
                 }
             }
             snapshot.metrics.emplace_back(std::move(operation));
-            entry.second = OperationCollector{};
         }
-        // Heartbeats report exactly the collector interval that just ended.
-        // Keep this separate from retained history so skipping an empty history
-        // entry cannot make the next heartbeat resend an older non-empty sample.
-        latest_snapshot = snapshot;
-        const auto history_start = snapshot.end_time - kMaxHistoryRangeMs;
-        while (!snapshots.empty() && snapshots.front().snapshot.end_time < history_start) {
-            snapshots.pop_front();
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            latest_snapshot_ = snapshot;
+            const auto history_start = snapshot.end_time - kMaxHistoryRangeMs;
+            while (!snapshots_.empty() && snapshots_.front().snapshot.end_time < history_start) {
+                snapshots_.pop_front();
+            }
+            if (snapshot.metrics.empty()) {
+                return;
+            }
+            snapshots_.push_back(std::move(stored));
+            while (snapshots_.size() > kSnapshotLimit) {
+                snapshots_.pop_front();
+            }
         }
-        if (snapshot.metrics.empty()) {
-            return;
-        }
-        snapshots.push_back(std::move(stored));
-        while (snapshots.size() > kSnapshotLimit) {
-            snapshots.pop_front();
-        }
+        // working is destroyed here, outside the lock.
     }
 
     void
@@ -683,49 +753,54 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
         uint64_t heartbeat_generation = 0;
         size_t reply_count = 0;
         {
-            std::lock_guard<std::mutex> lock(mutex);
-            if (stub == nullptr) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (stub_ == nullptr) {
                 return;
             }
             auto* info = request.mutable_client_info();
             info->set_sdk_type("CPP");
-            info->set_sdk_version(sdk_version);
+            info->set_sdk_version(sdk_version_);
             info->set_local_time(LocalTimeString());
-            info->set_user(username);
+            info->set_user(username_);
             info->set_host(HostName());
-            (*info->mutable_reserved())["client_id"] = client_id;
-            (*info->mutable_reserved())["client_id_stable"] = stable_client_id ? "true" : "false";
-            if (!database.empty()) {
-                (*info->mutable_reserved())["db_name"] = database;
+            (*info->mutable_reserved())["client_id"] = client_id_;
+            (*info->mutable_reserved())["client_id_stable"] = stable_client_id_ ? "true" : "false";
+            if (!database_.empty()) {
+                (*info->mutable_reserved())["db_name"] = database_;
             }
             request.set_report_timestamp(NowMillis());
             // Do not resend the final enabled snapshot after collection is disabled. Replies,
             // config hash, cursor and incoming commands remain active as the control plane.
-            if (config.enabled) {
-                for (const auto& operation : latest_snapshot.metrics) {
+            if (config_.enabled) {
+                // TODO: serializing every enabled collection's metrics here scales with the
+                // collection count and blocks RecordOperation for the duration while this lock
+                // is held. Build the request outside the lock instead: snapshot the cheap shared
+                // state (identity, config, filters, pending_replies, config hash, cursor) under
+                // the lock and reference latest_snapshot, whose only writer is this worker.
+                for (const auto& operation : latest_snapshot_.metrics) {
                     auto* output = request.add_metrics();
                     output->set_operation(operation.operation);
                     *output->mutable_global() = ToProtoMetric(operation.global);
                     for (const auto& collection : operation.collection_metrics) {
-                        if (all_collections_enabled || enabled_collections.count(collection.first) > 0) {
+                        if (all_collections_enabled_ || enabled_collections_.count(collection.first) > 0) {
                             (*output->mutable_collection_metrics())[collection.first] =
                                 ToProtoMetric(collection.second);
                         }
                     }
                 }
             }
-            for (const auto& reply : pending_replies) {
+            for (const auto& reply : pending_replies_) {
                 auto* output = request.add_command_replies();
                 output->set_command_id(reply.command_id);
                 output->set_success(reply.success);
                 output->set_error_message(reply.error_message);
                 output->set_payload(reply.payload);
             }
-            reply_count = pending_replies.size();
-            request.set_config_hash(config_hash);
-            request.set_last_command_timestamp(last_command_timestamp);
-            heartbeat_stub = stub;
-            heartbeat_generation = channel_generation;
+            reply_count = pending_replies_.size();
+            request.set_config_hash(config_hash_);
+            request.set_last_command_timestamp(last_command_timestamp_);
+            heartbeat_stub = stub_;
+            heartbeat_generation = channel_generation_;
         }
 
         grpc::ClientContext context;
@@ -733,26 +808,26 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
         proto::milvus::ClientHeartbeatResponse response;
         auto grpc_status = heartbeat_stub->ClientHeartbeat(&context, request, &response);
         if (!grpc_status.ok()) {
-            std::lock_guard<std::mutex> lock(mutex);
-            if (heartbeat_generation != channel_generation) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (heartbeat_generation != channel_generation_) {
                 return;
             }
-            last_heartbeat_error = grpc_status.error_message();
+            last_heartbeat_error_ = grpc_status.error_message();
             if (grpc_status.error_code() == grpc::StatusCode::UNIMPLEMENTED) {
-                ++unsupported_streak;
+                ++unsupported_streak_;
             }
             return;
         }
         {
-            std::lock_guard<std::mutex> lock(mutex);
-            if (heartbeat_generation != channel_generation) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (heartbeat_generation != channel_generation_) {
                 return;
             }
             // Reaching any server implementation proves the RPC exists, even when the
             // response carries a business error.
-            unsupported_streak = 0;
+            unsupported_streak_ = 0;
             if (response.status().code() != 0 || response.status().error_code() != proto::common::ErrorCode::Success) {
-                last_heartbeat_error = response.status().reason();
+                last_heartbeat_error_ = response.status().reason();
                 return;
             }
         }
@@ -763,13 +838,13 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                                 command.persistent(), command.target_scope()});
         }
         {
-            std::lock_guard<std::mutex> lock(mutex);
-            if (heartbeat_generation != channel_generation) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (heartbeat_generation != channel_generation_) {
                 return;
             }
-            pending_replies.erase(pending_replies.begin(),
-                                  pending_replies.begin() + std::min(reply_count, pending_replies.size()));
-            last_heartbeat_error.clear();
+            pending_replies_.erase(pending_replies_.begin(),
+                                  pending_replies_.begin() + std::min(reply_count, pending_replies_.size()));
+            last_heartbeat_error_.clear();
         }
         ProcessCommands(commands, heartbeat_generation);
     }
@@ -778,15 +853,19 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
     HandleCommand(const TelemetryCommand& command) {
         CommandHandler handler;
         {
-            std::lock_guard<std::mutex> lock(mutex);
-            auto iterator = handlers.find(command.command_type);
-            if (iterator == handlers.end()) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto iterator = handlers_.find(command.command_type);
+            if (iterator == handlers_.end()) {
                 return FailedReply(command.command_id, "unknown command type: " + command.command_type);
             }
             handler = iterator->second;
         }
         try {
-            return handler(command);
+            auto reply = handler(command);
+            // The incoming command ID is the protocol correlation key. Extension
+            // handlers control the result, but cannot redirect or drop its ACK.
+            reply.command_id = command.command_id;
+            return reply;
         } catch (const std::exception& exception) {
             return FailedReply(command.command_id, exception.what());
         } catch (...) {
@@ -798,14 +877,14 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
 
     void
     ProcessCommands(const std::vector<TelemetryCommand>& commands, uint64_t expected_generation = 0) {
-        std::lock_guard<std::recursive_mutex> command_lock(command_mutex);
+        std::lock_guard<std::recursive_mutex> command_lock(command_mutex_);
         int64_t previous_timestamp;
         {
-            std::lock_guard<std::mutex> lock(mutex);
-            if (expected_generation != 0 && expected_generation != channel_generation) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (expected_generation != 0 && expected_generation != channel_generation_) {
                 return;
             }
-            previous_timestamp = last_command_timestamp;
+            previous_timestamp = last_command_timestamp_;
         }
         int64_t max_timestamp = previous_timestamp;
         bool has_persistent = false;
@@ -814,37 +893,56 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             has_persistent = has_persistent || command.persistent;
             bool skip = false;
             {
-                std::lock_guard<std::mutex> lock(mutex);
-                skip = command.create_time < previous_timestamp || executed_commands.count(command.command_id) > 0;
+                std::lock_guard<std::mutex> lock(mutex_);
+                if (expected_generation != 0 && expected_generation != channel_generation_) {
+                    return;
+                }
+                skip = command.create_time < previous_timestamp || executed_commands_.count(command.command_id) > 0;
                 if (skip) {
-                    pending_replies.push_back(SuccessReply(command.command_id));
+                    auto executed = executed_commands_.find(command.command_id);
+                    if (executed != executed_commands_.end()) {
+                        // Re-queue the command's actual reply so a fenced redelivery cannot
+                        // turn an already-reported failure into a contradictory success ACK.
+                        pending_replies_.push_back(executed->second.reply_);
+                    } else {
+                        pending_replies_.push_back(SuccessReply(command.command_id));
+                    }
                 }
             }
             if (skip) {
                 continue;
             }
             auto reply = HandleCommand(command);
-            std::lock_guard<std::mutex> lock(mutex);
-            executed_commands[command.command_id] = command.create_time;
-            pending_replies.push_back(std::move(reply));
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                executed_commands_[command.command_id] = {command.create_time, reply};
+                pending_replies_.push_back(std::move(reply));
+                if (expected_generation != 0 && expected_generation != channel_generation_) {
+                    // Preserve the completed command's ACK/executed marker so a
+                    // redelivery cannot repeat its side effects, but leave the
+                    // cursor/hash unchanged and do not run the retired endpoint's
+                    // remaining commands.
+                    return;
+                }
+            }
         }
-        std::lock_guard<std::mutex> lock(mutex);
-        for (auto iterator = executed_commands.begin(); iterator != executed_commands.end();) {
-            if (iterator->second < max_timestamp) {
-                iterator = executed_commands.erase(iterator);
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (auto iterator = executed_commands_.begin(); iterator != executed_commands_.end();) {
+            if (iterator->second.create_time_ < max_timestamp) {
+                iterator = executed_commands_.erase(iterator);
             } else {
                 ++iterator;
             }
         }
         if (has_persistent) {
-            config_hash = ClientTelemetryManager::CalculateConfigHash(commands);
+            config_hash_ = ClientTelemetryManager::CalculateConfigHash(commands);
         }
-        last_command_timestamp = std::max(last_command_timestamp, max_timestamp);
+        last_command_timestamp_ = std::max(last_command_timestamp_, max_timestamp);
     }
 
     void
     RegisterDefaultHandlers() {
-        handlers["push_config"] = [this](const TelemetryCommand& command) {
+        handlers_["push_config"] = [this](const TelemetryCommand& command) {
             auto payload = command.payload.empty() ? nlohmann::json::object() : nlohmann::json::parse(command.payload);
             if (!payload.is_object()) {
                 throw std::invalid_argument("push_config payload must be a JSON object");
@@ -853,7 +951,7 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             std::vector<std::string> applied;
             std::vector<std::string> ignored;
             bool enabled = false;
-            int64_t interval = 0;
+            uint64_t interval = 0;
             double sampling_rate = 0;
             if (payload.count("enabled")) {
                 if (!payload["enabled"].is_boolean()) {
@@ -867,10 +965,16 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                     !payload["heartbeat_interval_ms"].is_number_unsigned()) {
                     throw std::invalid_argument("heartbeat_interval_ms must be an integer");
                 }
-                interval = payload["heartbeat_interval_ms"].get<int64_t>();
-                if (interval <= 0) {
+                if (payload["heartbeat_interval_ms"].is_number_integer() &&
+                    !payload["heartbeat_interval_ms"].is_number_unsigned() &&
+                    payload["heartbeat_interval_ms"].get<int64_t>() < 0) {
                     throw std::invalid_argument("heartbeat_interval_ms must be positive");
                 }
+                interval = payload["heartbeat_interval_ms"].get<uint64_t>();
+                if (interval == 0) {
+                    throw std::invalid_argument("heartbeat_interval_ms must be positive");
+                }
+                interval = std::min(interval, kMaxHeartbeatIntervalMs);
                 applied.emplace_back("heartbeat_interval_ms");
             }
             if (payload.count("sampling_rate")) {
@@ -884,12 +988,6 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                 sampling_rate = std::max(0.0, std::min(1.0, sampling_rate));
                 applied.emplace_back("sampling_rate");
             }
-            if (payload.count("ttl_seconds")) {
-                if (!payload["ttl_seconds"].is_number_integer() && !payload["ttl_seconds"].is_number_unsigned()) {
-                    throw std::invalid_argument("ttl_seconds must be an integer");
-                }
-                (void)payload["ttl_seconds"].get<int64_t>();
-            }
             for (auto iterator = payload.begin(); iterator != payload.end(); ++iterator) {
                 if (iterator.key() != "enabled" && iterator.key() != "heartbeat_interval_ms" &&
                     iterator.key() != "sampling_rate") {
@@ -898,27 +996,33 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             }
             std::sort(ignored.begin(), ignored.end());
             {
-                std::lock_guard<std::mutex> lock(mutex);
+                std::lock_guard<std::mutex> lock(mutex_);
                 if (payload.count("enabled")) {
-                    config.enabled = enabled;
+                    config_.enabled = enabled;
                 }
                 if (payload.count("heartbeat_interval_ms")) {
-                    config.heartbeat_interval_ms = static_cast<uint64_t>(interval);
+                    // A decrease must wake the chunked heartbeat wait so a corrective
+                    // interval push is applied on the next loop iteration instead of after
+                    // the current chunk; an increase takes effect at the next wake anyway.
+                    if (interval < config_.heartbeat_interval_ms) {
+                        ++wait_revision_;
+                    }
+                    config_.heartbeat_interval_ms = interval;
                 }
                 if (payload.count("sampling_rate")) {
-                    config.sampling_rate = sampling_rate;
+                    config_.sampling_rate = sampling_rate;
                 }
-                condition.notify_all();
+                condition_.notify_all();
             }
             return SuccessReply(command.command_id, nlohmann::json{{"applied", applied}, {"ignored", ignored}}.dump());
         };
-        handlers["collection_metrics"] = [this](const TelemetryCommand& command) {
-            std::lock_guard<std::mutex> lock(mutex);
+        handlers_["collection_metrics"] = [this](const TelemetryCommand& command) {
+            std::lock_guard<std::mutex> lock(mutex_);
             if (command.payload.empty()) {
-                std::vector<std::string> names(enabled_collections.begin(), enabled_collections.end());
+                std::vector<std::string> names(enabled_collections_.begin(), enabled_collections_.end());
                 std::sort(names.begin(), names.end());
                 nlohmann::json result = {{"enabled_collections", names},
-                                         {"all_collections_enabled", all_collections_enabled}};
+                                         {"all_collections_enabled", all_collections_enabled_}};
                 return SuccessReply(command.command_id, result.dump());
             }
             auto payload = nlohmann::json::parse(command.payload);
@@ -945,21 +1049,21 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                     throw std::invalid_argument("collections list cannot be empty when enabled=true");
                 }
                 if (wildcard) {
-                    all_collections_enabled = true;
+                    all_collections_enabled_ = true;
                 } else {
-                    enabled_collections.insert(collections.begin(), collections.end());
+                    enabled_collections_.insert(collections.begin(), collections.end());
                 }
             } else if (wildcard || collections.empty()) {
-                all_collections_enabled = false;
-                enabled_collections.clear();
+                all_collections_enabled_ = false;
+                enabled_collections_.clear();
             } else {
                 for (const auto& collection : collections) {
-                    enabled_collections.erase(collection);
+                    enabled_collections_.erase(collection);
                 }
             }
             return SuccessReply(command.command_id);
         };
-        handlers["show_errors"] = [this](const TelemetryCommand& command) {
+        handlers_["show_errors"] = [this](const TelemetryCommand& command) {
             auto payload = command.payload.empty() ? nlohmann::json::object() : nlohmann::json::parse(command.payload);
             if (!payload.is_object()) {
                 throw std::invalid_argument("show_errors payload must be a JSON object");
@@ -972,8 +1076,8 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             auto max_count = static_cast<size_t>(requested <= 0 ? 100 : requested);
             std::vector<TelemetryError> values;
             {
-                std::lock_guard<std::mutex> lock(mutex);
-                for (auto iterator = errors.rbegin(); iterator != errors.rend() && values.size() < max_count;
+                std::lock_guard<std::mutex> lock(mutex_);
+                for (auto iterator = errors_.rbegin(); iterator != errors_.rend() && values.size() < max_count;
                      ++iterator) {
                     values.push_back(*iterator);
                 }
@@ -997,34 +1101,74 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
                 result.erase(result.begin() + result.size() / 2, result.end());
             }
             auto encoded = result.dump();
-            while (encoded.size() > kMaxReplyBytes && result.size() == 1 &&
-                   result.at(0).value("error_msg", std::string{}).size() > 1) {
-                auto message = result.at(0).at("error_msg").get<std::string>();
-                result.at(0)["error_msg"] =
-                    message.substr(0, std::max<size_t>(1, message.size() / 2)) + "...(truncated)";
+            constexpr const char* kTruncated = "...(truncated)";
+            constexpr std::array<const char*, 4> kTruncatableFields = {"error_msg", "collection", "operation",
+                                                                       "request_id"};
+            while (encoded.size() > kMaxReplyBytes && result.size() == 1) {
+                auto& detail = result.at(0);
+                const char* longest_field = nullptr;
+                size_t longest_size = 0;
+                for (const auto* field : kTruncatableFields) {
+                    if (!detail.contains(field) || !detail.at(field).is_string()) {
+                        continue;
+                    }
+                    const auto size = detail.at(field).get_ref<const std::string&>().size();
+                    if (size > longest_size) {
+                        longest_field = field;
+                        longest_size = size;
+                    }
+                }
+                if (longest_field == nullptr || longest_size == 0) {
+                    break;
+                }
+
+                const auto previous_size = encoded.size();
+                const auto value = detail.at(longest_field).get<std::string>();
+                const auto suffix_size = std::strlen(kTruncated);
+                if (value.size() > suffix_size + 1) {
+                    auto keep = value.size() / 2;
+                    if (keep > suffix_size) {
+                        keep -= suffix_size;
+                    } else {
+                        keep = 0;
+                    }
+                    keep = Utf8SafePrefixLength(value, keep);
+                    detail[longest_field] = value.substr(0, keep) + kTruncated;
+                } else {
+                    detail[longest_field] = "";
+                }
                 encoded = result.dump();
+                if (encoded.size() >= previous_size) {
+                    // Guarantee monotonic progress even for strings whose JSON
+                    // escaping defeats the best-effort prefix truncation.
+                    detail[longest_field] = "";
+                    encoded = result.dump();
+                    if (encoded.size() >= previous_size) {
+                        break;
+                    }
+                }
             }
             if (encoded.size() > kMaxReplyBytes) {
                 throw std::invalid_argument("show_errors response exceeds the 1MB payload limit");
             }
             return SuccessReply(command.command_id, encoded);
         };
-        handlers["get_config"] = [this](const TelemetryCommand& command) {
-            std::lock_guard<std::mutex> lock(mutex);
-            std::vector<std::string> collections(enabled_collections.begin(), enabled_collections.end());
+        handlers_["get_config"] = [this](const TelemetryCommand& command) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            std::vector<std::string> collections(enabled_collections_.begin(), enabled_collections_.end());
             std::sort(collections.begin(), collections.end());
             nlohmann::json user_config = {
-                {"address", uri},
-                {"username", username},
-                {"db_name", database},
-                {"telemetry_enabled", config.enabled},
-                {"telemetry_heartbeat_interval_ms", config.heartbeat_interval_ms},
-                {"telemetry_sampling_rate", config.sampling_rate},
-                {"enabled_collections", all_collections_enabled ? std::vector<std::string>{"*"} : collections},
-                {"all_collections_enabled", all_collections_enabled}};
+                {"address", uri_},
+                {"username", username_},
+                {"db_name", database_},
+                {"telemetry_enabled", config_.enabled},
+                {"telemetry_heartbeat_interval_ms", config_.heartbeat_interval_ms},
+                {"telemetry_sampling_rate", config_.sampling_rate},
+                {"enabled_collections", all_collections_enabled_ ? std::vector<std::string>{"*"} : collections},
+                {"all_collections_enabled", all_collections_enabled_}};
             return SuccessReply(command.command_id, nlohmann::json{{"user_config", user_config}}.dump());
         };
-        handlers["show_latency_history"] = [this](const TelemetryCommand& command) {
+        handlers_["show_latency_history"] = [this](const TelemetryCommand& command) {
             if (command.payload.empty()) {
                 throw std::invalid_argument("payload is required with start_time and end_time");
             }
@@ -1045,9 +1189,9 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
             }
             std::vector<StoredSnapshot> selected;
             {
-                std::lock_guard<std::mutex> lock(mutex);
-                selected.reserve(snapshots.size());
-                for (const auto& stored : snapshots) {
+                std::lock_guard<std::mutex> lock(mutex_);
+                selected.reserve(snapshots_.size());
+                for (const auto& stored : snapshots_) {
                     const auto& snapshot = stored.snapshot;
                     if (snapshot.end_time >= start && snapshot.timestamp <= end) {
                         selected.push_back(stored);
@@ -1154,46 +1298,52 @@ class ClientTelemetryManager::Impl : public std::enable_shared_from_this<ClientT
         };
     }
 
-    mutable std::mutex mutex;
-    std::condition_variable condition;
-    TelemetryConfig config;
-    const TelemetryConfig connection_config;
-    const bool stable_client_id;
-    const std::string client_id;
-    std::shared_ptr<proto::milvus::ClientTelemetryService::Stub> stub;
-    uint64_t channel_generation{0};
-    std::string username;
-    std::string database;
-    std::string uri;
-    std::string sdk_version;
-    std::string connection_scope;
-    std::unordered_map<std::string, OperationCollector> collectors;
-    std::deque<TelemetryError> errors;
-    TelemetrySnapshot latest_snapshot;
-    std::deque<StoredSnapshot> snapshots;
-    std::vector<TelemetryCommandReply> pending_replies;
-    std::unordered_map<std::string, int64_t> executed_commands;
-    std::unordered_map<std::string, CommandHandler> handlers;
-    std::unordered_set<std::string> enabled_collections;
-    bool all_collections_enabled{false};
-    bool ready{false};
-    bool stopped{true};
-    bool control_plane_activated{false};
-    bool worker_running{false};
-    bool join_in_progress{false};
-    bool external_stop_requested{false};
-    int unsupported_streak{0};
+    struct ExecutedCommand {
+        int64_t create_time_{0};
+        TelemetryCommandReply reply_;
+    };
+
+    mutable std::mutex mutex_;
+    std::condition_variable condition_;
+    TelemetryConfig config_;
+    const TelemetryConfig connection_config_;
+    const bool stable_client_id_;
+    const std::string client_id_;
+    std::shared_ptr<proto::milvus::ClientTelemetryService::Stub> stub_;
+    uint64_t channel_generation_{0};
+    std::string username_;
+    std::string database_;
+    std::string uri_;
+    std::string sdk_version_;
+    std::string connection_scope_;
+    std::unordered_map<std::string, OperationCollector> collectors_;
+    std::deque<TelemetryError> errors_;
+    TelemetrySnapshot latest_snapshot_;
+    std::deque<StoredSnapshot> snapshots_;
+    std::vector<TelemetryCommandReply> pending_replies_;
+    std::unordered_map<std::string, ExecutedCommand> executed_commands_;
+    std::unordered_map<std::string, CommandHandler> handlers_;
+    std::unordered_set<std::string> enabled_collections_;
+    bool all_collections_enabled_{false};
+    bool ready_{false};
+    bool stopped_{true};
+    bool control_plane_activated_{false};
+    bool worker_running_{false};
+    bool join_in_progress_{false};
+    bool external_stop_requested_{false};
+    int unsupported_streak_{0};
+    uint64_t wait_revision_{0};
     // Carries the fractional sampling rate between operations, in kSamplingScale units:
     // each operation adds the rate and the one that pushes it past a whole unit is the one
     // sampled.
-    uint64_t sampling_accum{0};
-    int64_t last_command_timestamp{0};
-    int64_t last_snapshot_end{0};
-    std::string config_hash;
-    std::string last_heartbeat_error;
-    std::thread worker;
-    std::thread::id worker_id;
-    std::recursive_mutex command_mutex;
+    uint64_t sampling_accum_{0};
+    int64_t last_command_timestamp_{0};
+    int64_t last_snapshot_end_{0};
+    std::string config_hash_;
+    std::string last_heartbeat_error_;
+    std::thread worker_;
+    std::thread::id worker_id_;
+    std::recursive_mutex command_mutex_;
 };
 
 ClientTelemetryManager::ClientTelemetryManager(const TelemetryConfig& config, const std::string& runtime_client_id)
@@ -1226,62 +1376,62 @@ ClientTelemetryManager::Stop() {
 
 bool
 ClientTelemetryManager::IsReady() const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    return impl_->ready;
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->ready_;
 }
 
 bool
 ClientTelemetryManager::isWorkerThread() const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    return impl_->worker_running && impl_->worker_id == std::this_thread::get_id();
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->worker_running_ && impl_->worker_id_ == std::this_thread::get_id();
 }
 
 bool
 ClientTelemetryManager::IsSupported() const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    return impl_->unsupported_streak == 0;
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->unsupported_streak_ == 0;
 }
 
 const std::string&
 ClientTelemetryManager::ClientId() const {
-    return impl_->client_id;
+    return impl_->client_id_;
 }
 
 std::string
 ClientTelemetryManager::ConfigHash() const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    return impl_->config_hash;
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->config_hash_;
 }
 
 int64_t
 ClientTelemetryManager::LastCommandTimestamp() const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    return impl_->last_command_timestamp;
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->last_command_timestamp_;
 }
 
 TelemetryConfig
 ClientTelemetryManager::Config() const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    return impl_->config;
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->config_;
 }
 
 bool
 ClientTelemetryManager::MatchesConnection(const TelemetryConfig& config, const std::string& connection_scope) const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    return impl_->connection_scope == connection_scope &&
-           SameTelemetryConfig(impl_->connection_config, NormalizedTelemetryConfig(config));
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->connection_scope_ == connection_scope &&
+           SameTelemetryConfig(impl_->connection_config_, NormalizedTelemetryConfig(config));
 }
 
 std::string
 ClientTelemetryManager::LastHeartbeatError() const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    return impl_->last_heartbeat_error;
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->last_heartbeat_error_;
 }
 
 void
 ClientTelemetryManager::RegisterCommandHandler(const std::string& command_type, CommandHandler handler) {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    impl_->handlers[command_type] = std::move(handler);
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    impl_->handlers_[command_type] = std::move(handler);
 }
 
 void
@@ -1304,11 +1454,11 @@ ClientTelemetryManager::RecordOperation(const std::string& operation, const std:
     auto latency_us =
         std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - started).count();
     auto latency = static_cast<double>(latency_us) / 1000.0;
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    if (!impl_->config.enabled) {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    if (!impl_->config_.enabled) {
         return;
     }
-    auto rate = impl_->config.sampling_rate;
+    auto rate = impl_->config_.sampling_rate;
     bool sampled = rate >= 1.0;
     if (rate > 0.0 && rate < 1.0) {
         // Sample on the operation that carries the accumulator across a whole unit, so the
@@ -1321,33 +1471,33 @@ ClientTelemetryManager::RecordOperation(const std::string& operation, const std:
         if (step == 0) {
             step = 1;
         }
-        auto before = impl_->sampling_accum;
-        impl_->sampling_accum = before + step;
-        sampled = impl_->sampling_accum / kSamplingScale != before / kSamplingScale;
+        auto before = impl_->sampling_accum_;
+        impl_->sampling_accum_ = before + step;
+        sampled = impl_->sampling_accum_ / kSamplingScale != before / kSamplingScale;
     }
     if (!sampled) {
         return;
     }
-    bool collection_enabled = impl_->all_collections_enabled || impl_->enabled_collections.count(collection) > 0;
-    auto& collector = impl_->collectors[operation];
+    bool collection_enabled = impl_->all_collections_enabled_ || impl_->enabled_collections_.count(collection) > 0;
+    auto& collector = impl_->collectors_[operation];
     collector.global.Record(latency, success);
     if (!collection.empty() && collection_enabled) {
         collector.collections[collection].Record(latency, success);
     }
     if (!success) {
-        impl_->errors.push_back({NowMillis(), operation, error_message, collection,
+        impl_->errors_.push_back({NowMillis(), operation, error_message, collection,
                                  ClientRequestContext::IsValid(request_id) ? request_id : std::string{}});
-        while (impl_->errors.size() > impl_->config.error_max_count) {
-            impl_->errors.pop_front();
+        while (impl_->errors_.size() > impl_->config_.error_max_count) {
+            impl_->errors_.pop_front();
         }
     }
 }
 
 std::vector<TelemetryError>
 ClientTelemetryManager::RecentErrors(size_t max_count) const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
     std::vector<TelemetryError> result;
-    for (auto iterator = impl_->errors.rbegin(); iterator != impl_->errors.rend() && result.size() < max_count;
+    for (auto iterator = impl_->errors_.rbegin(); iterator != impl_->errors_.rend() && result.size() < max_count;
          ++iterator) {
         result.push_back(*iterator);
     }
@@ -1356,10 +1506,10 @@ ClientTelemetryManager::RecentErrors(size_t max_count) const {
 
 std::vector<TelemetrySnapshot>
 ClientTelemetryManager::MetricsSnapshots() const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
     std::vector<TelemetrySnapshot> result;
-    result.reserve(impl_->snapshots.size());
-    for (const auto& stored : impl_->snapshots) {
+    result.reserve(impl_->snapshots_.size());
+    for (const auto& stored : impl_->snapshots_) {
         result.push_back(stored.snapshot);
     }
     return result;
@@ -1367,8 +1517,8 @@ ClientTelemetryManager::MetricsSnapshots() const {
 
 std::vector<TelemetryCommandReply>
 ClientTelemetryManager::PendingCommandReplies() const {
-    std::lock_guard<std::mutex> lock(impl_->mutex);
-    return impl_->pending_replies;
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->pending_replies_;
 }
 
 void

--- a/test/ut/TestClientTelemetry.cpp
+++ b/test/ut/TestClientTelemetry.cpp
@@ -18,6 +18,7 @@
 #include <condition_variable>
 #include <future>
 #include <iomanip>
+#include <limits>
 #include <milvus/thirdparty/nlohmann/json.hpp>
 #include <sstream>
 #include <thread>
@@ -60,6 +61,164 @@ class ReconnectTelemetryService final : public milvus::proto::milvus::ClientTele
     }
 
     std::atomic<int> heartbeats{0};
+};
+
+class GenerationSwitchTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest*,
+                    milvus::proto::milvus::ClientHeartbeatResponse* response) override {
+        const auto count = ++heartbeats;
+        if (count > 1 && !allow_redelivery_.load()) {
+            return grpc::Status::OK;
+        }
+        auto* reconnect = response->add_commands();
+        reconnect->set_command_id("switch-generation");
+        reconnect->set_command_type("switch-generation");
+        reconnect->set_create_time(1);
+        auto* followup = response->add_commands();
+        followup->set_command_id("followup");
+        followup->set_command_type("followup");
+        followup->set_create_time(2);
+        return grpc::Status::OK;
+    }
+
+    void
+    AllowRedelivery() {
+        allow_redelivery_ = true;
+    }
+
+    std::atomic<int> heartbeats{0};
+
+ private:
+    std::atomic<bool> allow_redelivery_{false};
+};
+
+class ReplyRecordingSwitchService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest* request,
+                    milvus::proto::milvus::ClientHeartbeatResponse* response) override {
+        {
+            std::lock_guard<std::mutex> lock(received_mutex);
+            for (const auto& reply : request->command_replies()) {
+                received.push_back({reply.command_id(), reply.success()});
+            }
+        }
+        const auto count = ++heartbeats;
+        if (count > 1 && !allow_redelivery_.load()) {
+            return grpc::Status::OK;
+        }
+        auto* reconnect = response->add_commands();
+        reconnect->set_command_id("switch-generation");
+        reconnect->set_command_type("switch-generation");
+        reconnect->set_create_time(1);
+        auto* followup = response->add_commands();
+        followup->set_command_id("followup");
+        followup->set_command_type("followup");
+        followup->set_create_time(2);
+        return grpc::Status::OK;
+    }
+
+    void
+    AllowRedelivery() {
+        allow_redelivery_ = true;
+    }
+
+    bool
+    ReceivedReply(const std::string& command_id) {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        for (const auto& entry : received) {
+            if (entry.first == command_id) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::vector<std::pair<std::string, bool>>
+    Received() {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        return received;
+    }
+
+    std::atomic<int> heartbeats{0};
+
+ private:
+    std::atomic<bool> allow_redelivery_{false};
+    std::mutex received_mutex;
+    std::vector<std::pair<std::string, bool>> received;
+};
+
+class UnsupportedTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest*,
+                    milvus::proto::milvus::ClientHeartbeatResponse*) override {
+        ++heartbeats;
+        return {grpc::StatusCode::UNIMPLEMENTED, "telemetry is not supported"};
+    }
+
+    std::atomic<int> heartbeats{0};
+};
+
+class CountingTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    explicit CountingTelemetryService(bool push_max_interval = false) : push_max_interval_(push_max_interval) {
+    }
+
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest*,
+                    milvus::proto::milvus::ClientHeartbeatResponse* response) override {
+        const auto count = ++heartbeats;
+        if (push_max_interval_ && count == 1) {
+            auto* command = response->add_commands();
+            command->set_command_id("max-interval");
+            command->set_command_type("push_config");
+            command->set_payload(R"({"heartbeat_interval_ms":9223372036854775807})");
+            command->set_create_time(1);
+        }
+        return grpc::Status::OK;
+    }
+
+    std::atomic<int> heartbeats{0};
+
+ private:
+    bool push_max_interval_;
+};
+
+class BlockingTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
+ public:
+    grpc::Status
+    ClientHeartbeat(grpc::ServerContext*, const milvus::proto::milvus::ClientHeartbeatRequest*,
+                    milvus::proto::milvus::ClientHeartbeatResponse*) override {
+        std::unique_lock<std::mutex> lock(mutex_);
+        heartbeat_entered_ = true;
+        condition_.notify_all();
+        condition_.wait(lock, [this]() { return released_; });
+        return grpc::Status::OK;
+    }
+
+    bool
+    WaitForHeartbeat() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        return condition_.wait_for(lock, std::chrono::seconds(2), [this]() { return heartbeat_entered_; });
+    }
+
+    void
+    Release() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            released_ = true;
+        }
+        condition_.notify_all();
+    }
+
+ private:
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    bool heartbeat_entered_{false};
+    bool released_{false};
 };
 
 class ControlPlaneTelemetryService final : public milvus::proto::milvus::ClientTelemetryService::Service {
@@ -290,6 +449,100 @@ TEST(ClientTelemetryTest, RuntimeClientIdDoesNotBecomeStableConfiguration) {
     EXPECT_TRUE(manager.Config().client_id.empty());
 }
 
+TEST(ClientTelemetryTest, MaximumHeartbeatIntervalsAreSafeAndDoNotSpin) {
+    CountingTelemetryService service(true);
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = std::numeric_limits<uint64_t>::max();
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials()),
+                          "", "", "", "", "");
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && service.heartbeats.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(service.heartbeats.load(), 1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    manager.Stop();
+    server->Shutdown();
+
+    EXPECT_EQ(manager.Config().heartbeat_interval_ms, static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+    EXPECT_EQ(service.heartbeats.load(), 1);
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 1U);
+    EXPECT_EQ(replies.front().command_id, "max-interval");
+    EXPECT_TRUE(replies.front().success);
+}
+
+TEST(ClientTelemetryTest, SnapshotTimestampBoundedForMaximumInterval) {
+    CountingTelemetryService service(false);
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = std::numeric_limits<uint64_t>::max();
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials()),
+                          "", "", "", "", "");
+    manager.RecordOperation("Query", "books", std::chrono::steady_clock::now(), true, "", "");
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && service.heartbeats.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(service.heartbeats.load(), 1);
+    manager.Stop();
+    server->Shutdown();
+
+    const auto snapshots = manager.MetricsSnapshots();
+    ASSERT_FALSE(snapshots.empty());
+    EXPECT_GE(snapshots.front().timestamp, snapshots.front().end_time - 60 * 60 * 1000);
+}
+
+TEST(ClientTelemetryTest, PushConfigIntervalChangeWakesChunkedWait) {
+    CountingTelemetryService service(false);
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = std::numeric_limits<uint64_t>::max();
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials()),
+                          "", "", "", "", "");
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && service.heartbeats.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(service.heartbeats.load(), 1);
+
+    manager.ProcessCommands({{"interval", "push_config", R"({"heartbeat_interval_ms":100})", 1, true, ""}});
+
+    for (int retry = 0; retry < 2000 && service.heartbeats.load() < 2; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    server->Shutdown();
+
+    EXPECT_GE(service.heartbeats.load(), 2);
+    EXPECT_EQ(manager.Config().heartbeat_interval_ms, 100U);
+}
+
 TEST(ClientTelemetryTest, AppliesCommandsAndDeduplicatesIds) {
     milvus::TelemetryConfig config;
     config.enabled = false;
@@ -312,6 +565,30 @@ TEST(ClientTelemetryTest, AppliesCommandsAndDeduplicatesIds) {
     EXPECT_EQ(manager.LastCommandTimestamp(), 2);
     EXPECT_FALSE(manager.ConfigHash().empty());
     EXPECT_EQ(calls, 1);
+}
+
+TEST(ClientTelemetryTest, CustomHandlerRepliesAlwaysUseOriginalCommandId) {
+    milvus::TelemetryConfig config;
+    config.enabled = false;
+    milvus::ClientTelemetryManager manager(config);
+    manager.RegisterCommandHandler("wrong", [](const milvus::TelemetryCommand&) {
+        return milvus::TelemetryCommandReply{"different", true, "", ""};
+    });
+    manager.RegisterCommandHandler("empty", [](const milvus::TelemetryCommand&) {
+        return milvus::TelemetryCommandReply{"", true, "", ""};
+    });
+
+    manager.ProcessCommands({
+        {"wrong-id", "wrong", "", 1, false, ""},
+        {"empty-id", "empty", "", 2, false, ""},
+    });
+
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 2U);
+    EXPECT_EQ(replies[0].command_id, "wrong-id");
+    EXPECT_TRUE(replies[0].success);
+    EXPECT_EQ(replies[1].command_id, "empty-id");
+    EXPECT_TRUE(replies[1].success);
 }
 
 TEST(ClientTelemetryTest, RetainsMoreThanOneHundredTwentySnapshotsWithinOneHour) {
@@ -472,6 +749,225 @@ TEST(ClientTelemetryTest, ReusesHeartbeatWorkerWhenReconnectRunsInCommandHandler
 
     EXPECT_GE(service.heartbeats.load(), 2);
     EXPECT_EQ(reconnects.load(), 1);
+}
+
+TEST(ClientTelemetryTest, GenerationSwitchStopsOldBatchAndResumesOnRedelivery) {
+    GenerationSwitchTelemetryService service;
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = 60000;
+    milvus::ClientTelemetryManager manager(config);
+    auto channel = grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials());
+    manager.AttachChannel(channel, "", "", "", "", "");
+    std::atomic<int> switches{0};
+    std::atomic<int> followups{0};
+    manager.RegisterCommandHandler("switch-generation", [&](const milvus::TelemetryCommand&) {
+        ++switches;
+        manager.AttachChannel(channel, "", "", "", "", "");
+        return milvus::TelemetryCommandReply{"wrong-id", true, "", ""};
+    });
+    manager.RegisterCommandHandler("followup", [&](const milvus::TelemetryCommand& command) {
+        ++followups;
+        return milvus::TelemetryCommandReply{command.command_id, true, "", ""};
+    });
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && service.heartbeats.load() < 2; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    ASSERT_GE(service.heartbeats.load(), 2);
+    ASSERT_EQ(switches.load(), 1);
+    EXPECT_EQ(followups.load(), 0);
+    EXPECT_EQ(manager.LastCommandTimestamp(), 0);
+
+    service.AllowRedelivery();
+    manager.Start();
+    for (int retry = 0; retry < 2000 && followups.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    EXPECT_EQ(switches.load(), 1);
+    EXPECT_EQ(followups.load(), 1);
+    EXPECT_EQ(manager.LastCommandTimestamp(), 2);
+    server->Shutdown();
+}
+
+TEST(ClientTelemetryTest, FencedRedeliveryRequeuesOriginalFailedReply) {
+    ReplyRecordingSwitchService service;
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = 100;
+    milvus::ClientTelemetryManager manager(config);
+    auto channel = grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials());
+    manager.AttachChannel(channel, "", "", "", "", "");
+    std::atomic<int> switches{0};
+    std::atomic<int> followups{0};
+    manager.RegisterCommandHandler("switch-generation", [&](const milvus::TelemetryCommand& command) {
+        ++switches;
+        manager.AttachChannel(channel, "", "", "", "", "");
+        return milvus::TelemetryCommandReply{command.command_id, false, "boom", ""};
+    });
+    manager.RegisterCommandHandler("followup", [&](const milvus::TelemetryCommand& command) {
+        ++followups;
+        return milvus::TelemetryCommandReply{command.command_id, true, "", ""};
+    });
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && service.heartbeats.load() < 2; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    ASSERT_EQ(switches.load(), 1);
+    EXPECT_EQ(followups.load(), 0);
+
+    service.AllowRedelivery();
+    manager.Start();
+    for (int retry = 0; retry < 2000 && !service.ReceivedReply("followup"); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    server->Shutdown();
+
+    EXPECT_EQ(followups.load(), 1);
+    int switch_replies = 0;
+    for (const auto& entry : service.Received()) {
+        if (entry.first == "switch-generation") {
+            ++switch_replies;
+            EXPECT_FALSE(entry.second);
+        }
+    }
+    EXPECT_GE(switch_replies, 2);
+}
+
+TEST(ClientTelemetryTest, AttachChannelInterruptsUnsupportedBackoff) {
+    UnsupportedTelemetryService unsupported_service;
+    CountingTelemetryService supported_service;
+    grpc::ServerBuilder unsupported_builder;
+    grpc::ServerBuilder supported_builder;
+    int unsupported_port = 0;
+    int supported_port = 0;
+    unsupported_builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &unsupported_port);
+    unsupported_builder.RegisterService(&unsupported_service);
+    supported_builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &supported_port);
+    supported_builder.RegisterService(&supported_service);
+    auto unsupported_server = unsupported_builder.BuildAndStart();
+    auto supported_server = supported_builder.BuildAndStart();
+    ASSERT_NE(unsupported_server, nullptr);
+    ASSERT_NE(supported_server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = 60000;
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(
+        grpc::CreateChannel("127.0.0.1:" + std::to_string(unsupported_port), grpc::InsecureChannelCredentials()), "",
+        "", "", "", "");
+    manager.Start();
+    for (int retry = 0; retry < 2000 && manager.IsSupported(); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_FALSE(manager.IsSupported());
+    ASSERT_EQ(unsupported_service.heartbeats.load(), 1);
+
+    manager.AttachChannel(
+        grpc::CreateChannel("127.0.0.1:" + std::to_string(supported_port), grpc::InsecureChannelCredentials()), "", "",
+        "", "", "");
+    for (int retry = 0; retry < 2000 && supported_service.heartbeats.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    unsupported_server->Shutdown();
+    supported_server->Shutdown();
+
+    EXPECT_EQ(supported_service.heartbeats.load(), 1);
+    EXPECT_TRUE(manager.IsSupported());
+}
+
+TEST(ClientTelemetryTest, UnsupportedServerLargeIntervalDoesNotSpin) {
+    UnsupportedTelemetryService service;
+    grpc::ServerBuilder builder;
+    int port = 0;
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = std::numeric_limits<uint64_t>::max();
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(grpc::CreateChannel("127.0.0.1:" + std::to_string(port), grpc::InsecureChannelCredentials()),
+                          "", "", "", "", "");
+
+    manager.Start();
+    for (int retry = 0; retry < 2000 && manager.IsSupported(); ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_FALSE(manager.IsSupported());
+    ASSERT_EQ(service.heartbeats.load(), 1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    manager.Stop();
+    server->Shutdown();
+
+    // The worker must stay quiescent after the single initial probe: a configured
+    // maximum interval (chunked) cannot fire a second heartbeat within this window.
+    EXPECT_EQ(service.heartbeats.load(), 1);
+}
+
+TEST(ClientTelemetryTest, AttachChannelDuringHeartbeatImmediatelyProbesReplacement) {
+    BlockingTelemetryService old_service;
+    CountingTelemetryService new_service;
+    grpc::ServerBuilder old_builder;
+    grpc::ServerBuilder new_builder;
+    int old_port = 0;
+    int new_port = 0;
+    old_builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &old_port);
+    old_builder.RegisterService(&old_service);
+    new_builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &new_port);
+    new_builder.RegisterService(&new_service);
+    auto old_server = old_builder.BuildAndStart();
+    auto new_server = new_builder.BuildAndStart();
+    ASSERT_NE(old_server, nullptr);
+    ASSERT_NE(new_server, nullptr);
+
+    milvus::TelemetryConfig config;
+    config.heartbeat_interval_ms = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+    milvus::ClientTelemetryManager manager(config);
+    manager.AttachChannel(
+        grpc::CreateChannel("127.0.0.1:" + std::to_string(old_port), grpc::InsecureChannelCredentials()), "", "", "",
+        "", "");
+    manager.Start();
+    if (!old_service.WaitForHeartbeat()) {
+        old_service.Release();
+        manager.Stop();
+        old_server->Shutdown();
+        new_server->Shutdown();
+        FAIL() << "old heartbeat did not enter the in-flight state";
+    }
+
+    manager.AttachChannel(
+        grpc::CreateChannel("127.0.0.1:" + std::to_string(new_port), grpc::InsecureChannelCredentials()), "", "", "",
+        "", "");
+    old_service.Release();
+    for (int retry = 0; retry < 2000 && new_service.heartbeats.load() == 0; ++retry) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    manager.Stop();
+    old_server->Shutdown();
+    new_server->Shutdown();
+
+    EXPECT_EQ(new_service.heartbeats.load(), 1);
 }
 
 TEST(ClientTelemetryTest, ExternalStopWinsRaceWithHeartbeatSelfRestart) {
@@ -1011,6 +1507,103 @@ TEST(ClientTelemetryTest, PushConfigIsAtomicAndReportsAppliedAndIgnoredKeys) {
     EXPECT_EQ(payload["ignored"], nlohmann::json({"ttl_seconds", "unknown_a", "unknown_b"}));
 }
 
+TEST(ClientTelemetryTest, PushConfigClampsMaximumInterval) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config);
+
+    manager.ProcessCommands(
+        {{"max", "push_config", R"({"heartbeat_interval_ms":18446744073709551615})", 1, true, ""}});
+
+    auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 1U);
+    ASSERT_TRUE(replies.back().success) << replies.back().error_message;
+    auto payload = nlohmann::json::parse(replies.back().payload);
+    EXPECT_EQ(payload["applied"], nlohmann::json({"heartbeat_interval_ms"}));
+    EXPECT_EQ(manager.Config().heartbeat_interval_ms, static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+
+    const auto clamped_interval = manager.Config().heartbeat_interval_ms;
+    manager.ProcessCommands({{"negative", "push_config", R"({"heartbeat_interval_ms":-1})", 2, true, ""}});
+    auto negative_replies = manager.PendingCommandReplies();
+    ASSERT_EQ(negative_replies.size(), 2U);
+    EXPECT_FALSE(negative_replies.back().success);
+    EXPECT_EQ(manager.Config().heartbeat_interval_ms, clamped_interval);
+}
+
+TEST(ClientTelemetryTest, ReplyPayloadKeysStayUnderscoreFree) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config);
+    manager.ProcessCommands({{"cfg", "get_config", "", 1, false, ""},
+                             {"cm", "collection_metrics", "", 2, false, ""}});
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 2U);
+    ASSERT_TRUE(replies[0].success);
+    ASSERT_TRUE(replies[1].success);
+
+    const auto user_config = nlohmann::json::parse(replies[0].payload).at("user_config");
+    for (const char* key : {"address", "username", "db_name", "telemetry_enabled",
+                            "telemetry_heartbeat_interval_ms", "telemetry_sampling_rate",
+                            "enabled_collections", "all_collections_enabled"}) {
+        EXPECT_TRUE(user_config.contains(key)) << "get_config reply missing key: " << key;
+    }
+
+    const auto collection_metrics = nlohmann::json::parse(replies[1].payload);
+    for (const char* key : {"enabled_collections", "all_collections_enabled"}) {
+        EXPECT_TRUE(collection_metrics.contains(key)) << "collection_metrics reply missing key: " << key;
+    }
+
+    const auto now = std::chrono::system_clock::now();
+    manager.ProcessCommands({{"hist", "show_latency_history",
+                              nlohmann::json{{"start_time", Rfc3339(now - std::chrono::minutes(5))},
+                                             {"end_time", Rfc3339(now + std::chrono::minutes(5))},
+                                             {"detail", true}}
+                                  .dump(),
+                              3, false, ""}});
+    const auto history_replies = manager.PendingCommandReplies();
+    ASSERT_FALSE(history_replies.empty());
+    ASSERT_TRUE(history_replies.back().success) << history_replies.back().error_message;
+    const auto history = nlohmann::json::parse(history_replies.back().payload);
+    EXPECT_TRUE(history.contains("snapshots")) << "show_latency_history reply missing key: snapshots";
+}
+
+TEST(ClientTelemetryTest, ShowErrorsBoundsOversizedNonMessageFields) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config);
+    const std::string oversized_collection(1024 * 1024 + 1024, 'c');
+    manager.RecordOperation("Query", oversized_collection, std::chrono::steady_clock::now(), false, "tiny");
+
+    manager.ProcessCommands({{"errors", "show_errors", R"({"max_count":1})", 1, false, ""}});
+
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 1U);
+    ASSERT_TRUE(replies.front().success) << replies.front().error_message;
+    EXPECT_LE(replies.front().payload.size(), 1024U * 1024U);
+    const auto payload = nlohmann::json::parse(replies.front().payload);
+    ASSERT_EQ(payload.size(), 1U);
+    EXPECT_LT(payload.front().at("collection").get<std::string>().size(), oversized_collection.size());
+}
+
+TEST(ClientTelemetryTest, ShowErrorsTruncatesOversizedUtf8FieldsAtCodePointBoundaries) {
+    milvus::TelemetryConfig config;
+    milvus::ClientTelemetryManager manager(config);
+    std::string oversized_utf8;
+    oversized_utf8.reserve(1200000);
+    for (size_t index = 0; index < 400000; ++index) {
+        oversized_utf8 += "\xe7\x95\x8c";
+    }
+    manager.RecordOperation("Query", oversized_utf8, std::chrono::steady_clock::now(), false, oversized_utf8);
+
+    manager.ProcessCommands({{"utf8-errors", "show_errors", R"({"max_count":1})", 1, false, ""}});
+
+    const auto replies = manager.PendingCommandReplies();
+    ASSERT_EQ(replies.size(), 1U);
+    ASSERT_TRUE(replies.front().success) << replies.front().error_message;
+    EXPECT_LE(replies.front().payload.size(), 1024U * 1024U);
+    const auto payload = nlohmann::json::parse(replies.front().payload);
+    ASSERT_EQ(payload.size(), 1U);
+    EXPECT_LT(payload.front().at("collection").get<std::string>().size(), oversized_utf8.size());
+    EXPECT_LT(payload.front().at("error_msg").get<std::string>().size(), oversized_utf8.size());
+}
+
 TEST(ClientTelemetryTest, RejectsWrongCommandPayloadTypes) {
     milvus::TelemetryConfig config;
     config.enabled = false;
@@ -1019,13 +1612,16 @@ TEST(ClientTelemetryTest, RejectsWrongCommandPayloadTypes) {
     manager.ProcessCommands(
         {{"push", "push_config", R"({"enabled":"false"})", 1, false, ""},
          {"collection", "collection_metrics", R"({"enabled":false,"collections":"books"})", 2, false, ""},
-         {"ttl", "push_config", R"({"enabled":true,"ttl_seconds":"bad"})", 3, false, ""}});
+         {"ttl", "push_config", R"({"ttl_seconds":"bad"})", 3, true, ""}});
 
     auto replies = manager.PendingCommandReplies();
     ASSERT_EQ(replies.size(), 3U);
     EXPECT_FALSE(replies[0].success);
     EXPECT_FALSE(replies[1].success);
-    EXPECT_FALSE(replies[2].success);
+    // ttl_seconds belongs to the server-side push API and never reaches clients by design:
+    // it is reported as ignored, never validated.
+    EXPECT_TRUE(replies[2].success);
+    EXPECT_EQ(nlohmann::json::parse(replies[2].payload)["ignored"], nlohmann::json({"ttl_seconds"}));
     EXPECT_FALSE(manager.Config().enabled);
 }
 


### PR DESCRIPTION
- Treat ttl_seconds as an ignored push_config field (#587)
- Harden client telemetry control flow: make very large heartbeat intervals safe and cancellable across platforms, fence command batches across telemetry transport rebinding, canonicalize ACK IDs, wake the unsupported backoff on channel replacement, and bound show_errors truncation including UTF-8 payloads (#588)